### PR TITLE
feat: Immediate Execution with ABCI++

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -262,6 +262,13 @@ func (m *Manager) trySyncNextBlock(ctx context.Context, daHeight uint64) error {
 
 	if b1 != nil && commit != nil {
 		m.logger.Info("Syncing block", "height", b1.Header.Height)
+		ok, err := m.executor.ProcessProposal(b1)
+		if err != nil {
+			return fmt.Errorf("failed to ProcessProposal: %w", err)
+		}
+		if !ok {
+			return fmt.Errorf("Block was rejected by ProcessProposal: %s", b1.Hash())
+		}
 		newState, responses, err := m.executor.ApplyBlock(ctx, m.lastState, b1)
 		if err != nil {
 			return fmt.Errorf("failed to ApplyBlock: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -175,5 +175,6 @@ require (
 
 replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
+	github.com/tendermint/tendermint => github.com/celestiaorg/tendermint v0.34.22-0.20221025133716-62473b9c1b6d
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -175,6 +175,6 @@ require (
 
 replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
-	github.com/tendermint/tendermint => github.com/celestiaorg/tendermint v0.34.22-0.20221025133716-62473b9c1b6d
+	github.com/tendermint/tendermint => github.com/celestiaorg/tendermint v0.34.22-0.20221025142513-1b0977ff4c53
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -175,6 +175,6 @@ require (
 
 replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
-	github.com/tendermint/tendermint => github.com/celestiaorg/tendermint v0.34.22-0.20221025142513-1b0977ff4c53
+	github.com/tendermint/tendermint => github.com/celestiaorg/tendermint v0.34.22-0.20221025143357-5392eaab0bff
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.mod
+++ b/go.mod
@@ -175,6 +175,6 @@ require (
 
 replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.2-alpha.regen.4
-	github.com/tendermint/tendermint => github.com/celestiaorg/tendermint v0.34.22-0.20221025143357-5392eaab0bff
+	github.com/tendermint/tendermint => github.com/celestiaorg/tendermint v0.34.22-0.20221025160421-045807b8c645
 	google.golang.org/grpc => google.golang.org/grpc v1.33.2
 )

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/celestiaorg/go-cnc v0.1.0 h1:u986OnTc7AtbUZ4reY+zRCiar4fDdR1KehyP78uwsXg=
 github.com/celestiaorg/go-cnc v0.1.0/go.mod h1:Zf03bWWq6aldv5cYEaWvJ+I+z34bT/exrS0tO0y/jN8=
-github.com/celestiaorg/tendermint v0.34.22-0.20221025133716-62473b9c1b6d h1:AxJu7n9aHzunsLnLKYSP/UGMtl8SpRLtI/grZaA2iVE=
-github.com/celestiaorg/tendermint v0.34.22-0.20221025133716-62473b9c1b6d/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025142513-1b0977ff4c53 h1:npYYlwS/czUJ1E7cntZkik4t6ElHTikXdlo4DXq4xmU=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025142513-1b0977ff4c53/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/celestiaorg/go-cnc v0.1.0 h1:u986OnTc7AtbUZ4reY+zRCiar4fDdR1KehyP78uwsXg=
 github.com/celestiaorg/go-cnc v0.1.0/go.mod h1:Zf03bWWq6aldv5cYEaWvJ+I+z34bT/exrS0tO0y/jN8=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025133716-62473b9c1b6d h1:AxJu7n9aHzunsLnLKYSP/UGMtl8SpRLtI/grZaA2iVE=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025133716-62473b9c1b6d/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -697,8 +699,6 @@ github.com/syndtr/goleveldb v1.0.1-0.20200815110645-5c35d600f0ca/go.mod h1:u2MKk
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzHWCjJB1zZfXPIAaDpzXIEJ0eS6B5Ok=
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
-github.com/tendermint/tendermint v0.34.21 h1:UiGGnBFHVrZhoQVQ7EfwSOLuCtarqCSsRf8VrklqB7s=
-github.com/tendermint/tendermint v0.34.21/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
 github.com/tendermint/tm-db v0.6.6 h1:EzhaOfR0bdKyATqcd5PNeyeq8r+V4bRPHBfyFdD9kGM=
 github.com/tendermint/tm-db v0.6.6/go.mod h1:wP8d49A85B7/erz/r4YbKssKw6ylsO/hKtFk7E1aWZI=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/celestiaorg/go-cnc v0.1.0 h1:u986OnTc7AtbUZ4reY+zRCiar4fDdR1KehyP78uwsXg=
 github.com/celestiaorg/go-cnc v0.1.0/go.mod h1:Zf03bWWq6aldv5cYEaWvJ+I+z34bT/exrS0tO0y/jN8=
-github.com/celestiaorg/tendermint v0.34.22-0.20221025142513-1b0977ff4c53 h1:npYYlwS/czUJ1E7cntZkik4t6ElHTikXdlo4DXq4xmU=
-github.com/celestiaorg/tendermint v0.34.22-0.20221025142513-1b0977ff4c53/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025143357-5392eaab0bff h1:f6erYluYvYR6YMqxZPwPNjYdwQob91mYHvJBttBOHsI=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025143357-5392eaab0bff/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46f
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/celestiaorg/go-cnc v0.1.0 h1:u986OnTc7AtbUZ4reY+zRCiar4fDdR1KehyP78uwsXg=
 github.com/celestiaorg/go-cnc v0.1.0/go.mod h1:Zf03bWWq6aldv5cYEaWvJ+I+z34bT/exrS0tO0y/jN8=
-github.com/celestiaorg/tendermint v0.34.22-0.20221025143357-5392eaab0bff h1:f6erYluYvYR6YMqxZPwPNjYdwQob91mYHvJBttBOHsI=
-github.com/celestiaorg/tendermint v0.34.22-0.20221025143357-5392eaab0bff/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025160421-045807b8c645 h1:VYnnb29S1VH3R4uUZTdG4FSc1XuG7cLin4Rc3vBcM/Q=
+github.com/celestiaorg/tendermint v0.34.22-0.20221025160421-045807b8c645/go.mod h1:XDvfg6U7grcFTDx7VkzxnhazQ/bspGJAn4DZ6DcLLjQ=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/mocks/Application.go
+++ b/mocks/Application.go
@@ -40,6 +40,35 @@ func (_m *Application) BeginBlock(_a0 types.RequestBeginBlock) types.ResponseBeg
 	return r0
 }
 
+
+// PrepareProposalSync provides a mock function with given fields: _a0
+func (_m *Application) PrepareProposal(_a0 types.RequestPrepareProposal) types.ResponsePrepareProposal {
+	ret := _m.Called(_a0)
+
+	var r0 types.ResponsePrepareProposal
+	if rf, ok := ret.Get(0).(func(types.RequestPrepareProposal) types.ResponsePrepareProposal); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(types.ResponsePrepareProposal)
+	}
+
+	return r0
+}
+
+// PrepareProposalSync provides a mock function with given fields: _a0
+func (_m *Application) ProcessProposal(_a0 types.RequestProcessProposal) types.ResponseProcessProposal {
+	ret := _m.Called(_a0)
+
+	var r0 types.ResponseProcessProposal
+	if rf, ok := ret.Get(0).(func(types.RequestProcessProposal) types.ResponseProcessProposal); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(types.ResponseProcessProposal)
+	}
+
+	return r0
+}
+
 // CheckTx provides a mock function with given fields: _a0
 func (_m *Application) CheckTx(_a0 types.RequestCheckTx) types.ResponseCheckTx {
 	ret := _m.Called(_a0)

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -41,6 +41,11 @@ func TestAggregatorMode(t *testing.T) {
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	app.On("PrepareProposal", mock.Anything).
+		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+			return abci.ResponsePrepareProposal{Txs: req.Txs}
+		})
+	app.On("ProcessProposal", mock.Anything).Return(abci.ResponseProcessProposal{Result: abci.ResponseProcessProposal_ACCEPT})
 
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
@@ -230,6 +235,11 @@ func createNode(ctx context.Context, n int, aggregator bool, dalc da.DataAvailab
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{}).Run(func(args mock.Arguments) {
 		wg.Done()
 	})
+	app.On("PrepareProposal", mock.Anything).
+		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+			return abci.ResponsePrepareProposal{Txs: req.Txs}
+		})
+	app.On("ProcessProposal", mock.Anything).Return(abci.ResponseProcessProposal{Result: abci.ResponseProcessProposal_ACCEPT})
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/node/integration_test.go
+++ b/node/integration_test.go
@@ -45,7 +45,6 @@ func TestAggregatorMode(t *testing.T) {
 		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
 			return abci.ResponsePrepareProposal{Txs: req.Txs}
 		})
-	app.On("ProcessProposal", mock.Anything).Return(abci.ResponseProcessProposal{Result: abci.ResponseProcessProposal_ACCEPT})
 
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(rand.Reader)
@@ -235,11 +234,14 @@ func createNode(ctx context.Context, n int, aggregator bool, dalc da.DataAvailab
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{}).Run(func(args mock.Arguments) {
 		wg.Done()
 	})
-	app.On("PrepareProposal", mock.Anything).
-		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
-			return abci.ResponsePrepareProposal{Txs: req.Txs}
-		})
-	app.On("ProcessProposal", mock.Anything).Return(abci.ResponseProcessProposal{Result: abci.ResponseProcessProposal_ACCEPT})
+	if aggregator {
+		app.On("PrepareProposal", mock.Anything).
+			Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+				return abci.ResponsePrepareProposal{Txs: req.Txs}
+			})
+	} else {
+		app.On("ProcessProposal", mock.Anything).Return(abci.ResponseProcessProposal{Result: abci.ResponseProcessProposal_ACCEPT})
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}

--- a/proto/tendermint/abci/types.proto
+++ b/proto/tendermint/abci/types.proto
@@ -36,6 +36,8 @@ message Request {
     RequestOfferSnapshot      offer_snapshot       = 13;
     RequestLoadSnapshotChunk  load_snapshot_chunk  = 14;
     RequestApplySnapshotChunk apply_snapshot_chunk = 15;
+    RequestPrepareProposal    prepare_proposal     = 16;
+    RequestProcessProposal    process_proposal     = 17;
   }
 }
 
@@ -124,6 +126,18 @@ message RequestApplySnapshotChunk {
   string sender = 3;
 }
 
+message RequestPrepareProposal {
+  // the modified transactions cannot exceed this size.
+  int64 max_tx_bytes = 1;
+  // txs is an array of transactions that will be included in a block,
+  // sent to the app for possible modifications.
+  repeated bytes txs = 2;
+}
+
+message RequestProcessProposal {
+  repeated bytes txs = 1;
+}
+
 //----------------------------------------
 // Response types
 
@@ -145,6 +159,8 @@ message Response {
     ResponseOfferSnapshot      offer_snapshot       = 14;
     ResponseLoadSnapshotChunk  load_snapshot_chunk  = 15;
     ResponseApplySnapshotChunk apply_snapshot_chunk = 16;
+    ResponsePrepareProposal    prepare_proposal     = 17;
+    ResponseProcessProposal    process_proposal     = 18;
   }
 }
 
@@ -282,6 +298,20 @@ message ResponseApplySnapshotChunk {
   }
 }
 
+message ResponsePrepareProposal {
+  repeated bytes txs = 1;
+}
+
+message ResponseProcessProposal {
+  ProposalStatus status = 1;
+
+  enum ProposalStatus {
+    UNKNOWN = 0;
+    ACCEPT  = 1;
+    REJECT  = 2;
+  }
+}
+
 //----------------------------------------
 // Misc.
 
@@ -410,4 +440,6 @@ service ABCIApplication {
       returns (ResponseLoadSnapshotChunk);
   rpc ApplySnapshotChunk(RequestApplySnapshotChunk)
       returns (ResponseApplySnapshotChunk);
+  rpc PrepareProposal(RequestPrepareProposal) returns (ResponsePrepareProposal);
+  rpc ProcessProposal(RequestProcessProposal) returns (ResponseProcessProposal);
 }

--- a/rpc/client/client_test.go
+++ b/rpc/client/client_test.go
@@ -420,6 +420,10 @@ func TestTx(t *testing.T) {
 	mockApp.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
 	mockApp.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	mockApp.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
+	mockApp.On("PrepareProposal", mock.Anything).
+		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+			return abci.ResponsePrepareProposal{Txs: req.Txs}
+		})
 
 	err = rpc.node.Start()
 	require.NoError(err)
@@ -630,6 +634,10 @@ func TestValidatorSetHandling(t *testing.T) {
 	app.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+	app.On("PrepareProposal", mock.Anything).
+		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+			return abci.ResponsePrepareProposal{Txs: req.Txs}
+		})
 
 	key, _, _ := crypto.GenerateEd25519Key(crand.Reader)
 	signingKey, _, _ := crypto.GenerateEd25519Key(crand.Reader)

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -281,6 +281,10 @@ func getRPC(t *testing.T) (*mocks.Application, *client.Client) {
 		GasWanted: 1000,
 		GasUsed:   1000,
 	})
+	app.On("PrepareProposal", mock.Anything).
+		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+			return abci.ResponsePrepareProposal{Txs: req.Txs}
+		})
 	app.On("Info", mock.Anything).Return(abci.ResponseInfo{
 		Data:             "mock",
 		Version:          "mock",

--- a/state/executor.go
+++ b/state/executor.go
@@ -84,12 +84,29 @@ func (e *BlockExecutor) InitChain(genesis *tmtypes.GenesisDoc) (*abci.ResponseIn
 }
 
 // CreateBlock reaps transactions from mempool and builds a block.
-func (e *BlockExecutor) CreateBlock(height uint64, lastCommit *types.Commit, lastHeaderHash [32]byte, state types.State) *types.Block {
+func (e *BlockExecutor) CreateBlock(height uint64, lastCommit *types.Commit, lastHeaderHash [32]byte, state types.State) (*types.Block, error) {
 	maxBytes := state.ConsensusParams.Block.MaxBytes
 	maxGas := state.ConsensusParams.Block.MaxGas
 
 	mempoolTxs := e.mempool.ReapMaxBytesMaxGas(maxBytes, maxGas)
 
+	rpp, err := e.proxyApp.PrepareProposalSync(
+		abci.RequestPrepareProposal{
+			Txs:        toRollmintTxs(mempoolTxs).ToSliceOfBytes(),
+			MaxTxBytes: maxBytes,
+		},
+	)
+	if err != nil {
+		// The App MUST ensure that only valid (and hence 'processable') transactions
+		// enter the mempool. Hence, at this point, we can't have any non-processable
+		// transaction causing an error.
+		//
+		// Also, the App can simply skip any transaction that could cause any kind of trouble.
+		// Either way, we cannot recover in a meaningful way, unless we skip proposing
+		// this block, repair what caused the error and try again. Hence, we return an
+		// error for now (the production code calling this function is expected to panic).
+		return nil, err
+	}
 	block := &types.Block{
 		Header: types.Header{
 			Version: types.Version{
@@ -103,12 +120,12 @@ func (e *BlockExecutor) CreateBlock(height uint64, lastCommit *types.Commit, las
 			//LastCommitHash:  lastCommitHash,
 			DataHash:        [32]byte{},
 			ConsensusHash:   [32]byte{},
-			AppHash:         state.AppHash,
+			AppHash:         [32]byte{},
 			LastResultsHash: state.LastResultsHash,
 			ProposerAddress: e.proposerAddress,
 		},
 		Data: types.Data{
-			Txs:                    toRollmintTxs(mempoolTxs),
+			Txs:                    types.ToTxs(rpp.Txs),
 			IntermediateStateRoots: types.IntermediateStateRoots{RawRootsList: nil},
 			Evidence:               types.EvidenceData{Evidence: nil},
 		},
@@ -117,7 +134,7 @@ func (e *BlockExecutor) CreateBlock(height uint64, lastCommit *types.Commit, las
 	copy(block.Header.LastCommitHash[:], e.getLastCommitHash(lastCommit, &block.Header))
 	copy(block.Header.AggregatorsHash[:], state.Validators.Hash())
 
-	return block
+	return block, nil
 }
 
 // ApplyBlock validates and executes the block.

--- a/state/executor.go
+++ b/state/executor.go
@@ -137,6 +137,22 @@ func (e *BlockExecutor) CreateBlock(height uint64, lastCommit *types.Commit, las
 	return block, nil
 }
 
+func (e *BlockExecutor) ProcessProposal(
+	block *types.Block,
+) (bool, error) {
+	pData := block.Data.ToProto()
+	req := abci.RequestProcessProposal{
+		Txs: pData.Txs,
+	}
+
+	resp, err := e.proxyApp.ProcessProposalSync(req)
+	if err != nil {
+		return false, err
+	}
+
+	return resp.IsOK(), nil
+}
+
 // ApplyBlock validates and executes the block.
 func (e *BlockExecutor) ApplyBlock(ctx context.Context, state types.State, block *types.Block) (types.State, *tmstate.ABCIResponses, error) {
 	err := e.validate(state, block)

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -31,7 +31,10 @@ func TestCreateBlock(t *testing.T) {
 
 	app := &mocks.Application{}
 	app.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
-
+	app.On("PrepareProposal", mock.Anything).
+		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+			return abci.ResponsePrepareProposal{Txs: req.Txs}
+		})
 	client, err := proxy.NewLocalClientCreator(app).NewABCIClient()
 	require.NoError(err)
 	require.NotNil(client)
@@ -84,6 +87,10 @@ func TestApplyBlock(t *testing.T) {
 	app.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
 	app.On("DeliverTx", mock.Anything).Return(abci.ResponseDeliverTx{})
 	app.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
+	app.On("PrepareProposal", mock.Anything).
+		Return(func(req abci.RequestPrepareProposal) abci.ResponsePrepareProposal {
+			return abci.ResponsePrepareProposal{Txs: req.Txs}
+		})
 	var mockAppHash []byte
 	_, err := rand.Read(mockAppHash[:])
 	require.NoError(err)

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -47,7 +47,8 @@ func TestCreateBlock(t *testing.T) {
 	state.Validators = tmtypes.NewValidatorSet(nil)
 
 	// empty block
-	block := executor.CreateBlock(1, &types.Commit{}, [32]byte{}, state)
+	block, err := executor.CreateBlock(1, &types.Commit{}, [32]byte{}, state)
+	require.Nil(err)
 	require.NotNil(block)
 	assert.Empty(block.Data.Txs)
 	assert.Equal(uint64(1), block.Header.Height)
@@ -55,7 +56,8 @@ func TestCreateBlock(t *testing.T) {
 	// one small Tx
 	err = mpool.CheckTx([]byte{1, 2, 3, 4}, func(r *abci.Response) {}, mempool.TxInfo{})
 	require.NoError(err)
-	block = executor.CreateBlock(2, &types.Commit{}, [32]byte{}, state)
+	block, err = executor.CreateBlock(2, &types.Commit{}, [32]byte{}, state)
+	require.Nil(err)
 	require.NotNil(block)
 	assert.Equal(uint64(2), block.Header.Height)
 	assert.Len(block.Data.Txs, 1)
@@ -65,7 +67,8 @@ func TestCreateBlock(t *testing.T) {
 	require.NoError(err)
 	err = mpool.CheckTx(make([]byte, 100), func(r *abci.Response) {}, mempool.TxInfo{})
 	require.NoError(err)
-	block = executor.CreateBlock(3, &types.Commit{}, [32]byte{}, state)
+	block, err = executor.CreateBlock(3, &types.Commit{}, [32]byte{}, state)
+	require.Nil(err)
 	require.NotNil(block)
 	assert.Len(block.Data.Txs, 2)
 }
@@ -124,7 +127,8 @@ func TestApplyBlock(t *testing.T) {
 
 	_ = mpool.CheckTx([]byte{1, 2, 3, 4}, func(r *abci.Response) {}, mempool.TxInfo{})
 	require.NoError(err)
-	block := executor.CreateBlock(1, &types.Commit{}, [32]byte{}, state)
+	block, err := executor.CreateBlock(1, &types.Commit{}, [32]byte{}, state)
+	require.Nil(err)
 	require.NotNil(block)
 	assert.Equal(uint64(1), block.Header.Height)
 	assert.Len(block.Data.Txs, 1)
@@ -142,7 +146,8 @@ func TestApplyBlock(t *testing.T) {
 	require.NoError(mpool.CheckTx([]byte{5, 6, 7, 8, 9}, func(r *abci.Response) {}, mempool.TxInfo{}))
 	require.NoError(mpool.CheckTx([]byte{1, 2, 3, 4, 5}, func(r *abci.Response) {}, mempool.TxInfo{}))
 	require.NoError(mpool.CheckTx(make([]byte, 90), func(r *abci.Response) {}, mempool.TxInfo{}))
-	block = executor.CreateBlock(2, &types.Commit{}, [32]byte{}, newState)
+	block, err = executor.CreateBlock(2, &types.Commit{}, [32]byte{}, newState)
+	require.Nil(err)
 	require.NotNil(block)
 	assert.Equal(uint64(2), block.Header.Height)
 	assert.Len(block.Data.Txs, 3)

--- a/types/tx.go
+++ b/types/tx.go
@@ -35,6 +35,24 @@ func (txs Txs) Proof(i int) TxProof {
 	}
 }
 
+// ToSliceOfBytes converts a Txs to slice of byte slices.
+func (txs Txs) ToSliceOfBytes() [][]byte {
+	txBzs := make([][]byte, len(txs))
+	for i := 0; i < len(txs); i++ {
+		txBzs[i] = txs[i]
+	}
+	return txBzs
+}
+
+// ToTxs converts a slice of byte slices to a Txs.
+func ToTxs(txl [][]byte) Txs {
+	txs := make([]Tx, 0, len(txl))
+	for _, tx := range txl {
+		txs = append(txs, tx)
+	}
+	return txs
+}
+
 // TxProof represents a Merkle proof of the presence of a transaction in the Merkle tree.
 type TxProof struct {
 	RootHash tmbytes.HexBytes `json:"root_hash"`


### PR DESCRIPTION
Closes: #488 
 - Switches to immediate execution, 
 - uses PrepareProposal when a Block Producer creates a block (CreateBlock)
 - uses ProcessProposalbefore a full node calls ApplyBlock.
 - Fixed all the corresponding tests as well to have mocks for the new ABCI methods

Uses this branch of tendermint with the new ABCI methods: https://github.com/celestiaorg/tendermint/pull/150

Note from Marko: if you are using ibc-go, staking or some other modules in the sdk for this, you will run into issues