### PR TITLE
Fix ADR-006 title

### DIFF
--- a/docs/lazy-adr/adr-006-da-interface.md
+++ b/docs/lazy-adr/adr-006-da-interface.md
@@ -1,4 +1,4 @@
-# ADR 005: Data Availability Client Interface
+# ADR 006: Data Availability Client Interface
 
 ## Changelog
 


### PR DESCRIPTION
ADR-006 title had a typo where it was called ADR-005 before. Fixes it.