### PR TITLE
rewindability for soft-confirmations

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -12,7 +12,6 @@ import (
 	tmbytes "github.com/tendermint/tendermint/libs/bytes"
 	tmstate "github.com/tendermint/tendermint/proto/tendermint/state"
 	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
-	"github.com/tendermint/tendermint/proxy"
 	tmtypes "github.com/tendermint/tendermint/types"
 	"go.uber.org/multierr"
 
@@ -29,7 +28,7 @@ type BlockExecutor struct {
 	proposerAddress    []byte
 	namespaceID        types.NamespaceID
 	chainID            string
-	proxyApp           proxy.AppConnConsensus
+	proxyApp           RewindableAppConnConsensus
 	mempool            mempool.Mempool
 	fraudProofsEnabled bool
 
@@ -42,7 +41,7 @@ type BlockExecutor struct {
 
 // NewBlockExecutor creates new instance of BlockExecutor.
 // Proposer address and namespace ID will be used in all newly created blocks.
-func NewBlockExecutor(proposerAddress []byte, namespaceID [8]byte, chainID string, mempool mempool.Mempool, proxyApp proxy.AppConnConsensus, fraudProofsEnabled bool, eventBus *tmtypes.EventBus, logger log.Logger) *BlockExecutor {
+func NewBlockExecutor(proposerAddress []byte, namespaceID [8]byte, chainID string, mempool mempool.Mempool, proxyApp RewindableAppConnConsensus, fraudProofsEnabled bool, eventBus *tmtypes.EventBus, logger log.Logger) *BlockExecutor {
 	return &BlockExecutor{
 		proposerAddress:    proposerAddress,
 		namespaceID:        namespaceID,

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -39,7 +39,7 @@ func doTestCreateBlock(t *testing.T, fraudProofsEnabled bool) {
 	nsID := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
 
 	mpool := mempoolv1.NewTxMempool(logger, cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client), 0)
-	executor := NewBlockExecutor([]byte("test address"), nsID, "test", mpool, proxy.NewAppConnConsensus(client), fraudProofsEnabled, nil, logger)
+	executor := NewBlockExecutor([]byte("test address"), nsID, "test", mpool, RewindableFromStandard(proxy.NewAppConnConsensus(client)), fraudProofsEnabled, nil, logger)
 
 	state := types.State{}
 	state.ConsensusParams.Block.MaxBytes = 100
@@ -110,7 +110,7 @@ func doTestApplyBlock(t *testing.T, fraudProofsEnabled bool) {
 	mpool := mempoolv1.NewTxMempool(logger, cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client), 0)
 	eventBus := tmtypes.NewEventBus()
 	require.NoError(eventBus.Start())
-	executor := NewBlockExecutor([]byte("test address"), nsID, chainID, mpool, proxy.NewAppConnConsensus(client), fraudProofsEnabled, eventBus, logger)
+	executor := NewBlockExecutor([]byte("test address"), nsID, chainID, mpool, RewindableFromStandard(proxy.NewAppConnConsensus(client)), fraudProofsEnabled, eventBus, logger)
 
 	txQuery, err := query.New("tm.event='Tx'")
 	require.NoError(err)

--- a/state/rewindable_app_conn.go
+++ b/state/rewindable_app_conn.go
@@ -1,0 +1,44 @@
+package state
+
+import (
+	"errors"
+
+	"github.com/tendermint/tendermint/proxy"
+)
+
+// Rollkit supports receiving soft-confirmations.
+// This means the ACBI app's state must be rewindable,
+// in the event of a re-org caused by the observation of a block
+// that wins the fork-choice rule prior to finalization of a chain-segment in DA
+// we store the LatestFinalizedHeight to reject blocks that would override finality
+// we provide a RevertSoftToHeight function to support querying re-orgable state
+type RewindableAppConnConsensus interface {
+	proxy.AppConnConsensus
+	// ABCI apps supporting soft confirmations should have this feature so the rollups can be queried prior to finality
+	RevertSoftToHeight(int64) error
+	LatestFinalizedHeight() int64
+}
+
+// This function takes a normal non-rewindable ABCI connection and wraps it
+func RewindableFromStandard(app proxy.AppConnConsensus) rewindableAppConn {
+	return rewindableAppConn{
+		app,
+		0,
+		false,
+	}
+}
+
+var _ RewindableAppConnConsensus = rewindableAppConn{}
+
+type rewindableAppConn struct {
+	proxy.AppConnConsensus
+	latestFinalizedHeight int64
+	rewindable            bool
+}
+
+func (r rewindableAppConn) RevertSoftToHeight(height int64) error {
+	return errors.New("not implemented")
+}
+func (r rewindableAppConn) LatestFinalizedHeight() int64 {
+	return r.latestFinalizedHeight
+}


### PR DESCRIPTION
Interface and wrapper for ABCI apps that supports rewinding and storing `lastFinalizedHeight for supporting modular soft-confirmation schemes.