### PR TITLE
fix(p2p): fix race condition caused by startTestNetwork

### DIFF
--- a/p2p/utils_test.go
+++ b/p2p/utils_test.go
@@ -80,7 +80,7 @@ func startTestNetwork(ctx context.Context, t *testing.T, n int, conf map[int]hos
 			require.NoError(err)
 			host, err := mnet.AddPeer(privKey, addr)
 			require.NoError(err)
-			require.NotEmpty(host)
+			require.NotNil(host)
 		} else {
 			_, err := mnet.GenPeer()
 			require.NoError(err)


### PR DESCRIPTION
The `require.NotEmpty` utility reads through the struct fields of the Host via reflection, while the internal background routine in the host also accesses its field, causing race conditions. The fix is to use `require.NotNil` as it only checks whether the Host is nil or not without accessing its internal fields