### PR TITLE
Validate Aggregator hash from the validator set 

### DIFF
--- a/types/validation.go
+++ b/types/validation.go
@@ -64,7 +64,7 @@ func (h *SignedHeader) ValidateBasic() error {
 
 	validatorSetHash := h.Validators.Hash()
 	if !bytes.Equal(validatorSetHash, h.AggregatorsHash[:]) {
-		return errors.New("AggregatorHash and validator set hash mismatch")
+		return errors.New("aggregator set hash in signed header and hash of validator set do not match")
 	}
 
 	// Make sure there is exactly one signature

--- a/types/validation.go
+++ b/types/validation.go
@@ -62,8 +62,7 @@ func (h *SignedHeader) ValidateBasic() error {
 		return err
 	}
 
-	validatorSetHash := h.Validators.Hash()
-	if !bytes.Equal(validatorSetHash, h.AggregatorsHash[:]) {
+	if !bytes.Equal(h.Validators.Hash(), h.AggregatorsHash[:]) {
 		return errors.New("aggregator set hash in signed header and hash of validator set do not match")
 	}
 

--- a/types/validation.go
+++ b/types/validation.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"bytes"
 	"errors"
 
 	"github.com/tendermint/tendermint/crypto/ed25519"
@@ -59,6 +60,11 @@ func (h *SignedHeader) ValidateBasic() error {
 	err = h.Validators.ValidateBasic()
 	if err != nil {
 		return err
+	}
+
+	validatorSetHash := h.Validators.Hash()
+	if !bytes.Equal(validatorSetHash, h.AggregatorsHash[:]) {
+		return errors.New("AggregatorHash and validator set hash mismatch")
 	}
 
 	// Make sure there is exactly one signature


### PR DESCRIPTION
When validating the Signed Header in Validate Basic we should check if the aggregator hash corresponds to the hash of the validator set.

Closes: #820 