### PR TITLE
ws: support cors

### DIFF
--- a/rpc/json/ws.go
+++ b/rpc/json/ws.go
@@ -38,6 +38,7 @@ func (h *handler) wsHandler(w http.ResponseWriter, r *http.Request) {
 	upgrader := websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
+		CheckOrigin:     func(r *http.Request) bool { return true },
 	}
 
 	wsc, err := upgrader.Upgrade(w, r, nil)


### PR DESCRIPTION
The websocket JSON RPC server did not support CORS. This PR implements this. Fixes #436 #742 