### PR TITLE
feat: Txs To Shares Roundtrip

### DIFF
--- a/third_party/celestia-app/shares/compact_shares_test.go
+++ b/third_party/celestia-app/shares/compact_shares_test.go
@@ -179,10 +179,11 @@ func Test_parseCompactSharesErrors(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		{
-			"share with start indicator false",
-			txShares[1:], // set the first share to the second share which has the start indicator set to false
-		},
+		// out of context shares are supported so this error should not exist now
+		// {
+		// 	"share with start indicator false",
+		// 	txShares[1:], // set the first share to the second share which has the start indicator set to false
+		// },
 		{
 			"share with unsupported share version",
 			[]Share{*shareWithUnsupportedShareVersion},

--- a/third_party/celestia-app/shares/compact_shares_test.go
+++ b/third_party/celestia-app/shares/compact_shares_test.go
@@ -113,6 +113,29 @@ func Test_processCompactShares(t *testing.T) {
 	}
 }
 
+func TestAllSplit(t *testing.T) {
+	txs := testfactory.GenerateRandomlySizedTxs(1000, 150)
+	txShares, err := SplitTxs(txs)
+	require.NoError(t, err)
+	resTxs, err := ParseTxs(txShares)
+	require.NoError(t, err)
+	assert.Equal(t, resTxs, txs)
+}
+
+func TestParseRandomOutOfContextShares(t *testing.T) {
+	txs := testfactory.GenerateRandomlySizedTxs(1000, 150)
+	txShares, err := SplitTxs(txs)
+	require.NoError(t, err)
+
+	for i := 0; i < 1000; i++ {
+		start, length := testfactory.GetRandomSubSlice(len(txShares))
+		randomRange := NewRange(start, start+length)
+		resTxs, err := ParseTxs(txShares[randomRange.Start:randomRange.End])
+		require.NoError(t, err)
+		assert.True(t, testfactory.CheckSubArray(txs, resTxs))
+	}
+}
+
 func TestCompactShareContainsInfoByte(t *testing.T) {
 	css := NewCompactShareSplitter(appns.TxNamespace, appconsts.ShareVersionZero)
 	txs := testfactory.GenerateRandomTxs(1, appconsts.ContinuationCompactShareContentSize/4)
@@ -179,11 +202,6 @@ func Test_parseCompactSharesErrors(t *testing.T) {
 	}
 
 	testCases := []testCase{
-		// out of context shares are supported so this error should not exist now
-		// {
-		// 	"share with start indicator false",
-		// 	txShares[1:], // set the first share to the second share which has the start indicator set to false
-		// },
 		{
 			"share with unsupported share version",
 			[]Share{*shareWithUnsupportedShareVersion},

--- a/third_party/celestia-app/shares/compact_shares_test.go
+++ b/third_party/celestia-app/shares/compact_shares_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	coretypes "github.com/cometbft/cometbft/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 

--- a/third_party/celestia-app/shares/compact_shares_test.go
+++ b/third_party/celestia-app/shares/compact_shares_test.go
@@ -15,24 +15,6 @@ import (
 	"github.com/rollkit/rollkit/third_party/celestia-app/testfactory"
 )
 
-func SplitTxs(txs coretypes.Txs) (txShares []Share, err error) {
-	txWriter := NewCompactShareSplitter(appns.TxNamespace, appconsts.ShareVersionZero)
-
-	for _, tx := range txs {
-		err = txWriter.WriteTx(tx)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	txShares, _, err = txWriter.Export(0)
-	if err != nil {
-		return nil, err
-	}
-
-	return txShares, nil
-}
-
 func TestCompactShareSplitter(t *testing.T) {
 	// note that this test is mainly for debugging purposes, the main round trip
 	// tests occur in TestMerge and Test_processCompactShares

--- a/third_party/celestia-app/shares/parse_compact_shares.go
+++ b/third_party/celestia-app/shares/parse_compact_shares.go
@@ -25,13 +25,14 @@ func parseCompactShares(shares []Share, supportedShareVersions []uint8) (data []
 	if err != nil {
 		return nil, err
 	}
-	if !seqStart {
-		return nil, errors.New("first share is not the start of a sequence")
-	}
 
 	err = validateShareVersions(shares, supportedShareVersions)
 	if err != nil {
 		return nil, err
+	}
+
+	if !seqStart {
+		return nil, errors.New("first share is not the start of a sequence")
 	}
 
 	rawData, err := extractRawData(shares)
@@ -81,7 +82,12 @@ func parseRawData(rawData []byte) (units [][]byte, err error) {
 // not contain the namespace ID, info byte, sequence length, or reserved bytes.
 func extractRawData(shares []Share) (rawData []byte, err error) {
 	for i := 0; i < len(shares); i++ {
-		raw, err := shares[i].RawData()
+		var raw []byte
+		if i == 0 {
+			raw, err = shares[i].RawDataUsingReserved()
+		} else {
+			raw, err = shares[i].RawData()
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/third_party/celestia-app/shares/parse_compact_shares.go
+++ b/third_party/celestia-app/shares/parse_compact_shares.go
@@ -1,8 +1,6 @@
 package shares
 
 import (
-	"errors"
-
 	"github.com/rollkit/rollkit/libs/appconsts"
 )
 
@@ -21,19 +19,23 @@ func parseCompactShares(shares []Share, supportedShareVersions []uint8) (data []
 		return nil, nil
 	}
 
-	seqStart, err := shares[0].IsSequenceStart()
-	if err != nil {
-		return nil, err
-	}
+	// out of context shares are supported
+
+	// seqStart, err := shares[0].IsSequenceStart()
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	err = validateShareVersions(shares, supportedShareVersions)
 	if err != nil {
 		return nil, err
 	}
 
-	if !seqStart {
-		return nil, errors.New("first share is not the start of a sequence")
-	}
+	// out of context shares are supported
+
+	// if !seqStart {
+	// 	return nil, errors.New("first share is not the start of a sequence")
+	// }
 
 	rawData, err := extractRawData(shares)
 	if err != nil {
@@ -70,7 +72,7 @@ func parseRawData(rawData []byte) (units [][]byte, err error) {
 		if err != nil {
 			return nil, err
 		}
-		if unitLen == 0 {
+		if unitLen == 0 || unitLen > uint64(len(actualData)) {
 			return units, nil
 		}
 		rawData = actualData[unitLen:]

--- a/third_party/celestia-app/shares/parse_compact_shares.go
+++ b/third_party/celestia-app/shares/parse_compact_shares.go
@@ -1,6 +1,14 @@
 package shares
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/rollkit/rollkit/libs/appconsts"
+)
+
+func ParseCompactShares(shares []Share) (data [][]byte, err error) {
+	return parseCompactShares(shares, appconsts.SupportedShareVersions)
+}
 
 // parseCompactShares returns data (transactions or intermediate state roots
 // based on the contents of rawShares and supportedShareVersions. If rawShares

--- a/third_party/celestia-app/shares/parse_compact_shares.go
+++ b/third_party/celestia-app/shares/parse_compact_shares.go
@@ -1,7 +1,7 @@
 package shares
 
 import (
-	"github.com/rollkit/rollkit/libs/appconsts"
+	"github.com/rollkit/rollkit/libs/celestia-app/appconsts"
 )
 
 func ParseCompactShares(shares []Share) (data [][]byte, err error) {

--- a/third_party/celestia-app/shares/parse_compact_shares.go
+++ b/third_party/celestia-app/shares/parse_compact_shares.go
@@ -1,7 +1,7 @@
 package shares
 
 import (
-	"github.com/rollkit/rollkit/libs/celestia-app/appconsts"
+	"github.com/rollkit/rollkit/third_party/celestia-app/appconsts"
 )
 
 func ParseCompactShares(shares []Share) (data [][]byte, err error) {

--- a/third_party/celestia-app/shares/range.go
+++ b/third_party/celestia-app/shares/range.go
@@ -1,0 +1,26 @@
+package shares
+
+// Range is an end exclusive set of share indexes.
+type Range struct {
+	// Start is the index of the first share occupied by this range.
+	Start int
+	// End is the next index after the last share occupied by this range.
+	End int
+}
+
+func NewRange(start, end int) Range {
+	return Range{Start: start, End: end}
+}
+
+func EmptyRange() Range {
+	return Range{Start: 0, End: 0}
+}
+
+func (r Range) IsEmpty() bool {
+	return r.Start == 0 && r.End == 0
+}
+
+func (r *Range) Add(value int) {
+	r.Start += value
+	r.End += value
+}

--- a/third_party/celestia-app/shares/share_builder.go
+++ b/third_party/celestia-app/shares/share_builder.go
@@ -123,12 +123,12 @@ func (b *Builder) indexOfInfoBytes() int {
 	return appconsts.NamespaceSize
 }
 
-// MaybeWriteReservedBytes will be a no-op if the reserved bytes
+// MaybeWriteReservedBytes will be a no-op for a compact share or if the reserved bytes
 // have already been populated. If the reserved bytes are empty, it will write
 // the location of the next unit of data to the reserved bytes.
 func (b *Builder) MaybeWriteReservedBytes() error {
 	if !b.isCompactShare {
-		return errors.New("this is not a compact share")
+		return nil
 	}
 
 	empty, err := b.isEmptyReservedBytes()

--- a/third_party/celestia-app/shares/shares.go
+++ b/third_party/celestia-app/shares/shares.go
@@ -201,6 +201,11 @@ func (s *Share) RawDataUsingReserved() (rawData []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// This means share is the last share and does not have any transaction beginning in it
+	if rawDataStartIndexUsingReserved == 0 {
+		return []byte{}, nil
+	}
 	if len(s.data) < rawDataStartIndexUsingReserved {
 		return rawData, fmt.Errorf("share %s is too short to contain raw data", s)
 	}

--- a/third_party/celestia-app/shares/shares.go
+++ b/third_party/celestia-app/shares/shares.go
@@ -161,8 +161,7 @@ func (s *Share) ToBytes() []byte {
 	return s.data
 }
 
-// RawDataWithReserved returns the raw share data including the reserved bytes. The raw share data does not contain the
-// namespace ID, info byte, or sequence length.
+// RawDataWithReserved returns the raw share data including the reserved bytes. The raw share data does not contain the namespace ID, info byte, or sequence length.
 func (s *Share) RawDataWithReserved() (rawData []byte, err error) {
 	if len(s.data) < s.rawDataStartIndexWithReserved() {
 		return rawData, fmt.Errorf("share %s is too short to contain raw data", s)
@@ -213,14 +212,16 @@ func (s *Share) RawDataUsingReserved() (rawData []byte, err error) {
 	return s.data[rawDataStartIndexUsingReserved:], nil
 }
 
+// rawDataStartIndexUsingReserved returns the start index of raw data while accounting for
+// reserved bytes, if it exists in the share.
 func (s *Share) rawDataStartIndexUsingReserved() (int, error) {
 	isStart, err := s.IsSequenceStart()
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 	isCompact, err := s.IsCompactShare()
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
 	index := appconsts.NamespaceSize + appconsts.ShareInfoBytes
@@ -228,16 +229,12 @@ func (s *Share) rawDataStartIndexUsingReserved() (int, error) {
 		index += appconsts.SequenceLenBytes
 	}
 
-	if !isStart && isCompact {
+	if isCompact {
 		reservedBytes, err := ParseReservedBytes(s.data[index : index+appconsts.CompactShareReservedBytes])
 		if err != nil {
 			return 0, err
 		}
 		return int(reservedBytes), nil
-	}
-
-	if isCompact {
-		index += appconsts.CompactShareReservedBytes
 	}
 	return index, nil
 }

--- a/third_party/celestia-app/shares/split_compact_shares.go
+++ b/third_party/celestia-app/shares/split_compact_shares.go
@@ -107,7 +107,7 @@ func (css *CompactShareSplitter) WriteWithNoReservedBytes(rawData []byte) error 
 		if rawDataLeftOver == nil {
 			break
 		}
-		if err := css.stackPending(); err != nil {
+		if err := css.stackPendingWithIsCompactFalse(); err != nil {
 			return err
 		}
 
@@ -115,7 +115,7 @@ func (css *CompactShareSplitter) WriteWithNoReservedBytes(rawData []byte) error 
 	}
 
 	if css.shareBuilder.AvailableBytes() == 0 {
-		if err := css.stackPending(); err != nil {
+		if err := css.stackPendingWithIsCompactFalse(); err != nil {
 			return err
 		}
 	}
@@ -166,6 +166,21 @@ func (css *CompactShareSplitter) stackPending() error {
 
 	// Now we need to create a new builder
 	css.shareBuilder, err = NewBuilder(css.namespace, css.shareVersion, false).Init()
+	return err
+}
+
+// stackPending will build & add the pending share to accumulated shares
+func (css *CompactShareSplitter) stackPendingWithIsCompactFalse() error {
+	pendingShare, err := css.shareBuilder.Build()
+	if err != nil {
+		return err
+	}
+	css.shares = append(css.shares, *pendingShare)
+
+	// Now we need to create a new builder
+	builder := NewBuilder(css.namespace, css.shareVersion, false)
+	builder.isCompactShare = false
+	css.shareBuilder, err = builder.Init()
 	return err
 }
 

--- a/third_party/celestia-app/shares/utils.go
+++ b/third_party/celestia-app/shares/utils.go
@@ -5,6 +5,8 @@ import (
 	"encoding/binary"
 
 	coretypes "github.com/cometbft/cometbft/types"
+	"github.com/rollkit/rollkit/libs/celestia-app/appconsts"
+	appns "github.com/rollkit/rollkit/libs/celestia-app/namespace"
 )
 
 // DelimLen calculates the length of the delimiter for a given unit size
@@ -95,4 +97,22 @@ func ParseDelimiter(input []byte) (inputWithoutLenDelimiter []byte, unitLen uint
 
 	// return the input without the length delimiter
 	return input[n:], dataLen, nil
+}
+
+func SplitTxs(txs coretypes.Txs) (txShares []Share, err error) {
+	txWriter := NewCompactShareSplitter(appns.TxNamespace, appconsts.ShareVersionZero)
+
+	for _, tx := range txs {
+		err = txWriter.WriteTx(tx)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	txShares, _, err = txWriter.Export(0)
+	if err != nil {
+		return nil, err
+	}
+
+	return txShares, nil
 }

--- a/third_party/celestia-app/shares/utils.go
+++ b/third_party/celestia-app/shares/utils.go
@@ -99,6 +99,23 @@ func ParseDelimiter(input []byte) (inputWithoutLenDelimiter []byte, unitLen uint
 	return input[n:], dataLen, nil
 }
 
+// ParseTxs collects all of the transactions from the shares provided
+func ParseTxs(shares []Share) (coretypes.Txs, error) {
+	// parse the shares
+	rawTxs, err := parseCompactShares(shares, appconsts.SupportedShareVersions)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert to the Tx type
+	txs := make(coretypes.Txs, len(rawTxs))
+	for i := 0; i < len(txs); i++ {
+		txs[i] = coretypes.Tx(rawTxs[i])
+	}
+
+	return txs, nil
+}
+
 func SplitTxs(txs coretypes.Txs) (txShares []Share, err error) {
 	txWriter := NewCompactShareSplitter(appns.TxNamespace, appconsts.ShareVersionZero)
 

--- a/third_party/celestia-app/shares/utils.go
+++ b/third_party/celestia-app/shares/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 
 	coretypes "github.com/cometbft/cometbft/types"
+
 	"github.com/rollkit/rollkit/libs/celestia-app/appconsts"
 	appns "github.com/rollkit/rollkit/libs/celestia-app/namespace"
 )

--- a/third_party/celestia-app/shares/utils.go
+++ b/third_party/celestia-app/shares/utils.go
@@ -6,8 +6,8 @@ import (
 
 	coretypes "github.com/cometbft/cometbft/types"
 
-	"github.com/rollkit/rollkit/libs/celestia-app/appconsts"
-	appns "github.com/rollkit/rollkit/libs/celestia-app/namespace"
+	"github.com/rollkit/rollkit/third_party/celestia-app/appconsts"
+	appns "github.com/rollkit/rollkit/third_party/celestia-app/namespace"
 )
 
 // DelimLen calculates the length of the delimiter for a given unit size

--- a/third_party/celestia-app/testfactory/txs.go
+++ b/third_party/celestia-app/testfactory/txs.go
@@ -35,8 +35,8 @@ func GenerateRandomTxs(count, size int) types.Txs {
 
 // GetRandomSubSlice returns two integers representing a randomly sized range in the interval [0, size]
 func GetRandomSubSlice(size int) (start int, length int) {
-	length = rand.Intn(size + 1)
-	start = rand.Intn(size - length + 1)
+	length = rand.Intn(size + 1)         //nolint:gosec
+	start = rand.Intn(size - length + 1) //nolint:gosec
 	return start, length
 }
 

--- a/third_party/celestia-app/testfactory/txs.go
+++ b/third_party/celestia-app/testfactory/txs.go
@@ -2,7 +2,6 @@ package testfactory
 
 import (
 	"bytes"
-	"math/rand"
 	mrand "math/rand"
 
 	"github.com/cometbft/cometbft/types"
@@ -35,8 +34,8 @@ func GenerateRandomTxs(count, size int) types.Txs {
 
 // GetRandomSubSlice returns two integers representing a randomly sized range in the interval [0, size]
 func GetRandomSubSlice(size int) (start int, length int) {
-	length = rand.Intn(size + 1)         //nolint:gosec
-	start = rand.Intn(size - length + 1) //nolint:gosec
+	length = mrand.Intn(size + 1)         //nolint:gosec
+	start = mrand.Intn(size - length + 1) //nolint:gosec
 	return start, length
 }
 

--- a/third_party/celestia-app/testfactory/txs.go
+++ b/third_party/celestia-app/testfactory/txs.go
@@ -1,6 +1,8 @@
 package testfactory
 
 import (
+	"bytes"
+	"math/rand"
 	mrand "math/rand"
 
 	"github.com/cometbft/cometbft/types"
@@ -29,4 +31,29 @@ func GenerateRandomTxs(count, size int) types.Txs {
 		txs[i] = tx
 	}
 	return txs
+}
+
+// GetRandomSubSlice returns two integers representing a randomly sized range in the interval [0, size]
+func GetRandomSubSlice(size int) (start int, length int) {
+	length = rand.Intn(size + 1)
+	start = rand.Intn(size - length + 1)
+	return start, length
+}
+
+// CheckSubArray returns whether subTxList is a subarray of txList
+func CheckSubArray(txList []types.Tx, subTxList []types.Tx) bool {
+	for i := 0; i <= len(txList)-len(subTxList); i++ {
+		j := 0
+		for j = 0; j < len(subTxList); j++ {
+			tx := txList[i+j]
+			subTx := subTxList[j]
+			if !bytes.Equal([]byte(tx), []byte(subTx)) {
+				break
+			}
+		}
+		if j == len(subTxList) {
+			return true
+		}
+	}
+	return false
 }

--- a/types/tx.go
+++ b/types/tx.go
@@ -7,6 +7,8 @@ import (
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmbytes "github.com/cometbft/cometbft/libs/bytes"
 
+	"github.com/rollkit/rollkit/libs/celestia-app/appconsts"
+	appns "github.com/rollkit/rollkit/libs/celestia-app/namespace"
 	"github.com/rollkit/rollkit/libs/celestia-app/shares"
 	pb "github.com/rollkit/rollkit/types/pb/rollkit"
 )
@@ -88,6 +90,16 @@ func SharesToPostableBytes(txShares []shares.Share) (postableData []byte, err er
 		postableData = append(postableData, raw...)
 	}
 	return postableData, nil
+}
+
+func PostableBytesToShares(postableData []byte) (txShares []shares.Share, err error) {
+	css := shares.NewCompactShareSplitterWithIsCompactFalse(appns.TxNamespace, appconsts.ShareVersionZero)
+	err = css.WriteWithNoReservedBytes(postableData)
+	if err != nil {
+		return nil, err
+	}
+	shares, _, err := css.Export(0)
+	return shares, err
 }
 
 func SharesToTxsWithISRs(txShares []shares.Share) (txsWithISRs []pb.TxWithISRs, err error) {

--- a/types/tx.go
+++ b/types/tx.go
@@ -55,7 +55,7 @@ func (txs Txs) ToTxsWithISRs(intermediateStateRoots IntermediateStateRoots) ([]p
 	if len(intermediateStateRoots.RawRootsList) != expectedISRListLength {
 		return nil, fmt.Errorf("invalid length of ISR list: %d, expected length: %d", len(intermediateStateRoots.RawRootsList), expectedISRListLength)
 	}
-	txsWithISRs := make([]pb.TxWithISRs, 0, len(txs))
+	txsWithISRs := make([]pb.TxWithISRs, len(txs))
 	for i, tx := range txs {
 		txsWithISRs[i] = pb.TxWithISRs{
 			PreIsr:  intermediateStateRoots.RawRootsList[i],

--- a/types/tx.go
+++ b/types/tx.go
@@ -79,6 +79,17 @@ func TxsWithISRsToShares(txsWithISRs []pb.TxWithISRs) (txShares []shares.Share, 
 	return txShares, err
 }
 
+func SharesToPostableBytes(txShares []shares.Share) (postableData []byte, err error) {
+	for i := 0; i < len(txShares); i++ {
+		raw, err := txShares[i].RawDataWithReserved()
+		if err != nil {
+			return nil, err
+		}
+		postableData = append(postableData, raw...)
+	}
+	return postableData, nil
+}
+
 func SharesToTxsWithISRs(txShares []shares.Share) (txsWithISRs []pb.TxWithISRs, err error) {
 	byteSlices, err := shares.ParseCompactShares(txShares)
 	if err != nil {

--- a/types/tx.go
+++ b/types/tx.go
@@ -7,9 +7,9 @@ import (
 	"github.com/cometbft/cometbft/crypto/tmhash"
 	cmbytes "github.com/cometbft/cometbft/libs/bytes"
 
-	"github.com/rollkit/rollkit/libs/celestia-app/appconsts"
-	appns "github.com/rollkit/rollkit/libs/celestia-app/namespace"
-	"github.com/rollkit/rollkit/libs/celestia-app/shares"
+	"github.com/rollkit/rollkit/third_party/celestia-app/appconsts"
+	appns "github.com/rollkit/rollkit/third_party/celestia-app/namespace"
+	"github.com/rollkit/rollkit/third_party/celestia-app/shares"
 	pb "github.com/rollkit/rollkit/types/pb/rollkit"
 )
 

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -5,9 +5,10 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/rollkit/rollkit/types/pb/rollkit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rollkit/rollkit/types/pb/rollkit"
 )
 
 func TestTxWithISRSerializationRoundtrip(t *testing.T) {
@@ -79,8 +80,8 @@ func TestTxWithISRSerializationOutOfContextRoundtrip(t *testing.T) {
 	assert.Equal(txsWithISRs, newTxsWithISRs)
 
 	for i := 0; i < 1000; i++ {
-		numShares := rand.Int() % len(txShares)
-		startShare := rand.Int() % (len(txShares) - numShares + 1)
+		numShares := rand.Int() % len(txShares)                    //nolint: gosec
+		startShare := rand.Int() % (len(txShares) - numShares + 1) //nolint: gosec
 		newTxsWithISRs, err := SharesToTxsWithISRs(txShares[startShare : startShare+numShares])
 		require.NoError(err)
 		assert.True(checkSubArray(txsWithISRs, newTxsWithISRs))

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -30,7 +30,15 @@ func TestTxWithISRSerializationRoundtrip(t *testing.T) {
 	require.NoError(err)
 	require.NotEmpty(txShares)
 
-	newTxsWithISRs, err := SharesToTxsWithISRs(txShares)
+	txBytes, err := SharesToPostableBytes(txShares)
+	require.NoError(err)
+	require.NotEmpty(txBytes)
+
+	newTxShares, err := PostableBytesToShares(txBytes)
+	require.NoError(err)
+	require.NotEmpty(newTxShares)
+
+	newTxsWithISRs, err := SharesToTxsWithISRs(newTxShares)
 	require.NoError(err)
 	require.NotEmpty(txsWithISRs)
 

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -1,0 +1,51 @@
+package types
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxWithISRSerializationRoundtrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	txs := make(Txs, 50)
+	ISRs := IntermediateStateRoots{
+		RawRootsList: make([][]byte, len(txs)+1),
+	}
+	for i := 0; i < len(txs); i++ {
+		txs[i] = getRandomTx()
+		ISRs.RawRootsList[i] = getRandomBytes(32)
+	}
+	ISRs.RawRootsList[len(txs)] = getRandomBytes(32)
+
+	txsWithISRs, err := txs.ToTxsWithISRs(ISRs)
+	require.NoError(err)
+	require.NotEmpty(txsWithISRs)
+
+	txShares, err := TxsWithISRsToShares(txsWithISRs)
+	require.NoError(err)
+	require.NotEmpty(txShares)
+
+	newTxsWithISRs, err := SharesToTxsWithISRs(txShares)
+	require.NoError(err)
+	require.NotEmpty(txsWithISRs)
+
+	assert.Equal(txsWithISRs, newTxsWithISRs)
+}
+
+// copy-pasted from store/store_test.go
+func getRandomTx() Tx {
+	size := rand.Int()%100 + 100 //nolint:gosec
+	return Tx(getRandomBytes(size))
+}
+
+// copy-pasted from store/store_test.go
+func getRandomBytes(n int) []byte {
+	data := make([]byte, n)
+	_, _ = rand.Read(data) //nolint:gosec
+	return data
+}

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -12,7 +12,7 @@ func TestTxWithISRSerializationRoundtrip(t *testing.T) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	txs := make(Txs, 50)
+	txs := make(Txs, 1000)
 	ISRs := IntermediateStateRoots{
 		RawRootsList: make([][]byte, len(txs)+1),
 	}

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -1,9 +1,11 @@
 package types
 
 import (
+	"bytes"
 	"math/rand"
 	"testing"
 
+	"github.com/rollkit/rollkit/types/pb/rollkit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -38,11 +40,75 @@ func TestTxWithISRSerializationRoundtrip(t *testing.T) {
 	require.NoError(err)
 	require.NotEmpty(newTxShares)
 
+	// Note that txShares and newTxShares are not necessarily equal because newTxShares might
+	// contain zero padding at the end and thus sequence length can differ
 	newTxsWithISRs, err := SharesToTxsWithISRs(newTxShares)
 	require.NoError(err)
 	require.NotEmpty(txsWithISRs)
 
 	assert.Equal(txsWithISRs, newTxsWithISRs)
+}
+
+func TestTxWithISRSerializationOutOfContextRoundtrip(t *testing.T) {
+	require := require.New(t)
+	assert := assert.New(t)
+
+	numTxs := 1000
+	txs := make(Txs, numTxs)
+	ISRs := IntermediateStateRoots{
+		RawRootsList: make([][]byte, len(txs)+1),
+	}
+	for i := 0; i < len(txs); i++ {
+		txs[i] = getRandomTx()
+		ISRs.RawRootsList[i] = getRandomBytes(32)
+	}
+	ISRs.RawRootsList[len(txs)] = getRandomBytes(32)
+
+	txsWithISRs, err := txs.ToTxsWithISRs(ISRs)
+	require.NoError(err)
+	require.NotEmpty(txsWithISRs)
+
+	txShares, err := TxsWithISRsToShares(txsWithISRs)
+	require.NoError(err)
+	require.NotEmpty(txShares)
+
+	newTxsWithISRs, err := SharesToTxsWithISRs(txShares)
+	require.NoError(err)
+	require.NotEmpty(newTxsWithISRs)
+
+	assert.Equal(txsWithISRs, newTxsWithISRs)
+
+	for i := 0; i < 1000; i++ {
+		numShares := rand.Int() % len(txShares)
+		startShare := rand.Int() % (len(txShares) - numShares + 1)
+		newTxsWithISRs, err := SharesToTxsWithISRs(txShares[startShare : startShare+numShares])
+		require.NoError(err)
+		assert.True(checkSubArray(txsWithISRs, newTxsWithISRs))
+	}
+}
+
+// Returns whether subTxList is a subarray of txList
+func checkSubArray(txList []rollkit.TxWithISRs, subTxList []rollkit.TxWithISRs) (bool, error) {
+	for i := 0; i <= len(txList)-len(subTxList); i++ {
+		j := 0
+		for j = 0; j < len(subTxList); j++ {
+			tx, err := txList[i+j].Marshal()
+			if err != nil {
+				return false, err
+			}
+			subTx, err := subTxList[j].Marshal()
+			if err != nil {
+				return false, err
+			}
+			if !bytes.Equal(tx, subTx) {
+				break
+			}
+		}
+		if j == len(subTxList) {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // copy-pasted from store/store_test.go

--- a/types/tx_test.go
+++ b/types/tx_test.go
@@ -20,10 +20,10 @@ func TestTxWithISRSerializationRoundtrip(t *testing.T) {
 		RawRootsList: make([][]byte, len(txs)+1),
 	}
 	for i := 0; i < len(txs); i++ {
-		txs[i] = getRandomTx()
-		ISRs.RawRootsList[i] = getRandomBytes(32)
+		txs[i] = GetRandomTx()
+		ISRs.RawRootsList[i] = GetRandomBytes(32)
 	}
-	ISRs.RawRootsList[len(txs)] = getRandomBytes(32)
+	ISRs.RawRootsList[len(txs)] = GetRandomBytes(32)
 
 	txsWithISRs, err := txs.ToTxsWithISRs(ISRs)
 	require.NoError(err)
@@ -60,10 +60,10 @@ func TestTxWithISRSerializationOutOfContextRoundtrip(t *testing.T) {
 		RawRootsList: make([][]byte, len(txs)+1),
 	}
 	for i := 0; i < len(txs); i++ {
-		txs[i] = getRandomTx()
-		ISRs.RawRootsList[i] = getRandomBytes(32)
+		txs[i] = GetRandomTx()
+		ISRs.RawRootsList[i] = GetRandomBytes(32)
 	}
-	ISRs.RawRootsList[len(txs)] = getRandomBytes(32)
+	ISRs.RawRootsList[len(txs)] = GetRandomBytes(32)
 
 	txsWithISRs, err := txs.ToTxsWithISRs(ISRs)
 	require.NoError(err)
@@ -110,17 +110,4 @@ func checkSubArray(txList []rollkit.TxWithISRs, subTxList []rollkit.TxWithISRs) 
 		}
 	}
 	return false, nil
-}
-
-// copy-pasted from store/store_test.go
-func getRandomTx() Tx {
-	size := rand.Int()%100 + 100 //nolint:gosec
-	return Tx(getRandomBytes(size))
-}
-
-// copy-pasted from store/store_test.go
-func getRandomBytes(n int) []byte {
-	data := make([]byte, n)
-	_, _ = rand.Read(data) //nolint:gosec
-	return data
 }


### PR DESCRIPTION
Adds ability to:
- Convert `TxWithISRs` to Shares
- Convert Shares to byte array (that will be posted on celestia)
- Convert above byte array back to Shares
- Convert Shares back to `TxWithISRs`
- Parse Out of Context Shares

Adds relevant roundtrip tests

Resolves #881 
Resolves #934 
Resolves #886 
Resolves #925 

Note: All shares are written and interpreted as compact shares so they contain reserved bytes (see https://celestiaorg.github.io/celestia-app/specs/data_structures.html#compact-share)

Related PR in `celestia-app`: https://github.com/celestiaorg/celestia-app/pull/1770