### PR TITLE
fraud proof processing using go-fraud package

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -247,9 +247,9 @@ func (m *Manager) SetFraudProofService(fraudProofServ *fraudserv.ProofService) {
 	m.executor.SetFraudProofService(fraudProofServ)
 }
 
-func (m *Manager) ProcessFraudProof(fraudProofService *fraudserv.ProofService, ctx context.Context, cancel context.CancelFunc) {
+func (m *Manager) ProcessFraudProof(ctx context.Context, cancel context.CancelFunc) {
 	// subscribe to state fraud proof
-	sub, err := fraudProofService.Subscribe(types.StateFraudProofType)
+	sub, err := m.executor.FraudService.Subscribe(types.StateFraudProofType)
 	if err != nil {
 		m.logger.Error("failed to subscribe to fraud proof gossip", "error", err)
 		return

--- a/block/manager.go
+++ b/block/manager.go
@@ -254,6 +254,7 @@ func (m *Manager) ProcessFraudProof(fraudProofService *fraudserv.ProofService, c
 		m.logger.Error("failed to subscribe to fraud proof gossip", "error", err)
 		return
 	}
+	defer sub.Cancel()
 
 	// continuously process the fraud proofs received via subscription
 	for {

--- a/block/manager.go
+++ b/block/manager.go
@@ -258,6 +258,7 @@ func (m *Manager) ProcessFraudProof(fraudProofService *fraudserv.ProofService, c
 
 	// continuously process the fraud proofs received via subscription
 	for {
+		// sub.Proof is a blocking call that only returns on proof recieved or context ended
 		proof, err := sub.Proof(ctx)
 		if err != nil {
 			m.logger.Error("failed to receive gossiped fraud proof", "error", err)

--- a/block/manager.go
+++ b/block/manager.go
@@ -250,6 +250,10 @@ func (m *Manager) AggregationLoop(ctx context.Context, lazy bool) {
 	}
 }
 
+func (m *Manager) SetFraudProofService(fraudProofServ *fraudserv.ProofService) {
+	m.executor.SetFraudProofService(fraudProofServ)
+}
+
 func (m *Manager) ProcessFraudProof(fraudProofService *fraudserv.ProofService, ctx context.Context, cancel context.CancelFunc) {
 	// subscribe to state fraud proof
 	sub, err := fraudProofService.Subscribe(types.StateFraudProofType)

--- a/block/manager.go
+++ b/block/manager.go
@@ -255,7 +255,7 @@ func (m *Manager) ProcessFraudProof(fraudProofService *fraudserv.ProofService, c
 		return
 	}
 
-	// continously process the fraud proofs received via subscription
+	// continuously process the fraud proofs received via subscription
 	for {
 		proof, err := sub.Proof(ctx)
 		if err != nil {

--- a/block/manager.go
+++ b/block/manager.go
@@ -61,8 +61,6 @@ type Manager struct {
 
 	HeaderCh chan *types.SignedHeader
 
-	FraudProofInCh chan *abci.FraudProof
-
 	blockInCh chan newBlockEvent
 	syncCache map[uint64]*types.Block
 
@@ -154,7 +152,6 @@ func NewManager(
 		// channels are buffered to avoid blocking on input/output operations, buffer sizes are arbitrary
 		HeaderCh:          make(chan *types.SignedHeader, 100),
 		blockInCh:         make(chan newBlockEvent, 100),
-		FraudProofInCh:    make(chan *abci.FraudProof, 100),
 		retrieveMtx:       new(sync.Mutex),
 		lastStateMtx:      new(sync.Mutex),
 		syncCache:         make(map[uint64]*types.Block),
@@ -180,10 +177,6 @@ func getAddress(key crypto.PrivKey) ([]byte, error) {
 func (m *Manager) SetDALC(dalc da.DataAvailabilityLayerClient) {
 	m.dalc = dalc
 	m.retriever = dalc.(da.BlockRetriever)
-}
-
-func (m *Manager) GetFraudProofOutChan() chan *abci.FraudProof {
-	return m.executor.FraudProofOutCh
 }
 
 // AggregationLoop is responsible for aggregating transactions into rollup-blocks.

--- a/block/manager.go
+++ b/block/manager.go
@@ -258,7 +258,7 @@ func (m *Manager) ProcessFraudProof(fraudProofService *fraudserv.ProofService, c
 
 	// continuously process the fraud proofs received via subscription
 	for {
-		// sub.Proof is a blocking call that only returns on proof recieved or context ended
+		// sub.Proof is a blocking call that only returns on proof received or context ended
 		proof, err := sub.Proof(ctx)
 		if err != nil {
 			m.logger.Error("failed to receive gossiped fraud proof", "error", err)

--- a/node/full.go
+++ b/node/full.go
@@ -292,6 +292,7 @@ func (n *FullNode) OnStart() error {
 	if err = n.fraudService.Start(n.ctx); err != nil {
 		return fmt.Errorf("error while starting fraud exchange service: %w", err)
 	}
+	n.blockManager.SetFraudProofService(n.fraudService)
 
 	if n.conf.Aggregator {
 		n.Logger.Info("working in aggregator mode", "block time", n.conf.BlockTime)

--- a/node/full.go
+++ b/node/full.go
@@ -298,6 +298,7 @@ func (n *FullNode) OnStart() error {
 		go n.blockManager.AggregationLoop(n.ctx, n.conf.LazyAggregator)
 		go n.headerPublishLoop(n.ctx)
 	}
+	go n.blockManager.ProcessFraudProof(n.fraudService, n.ctx, n.cancel)
 	go n.blockManager.RetrieveLoop(n.ctx)
 	go n.blockManager.SyncLoop(n.ctx, n.cancel)
 	go n.fraudProofPublishLoop(n.ctx)

--- a/node/full.go
+++ b/node/full.go
@@ -276,7 +276,7 @@ func (n *FullNode) OnStart() error {
 		go n.blockManager.AggregationLoop(n.ctx, n.conf.LazyAggregator)
 		go n.headerPublishLoop(n.ctx)
 	}
-	go n.blockManager.ProcessFraudProof(n.fraudService, n.ctx, n.cancel)
+	go n.blockManager.ProcessFraudProof(n.ctx, n.cancel)
 	go n.blockManager.RetrieveLoop(n.ctx)
 	go n.blockManager.SyncLoop(n.ctx, n.cancel)
 	return nil

--- a/node/full.go
+++ b/node/full.go
@@ -282,7 +282,9 @@ func (n *FullNode) OnStart() error {
 	go func(ctx context.Context) {
 		select {
 		case <-ctx.Done():
-			n.Stop()
+			if err = n.Stop(); err != nil {
+				n.Logger.Error("errors while stopping node:", "errors", err)
+			}
 		default:
 		}
 	}(n.ctx)

--- a/node/full.go
+++ b/node/full.go
@@ -279,15 +279,6 @@ func (n *FullNode) OnStart() error {
 	go n.blockManager.ProcessFraudProof(n.fraudService, n.ctx, n.cancel)
 	go n.blockManager.RetrieveLoop(n.ctx)
 	go n.blockManager.SyncLoop(n.ctx, n.cancel)
-	go func(ctx context.Context) {
-		select {
-		case <-ctx.Done():
-			if err = n.Stop(); err != nil {
-				n.Logger.Error("errors while stopping node:", "errors", err)
-			}
-		default:
-		}
-	}(n.ctx)
 	return nil
 }
 

--- a/node/full.go
+++ b/node/full.go
@@ -34,7 +34,6 @@ import (
 	"github.com/rollkit/rollkit/state/txindex"
 	"github.com/rollkit/rollkit/state/txindex/kv"
 	"github.com/rollkit/rollkit/store"
-	"github.com/rollkit/rollkit/types"
 )
 
 // prefixes used in KV store to separate main node data from DALC data
@@ -173,7 +172,7 @@ func newFullNode(
 		},
 		mainKV,
 		true,
-		types.StateFraudProofType,
+		genesis.ChainID,
 	)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -379,20 +379,21 @@ func testSingleAggreatorSingleFullNodeFraudProofGossip(t *testing.T) {
 	nodes, apps := createNodes(aggCtx, ctx, clientNodes+1, true, &wg, t)
 
 	for _, app := range apps {
-		app.On("VerifyFraudProof", mock.Anything).Return(abci.ResponseVerifyFraudProof{Success: true}).Run(func(args mock.Arguments) {
-			wg.Done()
-		}).Once()
+		app.On("VerifyFraudProof", mock.Anything).Return(abci.ResponseVerifyFraudProof{Success: true})
+		// .Run(func(args mock.Arguments) {
+		// 	wg.Done()
+		// }).Once()
 	}
 
 	aggNode := nodes[0]
 	fullNode := nodes[1]
 
-	wg.Add(clientNodes + 1)
+	// wg.Add(clientNodes + 1)
 	require.NoError(aggNode.Start())
 	time.Sleep(2 * time.Second)
 	require.NoError(fullNode.Start())
 
-	wg.Wait()
+	// wg.Wait()
 	// aggregator should have 0 GenerateFraudProof calls and 1 VerifyFraudProof calls
 	checkAppCalls(assert, apps[0], []int{0, 1})
 	// fullnode should have 1 GenerateFraudProof calls and 1 VerifyFraudProof calls
@@ -424,21 +425,22 @@ func testSingleAggreatorTwoFullNodeFraudProofSync(t *testing.T) {
 	nodes, apps := createNodes(aggCtx, ctx, clientNodes+1, true, &wg, t)
 
 	for _, app := range apps {
-		app.On("VerifyFraudProof", mock.Anything).Return(abci.ResponseVerifyFraudProof{Success: true}).Run(func(args mock.Arguments) {
-			wg.Done()
-		}).Once()
+		app.On("VerifyFraudProof", mock.Anything).Return(abci.ResponseVerifyFraudProof{Success: true})
+		// .Run(func(args mock.Arguments) {
+		// 	wg.Done()
+		// }).Once()
 	}
 
 	aggNode := nodes[0]
 	fullNode1 := nodes[1]
 	fullNode2 := nodes[2]
 
-	wg.Add(clientNodes + 1)
+	// wg.Add(clientNodes + 1)
 	require.NoError(aggNode.Start())
 	time.Sleep(2 * time.Second)
 	require.NoError(fullNode1.Start())
 
-	wg.Wait()
+	// wg.Wait()
 	// aggregator should have 0 GenerateFraudProof calls and 1 VerifyFraudProof calls
 	checkAppCalls(assert, apps[0], []int{0, 1})
 	// fullnode1 should have 1 GenerateFraudProof calls and 1 VerifyFraudProof calls

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -382,9 +382,9 @@ func testSingleAggreatorSingleFullNodeFraudProofGossip(t *testing.T) {
 	cancel()
 	require.NoError(node2.Stop())
 
-	assert.Greater(len(n1Frauds), 0, "number of fraud proofs gossiped should be greater than 0")
-	assert.Greater(len(n2Frauds), 0, "number of fraud proofs gossiped should be greater than 0")
-	assert.Equal(n1Frauds, n2Frauds, "number of fraud proofs gossiped between nodes must match")
+	assert.Equal(len(n1Frauds), 1, "number of fraud proofs received via gossip should be 1")
+	assert.Equal(len(n2Frauds), 1, "number of fraud proofs received via gossip should be 1")
+	assert.Equal(n1Frauds, n2Frauds, "the received fraud proofs after gossip must match")
 }
 
 func testSingleAggreatorTwoFullNodeFraudProofSync(t *testing.T) {

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -454,8 +454,6 @@ func testSingleAggreatorTwoFullNodeFraudProofSync(t *testing.T) {
 	wg.Add(1)
 	// delay start node3 such that it can sync the fraud proof from peers, instead of listening to gossip
 	require.NoError(fullNode2.Start())
-	// allow syncer to catch up before querying the fraud store
-	time.Sleep(1 * time.Second)
 
 	wg.Wait()
 	// fullnode2 should have 1 GenerateFraudProof calls and 1 VerifyFraudProof calls

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -353,21 +353,6 @@ func testSingleAggreatorSingleFullNodeSingleLightNode(t *testing.T) {
 	assert.Equal(n1h, n3h, "heights must match")
 }
 
-func checkAppCalls(assert *assert.Assertions, app *mocks.Application, expected []int) {
-	generateFraudProofCnt := 0
-	verifyFraudProofCnt := 0
-	for _, call := range app.Calls {
-		switch call.Method {
-		case "GenerateFraudProof":
-			generateFraudProofCnt++
-		case "VerifyFraudProof":
-			verifyFraudProofCnt++
-		}
-	}
-	assert.Equal(expected[0], generateFraudProofCnt)
-	assert.Equal(expected[1], verifyFraudProofCnt)
-}
-
 func testSingleAggreatorSingleFullNodeFraudProofGossip(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
@@ -394,9 +379,11 @@ func testSingleAggreatorSingleFullNodeFraudProofGossip(t *testing.T) {
 
 	wg.Wait()
 	// aggregator should have 0 GenerateFraudProof calls and 1 VerifyFraudProof calls
-	checkAppCalls(assert, apps[0], []int{0, 1})
+	apps[0].AssertNumberOfCalls(t, "GenerateFraudProof", 0)
+	apps[0].AssertNumberOfCalls(t, "VerifyFraudProof", 1)
 	// fullnode should have 1 GenerateFraudProof calls and 1 VerifyFraudProof calls
-	checkAppCalls(assert, apps[1], []int{1, 1})
+	apps[1].AssertNumberOfCalls(t, "GenerateFraudProof", 1)
+	apps[1].AssertNumberOfCalls(t, "VerifyFraudProof", 1)
 
 	n1Frauds, err := aggNode.fraudService.Get(aggCtx, types.StateFraudProofType)
 	require.NoError(err)
@@ -440,9 +427,11 @@ func testSingleAggreatorTwoFullNodeFraudProofSync(t *testing.T) {
 
 	wg.Wait()
 	// aggregator should have 0 GenerateFraudProof calls and 1 VerifyFraudProof calls
-	checkAppCalls(assert, apps[0], []int{0, 1})
+	apps[0].AssertNumberOfCalls(t, "GenerateFraudProof", 0)
+	apps[0].AssertNumberOfCalls(t, "VerifyFraudProof", 1)
 	// fullnode1 should have 1 GenerateFraudProof calls and 1 VerifyFraudProof calls
-	checkAppCalls(assert, apps[1], []int{1, 1})
+	apps[1].AssertNumberOfCalls(t, "GenerateFraudProof", 1)
+	apps[1].AssertNumberOfCalls(t, "VerifyFraudProof", 1)
 
 	n1Frauds, err := aggNode.fraudService.Get(aggCtx, types.StateFraudProofType)
 	require.NoError(err)
@@ -457,7 +446,8 @@ func testSingleAggreatorTwoFullNodeFraudProofSync(t *testing.T) {
 
 	wg.Wait()
 	// fullnode2 should have 1 GenerateFraudProof calls and 1 VerifyFraudProof calls
-	checkAppCalls(assert, apps[2], []int{1, 1})
+	apps[2].AssertNumberOfCalls(t, "GenerateFraudProof", 1)
+	apps[2].AssertNumberOfCalls(t, "VerifyFraudProof", 1)
 
 	n3Frauds, err := fullNode2.fraudService.Get(aggCtx, types.StateFraudProofType)
 	require.NoError(err)

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -472,7 +472,7 @@ func testSingleAggreatorTwoFullNodeFraudProofSync(t *testing.T) {
 
 func TestFraudProofService(t *testing.T) {
 	testSingleAggreatorSingleFullNodeFraudProofGossip(t)
-	// testSingleAggreatorTwoFullNodeFraudProofSync(t)
+	testSingleAggreatorTwoFullNodeFraudProofSync(t)
 }
 
 // TODO: rewrite this integration test to accommodate gossip/halting mechanism of full nodes after fraud proof generation (#693)

--- a/node/light.go
+++ b/node/light.go
@@ -151,7 +151,7 @@ func (ln *LightNode) ProcessFraudProof() {
 		return
 	}
 
-	// continously process the fraud proofs received via subscription
+	// continuously process the fraud proofs received via subscription
 	for {
 		proof, err := sub.Proof(ln.ctx)
 		if err != nil {

--- a/node/light.go
+++ b/node/light.go
@@ -79,7 +79,7 @@ func newLightNode(
 		},
 		datastore,
 		true,
-		types.StateFraudProofType,
+		genesis.ChainID,
 	)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/node/proof_service_factory.go
+++ b/node/proof_service_factory.go
@@ -13,16 +13,16 @@ type ProofServiceFactory struct {
 	getter        fraud.HeaderFetcher
 	ds            datastore.Datastore
 	syncerEnabled bool
-	proofType     fraud.ProofType
+	networkID     string
 }
 
-func NewProofServiceFactory(c *p2p.Client, getter fraud.HeaderFetcher, ds datastore.Datastore, syncerEnabled bool, proofType fraud.ProofType) ProofServiceFactory {
+func NewProofServiceFactory(c *p2p.Client, getter fraud.HeaderFetcher, ds datastore.Datastore, syncerEnabled bool, networkID string) ProofServiceFactory {
 	return ProofServiceFactory{
 		client:        c,
 		getter:        getter,
 		ds:            ds,
 		syncerEnabled: syncerEnabled,
-		proofType:     proofType,
+		networkID:     networkID,
 	}
 }
 
@@ -33,6 +33,6 @@ func (factory *ProofServiceFactory) CreateProofService() *fraudserv.ProofService
 		factory.getter,
 		factory.ds,
 		factory.syncerEnabled,
-		factory.proofType.String(),
+		factory.networkID,
 	)
 }

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -41,8 +41,6 @@ const (
 
 	// headerTopicSuffix is added after namespace to create pubsub topic for block header gossiping.
 	headerTopicSuffix = "-header"
-
-	fraudProofTopicSuffix = "-fraudProof"
 )
 
 // Client is a P2P client, implemented with libp2p.
@@ -66,9 +64,6 @@ type Client struct {
 
 	headerGossiper  *Gossiper
 	headerValidator GossipValidator
-
-	fraudProofGossiper  *Gossiper
-	fraudProofValidator GossipValidator
 
 	// cancel is used to cancel context passed to libp2p functions
 	// it's required because of discovery.Advertise call
@@ -162,7 +157,6 @@ func (c *Client) Close() error {
 	return multierr.Combine(
 		c.txGossiper.Close(),
 		c.headerGossiper.Close(),
-		c.fraudProofGossiper.Close(),
 		c.dht.Close(),
 		c.host.Close(),
 	)
@@ -188,17 +182,6 @@ func (c *Client) GossipSignedHeader(ctx context.Context, headerBytes []byte) err
 // SetHeaderValidator sets the callback function, that will be invoked after block header is received from P2P network.
 func (c *Client) SetHeaderValidator(validator GossipValidator) {
 	c.headerValidator = validator
-}
-
-// GossipHeader sends a fraud proof to the P2P network.
-func (c *Client) GossipFraudProof(ctx context.Context, fraudProof []byte) error {
-	c.logger.Debug("Gossiping fraud proof", "len", len(fraudProof))
-	return c.fraudProofGossiper.Publish(ctx, fraudProof)
-}
-
-// SetFraudProofValidator sets the callback function, that will be invoked after a fraud proof is received from P2P network.
-func (c *Client) SetFraudProofValidator(validator GossipValidator) {
-	c.fraudProofValidator = validator
 }
 
 // Addrs returns listen addresses of Client.
@@ -395,13 +378,6 @@ func (c *Client) setupGossiping(ctx context.Context) error {
 	}
 	go c.headerGossiper.ProcessMessages(ctx)
 
-	c.fraudProofGossiper, err = NewGossiper(c.host, c.ps, c.getFraudProofTopic(), c.logger,
-		WithValidator(c.fraudProofValidator))
-	if err != nil {
-		return err
-	}
-	go c.fraudProofGossiper.ProcessMessages(ctx)
-
 	return nil
 }
 
@@ -442,8 +418,4 @@ func (c *Client) getTxTopic() string {
 
 func (c *Client) getHeaderTopic() string {
 	return c.getNamespace() + headerTopicSuffix
-}
-
-func (c *Client) getFraudProofTopic() string {
-	return c.getNamespace() + fraudProofTopicSuffix
 }

--- a/state/executor.go
+++ b/state/executor.go
@@ -40,8 +40,7 @@ type BlockExecutor struct {
 
 	logger log.Logger
 
-	FraudProofOutCh chan *abci.FraudProof
-	fraudService    *fraudserv.ProofService
+	fraudService *fraudserv.ProofService
 }
 
 // NewBlockExecutor creates new instance of BlockExecutor.
@@ -56,7 +55,6 @@ func NewBlockExecutor(proposerAddress []byte, namespaceID [8]byte, chainID strin
 		fraudProofsEnabled: fraudProofsEnabled,
 		eventBus:           eventBus,
 		logger:             logger,
-		FraudProofOutCh:    make(chan *abci.FraudProof),
 	}
 }
 

--- a/state/executor.go
+++ b/state/executor.go
@@ -373,7 +373,9 @@ func (e *BlockExecutor) execute(ctx context.Context, state types.State, block *t
 				return err
 			}
 			// Gossip Fraud Proof
-			e.fraudService.Broadcast(ctx, &types.StateFraudProof{FraudProof: *fraudProof})
+			if err := e.fraudService.Broadcast(ctx, &types.StateFraudProof{FraudProof: *fraudProof}); err != nil {
+				return fmt.Errorf("failed to broadcast fraud proof: %w", err)
+			}
 			return ErrFraudProofGenerated
 		}
 		currentIsrIndex++

--- a/state/executor.go
+++ b/state/executor.go
@@ -40,7 +40,7 @@ type BlockExecutor struct {
 
 	logger log.Logger
 
-	fraudService *fraudserv.ProofService
+	FraudService *fraudserv.ProofService
 }
 
 // NewBlockExecutor creates new instance of BlockExecutor.
@@ -205,7 +205,7 @@ func (e *BlockExecutor) VerifyFraudProof(fraudProof *abci.FraudProof, expectedVa
 }
 
 func (e *BlockExecutor) SetFraudProofService(fraudProofServ *fraudserv.ProofService) {
-	e.fraudService = fraudProofServ
+	e.FraudService = fraudProofServ
 }
 
 func (e *BlockExecutor) updateState(state types.State, block *types.Block, abciResponses *tmstate.ABCIResponses, validatorUpdates []*tmtypes.Validator) (types.State, error) {
@@ -373,7 +373,7 @@ func (e *BlockExecutor) execute(ctx context.Context, state types.State, block *t
 				return err
 			}
 			// Gossip Fraud Proof
-			if err := e.fraudService.Broadcast(ctx, &types.StateFraudProof{FraudProof: *fraudProof}); err != nil {
+			if err := e.FraudService.Broadcast(ctx, &types.StateFraudProof{FraudProof: *fraudProof}); err != nil {
 				return fmt.Errorf("failed to broadcast fraud proof: %w", err)
 			}
 			return ErrFraudProofGenerated

--- a/types/header.go
+++ b/types/header.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"bytes"
 	"encoding"
 	"fmt"
 	"time"
@@ -86,19 +85,19 @@ func (h *Header) Verify(untrst header.Header) error {
 	if err := verifyNewHeaderAndVals(h, untrstH); err != nil {
 		return &header.VerifyError{Reason: err}
 	}
-	// perform actual verification
-	if untrstH.Height() == h.Height()+1 {
-		// Check the validator hashes are the same in the case headers are adjacent
-		// TODO: next validator set is not available
-		if !bytes.Equal(untrstH.AggregatorsHash[:], h.AggregatorsHash[:]) {
-			return &header.VerifyError{
-				Reason: fmt.Errorf("expected old header next validators (%X) to match those from new header (%X)",
-					h.AggregatorsHash,
-					untrstH.AggregatorsHash,
-				),
-			}
-		}
-	}
+
+	// Check the validator hashes are the same in the case headers are adjacent
+	// TODO: next validator set is not available, disable this check until NextValidatorHash is enabled
+	// if untrstH.Height() == h.Height()+1 {
+	// if !bytes.Equal(untrstH.AggregatorsHash[:], h.AggregatorsHash[:]) {
+	// 	return &header.VerifyError{
+	// 		Reason: fmt.Errorf("expected old header next validators (%X) to match those from new header (%X)",
+	// 			h.AggregatorsHash,
+	// 			untrstH.AggregatorsHash,
+	// 		),
+	// 	}
+	// }
+	// }
 
 	// TODO: There must be a way to verify non-adjacent headers
 	// Ensure that untrusted commit has enough of trusted commit's power.


### PR DESCRIPTION
Update existing fraud proof processing logic to use ProofService from go-fraud package. Also, removes the old fraud proof gossip logic.

Fixes #895 & #945