### PR TITLE
Upgrade to go-cnc:v0.4.1, use cnc.Namespace

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,7 +73,7 @@ func TestInitialState(t *testing.T) {
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
 	conf := config.BlockManagerConfig{
 		BlockTime:   10 * time.Second,
-		NamespaceID: types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8},
+		NamespaceID: cnc.MustNewV0([]byte{0, 0, 1, 2, 3, 4, 5, 6, 7, 8}),
 	}
 
 	for _, c := range cases {
@@ -93,7 +94,7 @@ func TestInitialState(t *testing.T) {
 
 func getMockDALC(logger log.Logger) da.DataAvailabilityLayerClient {
 	dalc := &mockda.DataAvailabilityLayerClient{}
-	_ = dalc.Init([8]byte{}, nil, nil, logger)
+	_ = dalc.Init(cnc.Namespace{}, nil, nil, logger)
 	_ = dalc.Start()
 	return dalc
 }

--- a/config/config.go
+++ b/config/config.go
@@ -4,10 +4,9 @@ import (
 	"encoding/hex"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-
-	"github.com/rollkit/rollkit/types"
 )
 
 const (
@@ -53,9 +52,9 @@ type BlockManagerConfig struct {
 	// DABlockTime informs about block time of underlying data availability layer
 	DABlockTime time.Duration `mapstructure:"da_block_time"`
 	// DAStartHeight allows skipping first DAStartHeight-1 blocks when querying for blocks.
-	DAStartHeight uint64            `mapstructure:"da_start_height"`
-	NamespaceID   types.NamespaceID `mapstructure:"namespace_id"`
-	FraudProofs   bool              `mapstructure:"fraud_proofs"`
+	DAStartHeight uint64        `mapstructure:"da_start_height"`
+	NamespaceID   cnc.Namespace `mapstructure:"namespace_id"`
+	FraudProofs   bool          `mapstructure:"fraud_proofs"`
 }
 
 // GetViperConfig reads configuration parameters from Viper instance.
@@ -76,7 +75,7 @@ func (nc *NodeConfig) GetViperConfig(v *viper.Viper) error {
 	if err != nil {
 		return err
 	}
-	copy(nc.NamespaceID[:], bytes)
+	nc.NamespaceID = cnc.MustNewV0(bytes)
 	nc.TrustedHash = v.GetString(flagTrustedHash)
 	return nil
 }
@@ -93,7 +92,7 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Duration(flagBlockTime, def.BlockTime, "block time (for aggregator mode)")
 	cmd.Flags().Duration(flagDABlockTime, def.DABlockTime, "DA chain block time (for syncing)")
 	cmd.Flags().Uint64(flagDAStartHeight, def.DAStartHeight, "starting DA block height (for syncing)")
-	cmd.Flags().BytesHex(flagNamespaceID, def.NamespaceID[:], "namespace identifies (8 bytes in hex)")
+	cmd.Flags().BytesHex(flagNamespaceID, def.NamespaceID.ID, "namespace identifies (8 bytes in hex)")
 	cmd.Flags().Bool(flagFraudProofs, def.FraudProofs, "enable fraud proofs (experimental & insecure)")
 	cmd.Flags().Bool(flagLight, def.Light, "run light client")
 	cmd.Flags().String(flagTrustedHash, def.TrustedHash, "initial trusted hash to start the header exchange service")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
-
-	"github.com/rollkit/rollkit/types"
 )
 
 func TestViperAndCobra(t *testing.T) {
@@ -25,7 +24,7 @@ func TestViperAndCobra(t *testing.T) {
 	assert.NoError(cmd.Flags().Set(flagDALayer, "foobar"))
 	assert.NoError(cmd.Flags().Set(flagDAConfig, `{"json":true}`))
 	assert.NoError(cmd.Flags().Set(flagBlockTime, "1234s"))
-	assert.NoError(cmd.Flags().Set(flagNamespaceID, "0102030405060708"))
+	assert.NoError(cmd.Flags().Set(flagNamespaceID, "00000102030405060708"))
 	assert.NoError(cmd.Flags().Set(flagFraudProofs, "false"))
 
 	nc := DefaultNodeConfig
@@ -35,6 +34,6 @@ func TestViperAndCobra(t *testing.T) {
 	assert.Equal("foobar", nc.DALayer)
 	assert.Equal(`{"json":true}`, nc.DAConfig)
 	assert.Equal(1234*time.Second, nc.BlockTime)
-	assert.Equal(types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8}, nc.NamespaceID)
+	assert.Equal(cnc.MustNewV0([]byte{0, 0, 1, 2, 3, 4, 5, 6, 7, 8}), nc.NamespaceID)
 	assert.Equal(false, nc.FraudProofs)
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -3,7 +3,7 @@ package config
 import (
 	"time"
 
-	"github.com/rollkit/rollkit/types"
+	"github.com/celestiaorg/go-cnc"
 )
 
 const (
@@ -22,7 +22,7 @@ var DefaultNodeConfig = NodeConfig{
 	LazyAggregator: false,
 	BlockManagerConfig: BlockManagerConfig{
 		BlockTime:   30 * time.Second,
-		NamespaceID: types.NamespaceID{},
+		NamespaceID: cnc.Namespace{},
 		FraudProofs: false,
 	},
 	DALayer:  "mock",

--- a/da/celestia/celestia.go
+++ b/da/celestia/celestia.go
@@ -25,7 +25,7 @@ type DataAvailabilityLayerClient struct {
 	_      *openrpc.Client
 	client *cnc.Client
 
-	namespaceID types.NamespaceID
+	namespaceID cnc.Namespace
 	config      Config
 	logger      log.Logger
 }
@@ -43,7 +43,7 @@ type Config struct {
 
 // Init initializes DataAvailabilityLayerClient instance.
 func (c *DataAvailabilityLayerClient) Init(
-	namespaceID types.NamespaceID, config []byte, kvStore ds.Datastore, logger log.Logger,
+	namespaceID cnc.Namespace, config []byte, kvStore ds.Datastore, logger log.Logger,
 ) error {
 	c.namespaceID = namespaceID
 	c.logger = logger

--- a/da/celestia/mock/server.go
+++ b/da/celestia/mock/server.go
@@ -44,7 +44,7 @@ func (s *Server) Start(listener net.Listener) error {
 	if err != nil {
 		return err
 	}
-	err = s.mock.Init([8]byte{}, []byte(s.blockTime.String()), kvStore, s.logger)
+	err = s.mock.Init(cnc.Namespace{}, []byte(s.blockTime.String()), kvStore, s.logger)
 	if err != nil {
 		return err
 	}

--- a/da/da.go
+++ b/da/da.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/celestiaorg/go-cnc"
 	ds "github.com/ipfs/go-datastore"
 
 	"github.com/rollkit/rollkit/log"
@@ -70,7 +71,7 @@ type ResultRetrieveBlocks struct {
 // It also contains life-cycle methods.
 type DataAvailabilityLayerClient interface {
 	// Init is called once to allow DA client to read configuration and initialize resources.
-	Init(namespaceID types.NamespaceID, config []byte, kvStore ds.Datastore, logger log.Logger) error
+	Init(namespaceID cnc.Namespace, config []byte, kvStore ds.Datastore, logger log.Logger) error
 
 	// Start is called once, after Init. It's implementation should start operation of DataAvailabilityLayerClient.
 	Start() error

--- a/da/grpc/grpc.go
+++ b/da/grpc/grpc.go
@@ -7,6 +7,7 @@ import (
 
 	"google.golang.org/grpc"
 
+	"github.com/celestiaorg/go-cnc"
 	ds "github.com/ipfs/go-datastore"
 
 	"github.com/rollkit/rollkit/da"
@@ -42,7 +43,7 @@ var _ da.DataAvailabilityLayerClient = &DataAvailabilityLayerClient{}
 var _ da.BlockRetriever = &DataAvailabilityLayerClient{}
 
 // Init sets the configuration options.
-func (d *DataAvailabilityLayerClient) Init(_ types.NamespaceID, config []byte, _ ds.Datastore, logger log.Logger) error {
+func (d *DataAvailabilityLayerClient) Init(_ cnc.Namespace, config []byte, _ ds.Datastore, logger log.Logger) error {
 	d.logger = logger
 	if len(config) == 0 {
 		d.config = DefaultConfig

--- a/da/grpc/mockserv/mockserv.go
+++ b/da/grpc/mockserv/mockserv.go
@@ -3,6 +3,7 @@ package mockserv
 import (
 	"context"
 
+	"github.com/celestiaorg/go-cnc"
 	ds "github.com/ipfs/go-datastore"
 	tmlog "github.com/tendermint/tendermint/libs/log"
 	"google.golang.org/grpc"
@@ -18,7 +19,7 @@ import (
 func GetServer(kv ds.Datastore, conf grpcda.Config, mockConfig []byte, logger tmlog.Logger) *grpc.Server {
 	srv := grpc.NewServer()
 	mockImpl := &mockImpl{}
-	err := mockImpl.mock.Init([8]byte{}, mockConfig, kv, logger)
+	err := mockImpl.mock.Init(cnc.Namespace{}, mockConfig, kv, logger)
 	if err != nil {
 		logger.Error("failed to initialize mock DALC", "error", err)
 		panic(err)

--- a/da/mock/mock.go
+++ b/da/mock/mock.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	ds "github.com/ipfs/go-datastore"
 
 	"github.com/rollkit/rollkit/da"
@@ -34,7 +35,7 @@ var _ da.DataAvailabilityLayerClient = &DataAvailabilityLayerClient{}
 var _ da.BlockRetriever = &DataAvailabilityLayerClient{}
 
 // Init is called once to allow DA client to read configuration and initialize resources.
-func (m *DataAvailabilityLayerClient) Init(_ types.NamespaceID, config []byte, dalcKV ds.Datastore, logger log.Logger) error {
+func (m *DataAvailabilityLayerClient) Init(_ cnc.Namespace, config []byte, dalcKV ds.Datastore, logger log.Logger) error {
 	m.logger = logger
 	m.dalcKV = dalcKV
 	m.daHeight = 1

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -20,7 +21,7 @@ import (
 	"github.com/rollkit/rollkit/types"
 )
 
-var testNamespaceID = types.NamespaceID{0, 1, 2, 3, 4, 5, 6, 7}
+var testNamespaceID = cnc.MustNewV0([]byte{0, 0, 1, 2, 3, 4, 5, 6, 7, 8})
 
 func TestMain(m *testing.M) {
 	srv := startMockGRPCServ()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/rollkit/rollkit
 go 1.18
 
 require (
-	github.com/celestiaorg/go-cnc v0.3.0
+	github.com/celestiaorg/go-cnc v0.4.1
 	github.com/celestiaorg/go-fraud v0.1.0
 	github.com/celestiaorg/go-header v0.2.8
 	github.com/dgraph-io/badger/v3 v3.2103.5

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/btcsuite/websocket v0.0.0-20150119174127-31079b680792/go.mod h1:ghJtE
 github.com/btcsuite/winsvc v1.0.0/go.mod h1:jsenWakMcC0zFBFurPLEAyrnc/teJEM1O46fmI40EZs=
 github.com/buger/jsonparser v0.0.0-20181115193947-bf1c66bbce23/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
 github.com/casbin/casbin/v2 v2.1.2/go.mod h1:YcPU1XXisHhLzuxH9coDNf2FbKpjGlbCg3n9yuLkIJQ=
-github.com/celestiaorg/go-cnc v0.3.0 h1:eAVPNHGpx+2sBO7NZyQ1+VW8rzf6W4FQDlSq6aqSTsM=
-github.com/celestiaorg/go-cnc v0.3.0/go.mod h1:zYzvHudSd1iNPuHBMyvZ1YvWou5aT9JXgtch9Tkaf70=
+github.com/celestiaorg/go-cnc v0.4.1 h1:7fz8Y8HKKxE2dCp2m9Qlm+NoROxJWGCiKtcvaYp8iM8=
+github.com/celestiaorg/go-cnc v0.4.1/go.mod h1:zYzvHudSd1iNPuHBMyvZ1YvWou5aT9JXgtch9Tkaf70=
 github.com/celestiaorg/go-fraud v0.1.0 h1:v6mZvlmf2J5ELZfPnrtmmOvKbaYIUs/erDWPO8NbZyY=
 github.com/celestiaorg/go-fraud v0.1.0/go.mod h1:yoNM35cKMAkt5Mi/Qx3Wi9bnPilLi8n6RpHZVglTUDs=
 github.com/celestiaorg/go-header v0.2.8 h1:NS6fOzfRoGqQF3RrstSjAxLArWyJWob+25T4GFCQj30=

--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -780,7 +781,7 @@ func createGenesisValidators(numNodes int, appCreator func(require *require.Asse
 	dalc := &mockda.DataAvailabilityLayerClient{}
 	ds, err := store.NewDefaultInMemoryKVStore()
 	require.Nil(err)
-	err = dalc.Init([8]byte{}, nil, ds, log.TestingLogger())
+	err = dalc.Init(cnc.Namespace{}, nil, ds, log.TestingLogger())
 	require.Nil(err)
 	err = dalc.Start()
 	require.Nil(err)

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/libp2p/go-libp2p/core/crypto"
@@ -48,7 +49,7 @@ func TestAggregatorMode(t *testing.T) {
 	genesisValidators, signingKey := getGenesisValidatorSetWithSigner(1)
 	blockManagerConfig := config.BlockManagerConfig{
 		BlockTime:   1 * time.Second,
-		NamespaceID: types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8},
+		NamespaceID: cnc.MustNewV0([]byte{0, 0, 1, 2, 3, 4, 5, 6, 7, 8}),
 	}
 	node, err := newFullNode(context.Background(), config.NodeConfig{DALayer: "mock", Aggregator: true, BlockManagerConfig: blockManagerConfig}, key, signingKey, proxy.NewLocalClientCreator(app), &tmtypes.GenesisDoc{ChainID: "test", Validators: genesisValidators}, log.TestingLogger())
 	require.NoError(err)
@@ -148,7 +149,7 @@ func TestLazyAggregator(t *testing.T) {
 	genesisValidators, signingKey := getGenesisValidatorSetWithSigner(1)
 	blockManagerConfig := config.BlockManagerConfig{
 		BlockTime:   1 * time.Second,
-		NamespaceID: types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8},
+		NamespaceID: cnc.MustNewV0([]byte{0, 0, 1, 2, 3, 4, 5, 6, 7, 8}),
 	}
 
 	node, err := NewNode(context.Background(), config.NodeConfig{
@@ -319,7 +320,7 @@ func testSingleAggreatorSingleFullNodeSingleLightNode(t *testing.T) {
 	}
 	dalc := &mockda.DataAvailabilityLayerClient{}
 	ds, _ := store.NewDefaultInMemoryKVStore()
-	_ = dalc.Init([8]byte{}, nil, ds, log.TestingLogger())
+	_ = dalc.Init(cnc.Namespace{}, nil, ds, log.TestingLogger())
 	_ = dalc.Start()
 	sequencer, _ := createNode(aggCtx, 0, false, true, false, keys, &wg, t)
 	fullNode, _ := createNode(ctx, 1, false, false, false, keys, &wg, t)
@@ -595,7 +596,7 @@ func createNodes(aggCtx, ctx context.Context, num int, isMalicious bool, wg *syn
 	apps := make([]*mocks.Application, num)
 	dalc := &mockda.DataAvailabilityLayerClient{}
 	ds, _ := store.NewDefaultInMemoryKVStore()
-	_ = dalc.Init([8]byte{}, nil, ds, log.TestingLogger())
+	_ = dalc.Init(cnc.Namespace{}, nil, ds, log.TestingLogger())
 	_ = dalc.Start()
 	node, app := createNode(aggCtx, 0, isMalicious, true, false, keys, wg, t)
 	apps[0] = app
@@ -625,7 +626,7 @@ func createNode(ctx context.Context, n int, isMalicious bool, aggregator bool, i
 	bmConfig := config.BlockManagerConfig{
 		DABlockTime: 100 * time.Millisecond,
 		BlockTime:   1 * time.Second, // blocks must be at least 1 sec apart for adjacent headers to get verified correctly
-		NamespaceID: types.NamespaceID{8, 7, 6, 5, 4, 3, 2, 1},
+		NamespaceID: cnc.MustNewV0([]byte{8, 7, 6, 5, 4, 3, 2, 1, 0, 0}),
 		FraudProofs: true,
 	}
 	for i := 0; i < len(keys); i++ {

--- a/state/executor.go
+++ b/state/executor.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/celestiaorg/go-fraud/fraudserv"
 	abci "github.com/tendermint/tendermint/abci/types"
 	cryptoenc "github.com/tendermint/tendermint/crypto/encoding"
@@ -30,7 +31,7 @@ var ErrAddingValidatorToBased = errors.New("cannot add validators to empty valid
 // BlockExecutor creates and applies blocks and maintains state.
 type BlockExecutor struct {
 	proposerAddress    []byte
-	namespaceID        types.NamespaceID
+	namespaceID        cnc.Namespace
 	chainID            string
 	proxyApp           proxy.AppConnConsensus
 	mempool            mempool.Mempool
@@ -45,7 +46,7 @@ type BlockExecutor struct {
 
 // NewBlockExecutor creates new instance of BlockExecutor.
 // Proposer address and namespace ID will be used in all newly created blocks.
-func NewBlockExecutor(proposerAddress []byte, namespaceID [8]byte, chainID string, mempool mempool.Mempool, proxyApp proxy.AppConnConsensus, fraudProofsEnabled bool, eventBus *tmtypes.EventBus, logger log.Logger) *BlockExecutor {
+func NewBlockExecutor(proposerAddress []byte, namespaceID cnc.Namespace, chainID string, mempool mempool.Mempool, proxyApp proxy.AppConnConsensus, fraudProofsEnabled bool, eventBus *tmtypes.EventBus, logger log.Logger) *BlockExecutor {
 	return &BlockExecutor{
 		proposerAddress:    proposerAddress,
 		namespaceID:        namespaceID,

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/celestiaorg/go-cnc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -37,7 +38,7 @@ func doTestCreateBlock(t *testing.T, fraudProofsEnabled bool) {
 	require.NoError(err)
 	require.NotNil(client)
 
-	nsID := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	nsID := cnc.MustNewV0([]byte{0, 0, 1, 2, 3, 4, 5, 6, 7, 8})
 
 	mpool := mempoolv1.NewTxMempool(logger, cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client), 0)
 	executor := NewBlockExecutor([]byte("test address"), nsID, "test", mpool, proxy.NewAppConnConsensus(client), fraudProofsEnabled, nil, logger)
@@ -114,7 +115,7 @@ func doTestApplyBlock(t *testing.T, fraudProofsEnabled bool) {
 	require.NoError(err)
 	require.NotNil(client)
 
-	nsID := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	nsID := cnc.MustNewV0([]byte{0, 0, 1, 2, 3, 4, 5, 6, 7, 8})
 	chainID := "test"
 
 	mpool := mempoolv1.NewTxMempool(logger, cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client), 0)

--- a/types/block.go
+++ b/types/block.go
@@ -6,8 +6,6 @@ import (
 	tmtypes "github.com/tendermint/tendermint/types"
 )
 
-type NamespaceID [8]byte
-
 // Version captures the consensus rules for processing a block in the blockchain,
 // including all blockchain data structures and the rules of the application's
 // state transition machine.


### PR DESCRIPTION
This PR manually upgrades go-cnc from 0.3.0 to 0.4.1, which has a breaking change of 8 byte namespace to 10 byte. 

I have tested the PR using local-celestia-devnet with app:v1.0.0-rc0 and node:v0.11.0-rc2, which are celestia's arabica testnet configurations.
https://github.com/rollkit/local-celestia-devnet/releases/tag/v0.11.0-rc2