### PR TITLE
set node id using p2p key instead of local host id

### DIFF
--- a/node/block_exchange.go
+++ b/node/block_exchange.go
@@ -127,9 +127,13 @@ func (bExService *BlockExchangeService) Start() error {
 		return fmt.Errorf("error while starting block store: %w", err)
 	}
 
-	_, _, network := bExService.p2p.Info()
-	networkIDBlock := network + "-block"
 	var err error
+	_, _, network, err := bExService.p2p.Info()
+	if err != nil {
+		return fmt.Errorf("error while fetching the network: %w", err)
+	}
+	networkIDBlock := network + "-block"
+
 	if bExService.p2pServer, err = newBlockP2PServer(bExService.p2p.Host(), bExService.blockStore, networkIDBlock); err != nil {
 		return fmt.Errorf("error while creating p2p server: %w", err)
 	}

--- a/node/full_client.go
+++ b/node/full_client.go
@@ -717,7 +717,10 @@ func (c *FullClient) Status(ctx context.Context) (*ctypes.ResultStatus, error) {
 		state.Version.Consensus.Block,
 		state.Version.Consensus.App,
 	)
-	id, addr, network := c.node.P2P.Info()
+	id, addr, network, err := c.node.P2P.Info()
+	if err != nil {
+		return nil, fmt.Errorf("failed to load node p2p2 info: %w", err)
+	}
 	txIndexerStatus := "on"
 
 	result := &ctypes.ResultStatus{

--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 	crand "crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"sync"
 	"testing"
@@ -1099,6 +1100,10 @@ func TestStatus(t *testing.T) {
 		res := resp.NodeInfo.Other.TxIndex == tc.other.TxIndex
 		assert.Equal(tc.expected, res, tc)
 	}
+	// check that NodeInfo DefaultNodeID matches the ID derived from p2p key
+	rawKey, err := key.GetPublic().Raw()
+	assert.NoError(err)
+	assert.Equal(p2p.ID(hex.EncodeToString(tmcrypto.AddressHash(rawKey))), resp.NodeInfo.DefaultNodeID)
 }
 
 func TestFutureGenesisTime(t *testing.T) {

--- a/node/header_exchange.go
+++ b/node/header_exchange.go
@@ -126,8 +126,11 @@ func (hExService *HeaderExchangeService) Start() error {
 		return fmt.Errorf("error while starting header store: %w", err)
 	}
 
-	_, _, network := hExService.p2p.Info()
 	var err error
+	_, _, network, err := hExService.p2p.Info()
+	if err != nil {
+		return fmt.Errorf("error while fetching the network: %w", err)
+	}
 	if hExService.p2pServer, err = newP2PServer(hExService.p2p.Host(), hExService.headerStore, network); err != nil {
 		return fmt.Errorf("error while creating p2p server: %w", err)
 	}

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -2,6 +2,7 @@ package p2p
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/rollkit/rollkit/config"
 	"github.com/rollkit/rollkit/log"
+	tmcrypto "github.com/tendermint/tendermint/crypto"
 )
 
 // TODO(tzdybal): refactor to configuration parameters
@@ -187,7 +189,11 @@ func (c *Client) ConnectionGater() *conngater.BasicConnectionGater {
 
 // Info returns client ID, ListenAddr, and Network info
 func (c *Client) Info() (p2p.ID, string, string) {
-	return p2p.ID(c.host.ID().String()), c.conf.ListenAddress, c.chainID
+	rawKey, err := c.privKey.GetPublic().Raw()
+	if err != nil {
+		c.logger.Error("failed to extract raw bytes from p2p key", "error", err)
+	}
+	return p2p.ID(hex.EncodeToString(tmcrypto.AddressHash(rawKey))), c.conf.ListenAddress, c.chainID
 }
 
 // PeerConnection describe basic information about P2P connection.

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -25,9 +25,10 @@ import (
 	"github.com/tendermint/tendermint/p2p"
 	"go.uber.org/multierr"
 
+	tmcrypto "github.com/tendermint/tendermint/crypto"
+
 	"github.com/rollkit/rollkit/config"
 	"github.com/rollkit/rollkit/log"
-	tmcrypto "github.com/tendermint/tendermint/crypto"
 )
 
 // TODO(tzdybal): refactor to configuration parameters

--- a/p2p/client.go
+++ b/p2p/client.go
@@ -189,12 +189,12 @@ func (c *Client) ConnectionGater() *conngater.BasicConnectionGater {
 }
 
 // Info returns client ID, ListenAddr, and Network info
-func (c *Client) Info() (p2p.ID, string, string) {
+func (c *Client) Info() (p2p.ID, string, string, error) {
 	rawKey, err := c.privKey.GetPublic().Raw()
 	if err != nil {
-		c.logger.Error("failed to extract raw bytes from p2p key", "error", err)
+		return "", "", "", err
 	}
-	return p2p.ID(hex.EncodeToString(tmcrypto.AddressHash(rawKey))), c.conf.ListenAddress, c.chainID
+	return p2p.ID(hex.EncodeToString(tmcrypto.AddressHash(rawKey))), c.conf.ListenAddress, c.chainID, nil
 }
 
 // PeerConnection describe basic information about P2P connection.


### PR DESCRIPTION
Node ID is set using local p2p host which does not match with cosmos-sdk node ID, which is set using the p2p key. Hence, changing the ID on the rollkit side to match with cosmos-sdk.