### PR TITLE
Update mempool_test_helpers.go

### DIFF
--- a/mempool/v1/mempool_test_helpers.go
+++ b/mempool/v1/mempool_test_helpers.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cometbft/cometbft/abci/example/code"
 	"github.com/cometbft/cometbft/abci/example/kvstore"
 	abci "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/config"
@@ -64,7 +63,7 @@ func (app *application) CheckTx(req abci.RequestCheckTx) abci.ResponseCheckTx {
 	return abci.ResponseCheckTx{
 		Priority:  priority,
 		Sender:    sender,
-		Code:      code.CodeTypeOK,
+		Code:      abci.CodeTypeOK,
 		GasWanted: 1,
 	}
 }


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

When I follow the instructions here: https://rollkit.dev/tutorials/gm-world#macos-setup, I encountered the following error:

```
github.com/cosmos/cosmos-sdk/server imports
        github.com/rollkit/rollkit/node imports
        github.com/rollkit/rollkit/mempool/v1 imports
        github.com/cometbft/cometbft/abci/example/code: package github.com/cometbft/cometbft/abci/example/code provided by github.com/cometbft/cometbft at latest version v0.37.2 but not at required version v0.38.0-rc2
```

Then I finally found package `github.com/cometbft/cometbft/abci/example/code` has been removed. Use the code defined in the abci types instead.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
