### PR TITLE
test: use pkg httptest to avoid port conflict

### DIFF
--- a/da/celestia/mock/server.go
+++ b/da/celestia/mock/server.go
@@ -84,7 +84,7 @@ func (s *Server) Start(listener net.Listener) error {
 	}
 	go func() {
 		s.server = new(http.Server)
-		s.server.Handler = s.getHandler()
+		s.server.Handler = s.Handler()
 		err := s.server.Serve(listener)
 		s.logger.Debug("http server exited with", "error", err)
 	}()
@@ -98,7 +98,7 @@ func (s *Server) Stop() {
 	_ = s.server.Shutdown(ctx)
 }
 
-func (s *Server) getHandler() http.Handler {
+func (s *Server) Handler() http.Handler {
 	mux := mux2.NewRouter()
 	mux.HandleFunc("/", s.rpc).Methods(http.MethodPost)
 

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"net/http/httptest"
 	"os"
 	"strconv"
 	"testing"
@@ -119,16 +120,9 @@ func startMockGRPCServ() *grpc.Server {
 
 func startMockCelestiaNodeServer() *cmock.Server {
 	httpSrv := cmock.NewServer(mockDaBlockTime, cmlog.NewTMLogger(os.Stdout))
-	l, err := net.Listen("tcp4", "127.0.0.1:26658")
-	if err != nil {
-		fmt.Println("failed to create listener for mock celestia-node RPC server, error: %w", err)
-		return nil
-	}
-	err = httpSrv.Start(l)
-	if err != nil {
-		fmt.Println("can't start mock celestia-node RPC server")
-		return nil
-	}
+	ts := httptest.NewServer(httpSrv.Handler())
+	testConfig.BaseURL = ts.URL
+	httpSrv.Start(ts.Listener)
 	return httpSrv
 }
 

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -122,7 +122,11 @@ func startMockCelestiaNodeServer() *cmock.Server {
 	httpSrv := cmock.NewServer(mockDaBlockTime, cmlog.NewTMLogger(os.Stdout))
 	ts := httptest.NewServer(httpSrv.Handler())
 	testConfig.BaseURL = ts.URL
-	httpSrv.Start(ts.Listener)
+	err := httpSrv.Start(ts.Listener)
+	if err != nil {
+		fmt.Println("can't start mock celestia-node RPC server")
+		return nil
+	}
 	return httpSrv
 }
 


### PR DESCRIPTION
## Overview

This PR uses pkg `httptest` to avoid port conflict when running tests under `da/test` i.e. `TestLifecycle`, `TestRetrieve`.

This allows the tests to pass even if an address is bound to the default port i.e. `127.0.0.1:26658`

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
