### PR TITLE
test: update mock.Server to use httptest.Server

### DIFF
--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"net/http/httptest"
 	"os"
 	"strconv"
 	"testing"
@@ -34,7 +33,7 @@ var (
 	testNamespaceID = types.NamespaceID{0, 1, 2, 3, 4, 5, 6, 7}
 
 	testConfig = celestia.Config{
-		BaseURL:  "http://localhost:26658",
+		BaseURL:  "http://localhost:26658", // placeholder; actually set in startMockCelestiaNodeServer
 		Timeout:  30 * time.Second,
 		GasLimit: 3000000,
 	}
@@ -120,13 +119,12 @@ func startMockGRPCServ() *grpc.Server {
 
 func startMockCelestiaNodeServer() *cmock.Server {
 	httpSrv := cmock.NewServer(mockDaBlockTime, cmlog.NewTMLogger(os.Stdout))
-	ts := httptest.NewServer(httpSrv.Handler())
-	testConfig.BaseURL = ts.URL
-	err := httpSrv.Start(ts.Listener)
+	url, err := httpSrv.Start()
 	if err != nil {
 		fmt.Println("can't start mock celestia-node RPC server")
 		return nil
 	}
+	testConfig.BaseURL = url
 	return httpSrv
 }
 

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -33,7 +33,6 @@ var (
 	testNamespaceID = types.NamespaceID{0, 1, 2, 3, 4, 5, 6, 7}
 
 	testConfig = celestia.Config{
-		BaseURL:  "http://localhost:26658", // placeholder; actually set in startMockCelestiaNodeServer
 		Timeout:  30 * time.Second,
 		GasLimit: 3000000,
 	}


### PR DESCRIPTION
## Overview

This PR improves upon #1144 by simplifying `mock.Server` to use `httptest` directly, avoiding a duplicate `http.Server`. `Server.Start` doesn't need a listener anymore, and it returns the URL at which the `httptest.Server` is running.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
