### PR TITLE
feat: add release trigger for merged PRs with create-release label

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -37,11 +37,50 @@ jobs:
   proto:
     uses: ./.github/workflows/proto.yml
 
-  # Make a release if this is a manually trigger job, i.e. workflow_dispatch
-  release:
-    needs: [lint, test, proto]
+  # get_merged_pr_labels uses the listPullRequestsAssociatedWithCommit API
+  # endpoint to get the PR information for the commit during a push event. Once
+  # the PR information is received, we check to see if the create-release label
+  # was added to the pr.
+  get_merged_pr_labels:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    outputs:
+      has_release_label: ${{ steps.set-outputs.outputs.has_release_label }}
+    steps:
+      # We only want to run this step on a push event, otherwise this will error
+      # out as the result is null. We have the if condition here as to not block
+      # steps that rely on this step and others if this step is skipped.
+      - name: Query listPullRequestsAssociatedWithCommit for the PR information
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/github-script@v6
+        id: get_pr_data
+        with:
+          script: |
+            const prData = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              commit_sha: context.sha,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+            const pr = prData.data[0];
+            const prLabels = pr ? pr.labels.map(label => label.name) : [];
+            const hasReleaseLabel = prLabels.includes('create-release');
+            return { hasReleaseLabel };
+      # Only run if the result is not null. We add this check so that the CI
+      # does not show a failure when the previous step is skipped.
+      - name: Set the outputs
+        if: steps.get_pr_data.outputs.result != null
+        id: set-outputs
+        run: echo "has_release_label=${{ fromJSON(steps.get_pr_data.outputs.result).hasReleaseLabel }}" >> "$GITHUB_OUTPUT"
+
+  # Make a release if this is a manually trigger job, i.e. workflow_dispatch, or
+  # there was a merged pr with the create-release label
+  release:
+    needs: [lint, test, proto, get_merged_pr_labels]
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' &&
+      contains(github.ref, 'refs/heads/main') &&
+      needs.get_merged_pr_labels.outputs.has_release_label)
     permissions: "write-all"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR updates the release CI to trigger when a PR with the `create-release` label is merged. 

See tested action: https://github.com/MSevey/workflows/actions/runs/6489995567

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
