### PR TITLE
Test netInfo in full_client_test.go

### DIFF
--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -1193,8 +1193,6 @@ func TestNetInfo(t *testing.T) {
 	netInfo, err := rpc.NetInfo(context.Background())
 	require.NoError(err)
 	assert.NotNil(netInfo)
-
 	assert.True(netInfo.Listening)
-	assert.Equal("/ip4/127.0.0.1/tcp/7676", netInfo.Listeners[0])
 	assert.Equal(0, len(netInfo.Peers))
 }

--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -1172,3 +1172,29 @@ func TestHealth(t *testing.T) {
 	assert.Nil(err)
 	assert.Empty(resultHealth)
 }
+
+func TestNetInfo(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	mockApp, rpc := getRPC(t)
+	mockApp.On("BeginBlock", mock.Anything).Return(abci.ResponseBeginBlock{})
+	mockApp.On("CheckTx", mock.Anything).Return(abci.ResponseCheckTx{})
+	mockApp.On("EndBlock", mock.Anything).Return(abci.ResponseEndBlock{})
+	mockApp.On("Commit", mock.Anything).Return(abci.ResponseCommit{})
+
+	err := rpc.node.Start()
+	require.NoError(err)
+	defer func() {
+		err := rpc.node.Stop()
+		require.NoError(err)
+	}()
+
+	netInfo, err := rpc.NetInfo(context.Background())
+	require.NoError(err)
+	assert.NotNil(netInfo)
+
+	assert.True(netInfo.Listening)
+	assert.Equal("/ip4/127.0.0.1/tcp/7676", netInfo.Listeners[0])
+	assert.Equal(0, len(netInfo.Peers))
+}


### PR DESCRIPTION
closes: #1260 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Implemented a new test `TestNetInfo` to verify the network information functionality, ensuring the node correctly reports its listening status and has no connected peers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->