### PR TITLE
chore: fix permissions of files generated in docker

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -4,7 +4,7 @@ version: v1beta1
 plugins:
   # The name of the plugin.
   - name: gogofaster
-     # The the relative output directory.
-    out: proto/pb
+     # The relative output directory.
+    out: types/pb
     # Any options to provide to the plugin.
     opt: plugins=grpc,paths=source_relative

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/rollkit/rollkit
 
-go 1.20
+go 1.21
+
+toolchain go1.21.3
 
 require (
 	github.com/celestiaorg/go-header v0.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/rollkit/rollkit
 
-go 1.21
-
-toolchain go1.21.3
+go 1.20
 
 require (
 	github.com/celestiaorg/go-header v0.4.0

--- a/proto/gen.sh
+++ b/proto/gen.sh
@@ -7,8 +7,7 @@ TARGET_DIR=./types/pb
 cd $SCRIPT_DIR
 mkdir -p $TARGET_DIR
 rm -rf $TARGET_DIR/*
-docker run -v $PWD:/workspace --workdir /workspace tendermintdev/docker-build-proto sh ./proto/protoc.sh
+docker run -u $UID:$(id -g) -e XDG_CACHE_HOME=/tmp/.cache -v $PWD:/workspace --workdir /workspace tendermintdev/docker-build-proto sh ./proto/protoc.sh
 
-cp -r ./proto/pb/* $TARGET_DIR/
 
 rm -rf $TARGET_DIR/tendermint


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Currently, docker is executed with default privileges (as root), which makes it hard to deal with files generated by `make proto-gen`. As a workaround, files are copied to a new directory (to get correct access rights), and the original directory is a part of .gitignore.

The solution consists of three improvements:
 - -u flag added to docker command to run as the current user
 - XDG_CHACHE_HOME modified, to mitigate access permissions (it's picked up by buf process inside container)
 - buf output directory is set properly, so there is no need for copying


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

### Summary by CodeRabbit

- Chore: Updated the script used for generating protocol buffers. The changes ensure that the script runs in a more secure and efficient manner by using the current user's UID and GID, and by setting the cache directory to a temporary location. This will help in maintaining the cleanliness of the project directory and improve the overall development experience. Please note that the copying of protocol buffer files to the target directory has been removed, so you may need to adjust your workflow accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->