### PR TITLE
Rename NewDefaultInMemoryKVStore to NewDefaultTestKVStore across the repo

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -36,10 +36,10 @@ func TestInitialState(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	es, _ := store.NewDefaultInMemoryKVStore()
+	es, _ := store.NewDefaultTestKVStore()
 	emptyStore := store.New(ctx, es)
 
-	es2, _ := store.NewDefaultInMemoryKVStore()
+	es2, _ := store.NewDefaultTestKVStore()
 	fullStore := store.New(ctx, es2)
 	err := fullStore.UpdateState(sampleState)
 	require.NoError(t, err)

--- a/da/celestia/mock/server.go
+++ b/da/celestia/mock/server.go
@@ -68,7 +68,7 @@ func NewServer(blockTime time.Duration, logger log.Logger) *Server {
 
 // Start starts HTTP server with given listener.
 func (s *Server) Start() (string, error) {
-	kvStore, err := store.NewDefaultInMemoryKVStore()
+	kvStore, err := store.NewDefaultTestKVStore()
 	if err != nil {
 		return "", err
 	}

--- a/da/test/da_test.go
+++ b/da/test/da_test.go
@@ -103,7 +103,7 @@ func startMockGRPCServ() *grpc.Server {
 	conf := grpcda.DefaultConfig
 	logger := cmlog.NewTMLogger(os.Stdout)
 
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	srv := mockserv.GetServer(kvStore, conf, []byte(mockDaBlockTime.String()), logger)
 	lis, err := net.Listen("tcp", conf.Host+":"+strconv.Itoa(conf.Port))
 	if err != nil {
@@ -141,7 +141,7 @@ func doTestRetrieve(t *testing.T, dalc da.DataAvailabilityLayerClient) {
 	if _, ok := dalc.(*celestia.DataAvailabilityLayerClient); ok {
 		conf, _ = json.Marshal(testConfig)
 	}
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	err := dalc.Init(testNamespaceID, conf, kvStore, test.NewFileLoggerCustom(t, test.TempLogFileName(t, "dalc")))
 	require.NoError(err)
 

--- a/node/full.go
+++ b/node/full.go
@@ -194,7 +194,7 @@ func initEventBus(logger log.Logger) (*cmtypes.EventBus, error) {
 func initBaseKV(nodeConfig config.NodeConfig, logger log.Logger) (ds.TxnDatastore, error) {
 	if nodeConfig.RootDir == "" && nodeConfig.DBPath == "" { // this is used for testing
 		logger.Info("WARNING: working in in-memory mode")
-		return store.NewDefaultInMemoryKVStore()
+		return store.NewDefaultTestKVStore()
 	}
 	return store.NewDefaultKVStore(nodeConfig.RootDir, nodeConfig.DBPath, "rollkit")
 }

--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -769,7 +769,7 @@ func createGenesisValidators(t *testing.T, numNodes int, appCreator func(require
 	}
 
 	dalc := &mockda.DataAvailabilityLayerClient{}
-	ds, err := store.NewDefaultInMemoryKVStore()
+	ds, err := store.NewDefaultTestKVStore()
 	require.Nil(err)
 	err = dalc.Init([8]byte{}, nil, ds, log.TestingLogger())
 	require.Nil(err)

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -378,7 +378,7 @@ func testSingleAggregatorSingleFullNodeSingleLightNode(t *testing.T) {
 		keys[i], _, _ = crypto.GenerateEd25519Key(rand.Reader)
 	}
 	dalc := &mockda.DataAvailabilityLayerClient{}
-	ds, _ := store.NewDefaultInMemoryKVStore()
+	ds, _ := store.NewDefaultTestKVStore()
 	_ = dalc.Init([8]byte{}, nil, ds, log.TestingLogger())
 	_ = dalc.Start()
 	defer func() {
@@ -497,7 +497,7 @@ func createNodes(aggCtx, ctx context.Context, num int, bmConfig config.BlockMana
 	nodes := make([]*FullNode, num)
 	apps := make([]*mocks.Application, num)
 	dalc := &mockda.DataAvailabilityLayerClient{}
-	ds, _ := store.NewDefaultInMemoryKVStore()
+	ds, _ := store.NewDefaultTestKVStore()
 	_ = dalc.Init([8]byte{}, nil, ds, test.NewFileLoggerCustom(t, test.TempLogFileName(t, "dalc")))
 	_ = dalc.Start()
 	node, app := createNode(aggCtx, 0, true, false, keys, bmConfig, t)

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -29,7 +29,7 @@ func TestGetNodeHeight(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	dalc := &mockda.DataAvailabilityLayerClient{}
-	ds, _ := store.NewDefaultInMemoryKVStore()
+	ds, _ := store.NewDefaultTestKVStore()
 	_ = dalc.Init([8]byte{}, nil, ds, log.TestingLogger())
 	_ = dalc.Start()
 	defer func() {

--- a/node/light.go
+++ b/node/light.go
@@ -87,7 +87,7 @@ func newLightNode(
 func openDatastore(conf config.NodeConfig, logger log.Logger) (ds.TxnDatastore, error) {
 	if conf.RootDir == "" && conf.DBPath == "" { // this is used for testing
 		logger.Info("WARNING: working in in-memory mode")
-		return store.NewDefaultInMemoryKVStore()
+		return store.NewDefaultTestKVStore()
 	}
 	return store.NewDefaultKVStore(conf.RootDir, conf.DBPath, "rollkit-light")
 }

--- a/state/indexer/block/kv/kv_test.go
+++ b/state/indexer/block/kv/kv_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestBlockIndexer(t *testing.T) {
-	kvStore, err := store.NewDefaultInMemoryKVStore()
+	kvStore, err := store.NewDefaultTestKVStore()
 	require.NoError(t, err)
 	prefixStore := (ktds.Wrap(kvStore, ktds.PrefixTransform{Prefix: ds.NewKey("block_events")}).Children()[0]).(ds.TxnDatastore)
 	indexer := blockidxkv.New(context.Background(), prefixStore)

--- a/state/txindex/indexer_service_test.go
+++ b/state/txindex/indexer_service_test.go
@@ -31,7 +31,7 @@ func TestIndexerServiceIndexesBlocks(t *testing.T) {
 	})
 
 	// tx indexer
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	txIndexer := kv.NewTxIndex(context.Background(), kvStore)
 	prefixStore := (ktds.Wrap(kvStore, ktds.PrefixTransform{Prefix: ds.NewKey("block_events")}).Children()[0]).(ds.TxnDatastore)
 	blockIndexer := blockidxkv.New(context.Background(), prefixStore)

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestTxIndex(t *testing.T) {
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	indexer := NewTxIndex(context.Background(), kvStore)
 
 	tx := types.Tx("HELLO WORLD")
@@ -70,7 +70,7 @@ func TestTxIndex(t *testing.T) {
 }
 
 func TestTxSearch(t *testing.T) {
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	indexer := NewTxIndex(context.Background(), kvStore)
 
 	txResult := txResultWithEvents([]abci.Event{
@@ -145,7 +145,7 @@ func TestTxSearch(t *testing.T) {
 }
 
 func TestTxSearchWithCancelation(t *testing.T) {
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	indexer := NewTxIndex(context.Background(), kvStore)
 
 	txResult := txResultWithEvents([]abci.Event{
@@ -166,7 +166,7 @@ func TestTxSearchWithCancelation(t *testing.T) {
 func TestTxSearchDeprecatedIndexing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	indexer := NewTxIndex(ctx, kvStore)
 
 	// index tx using events indexing (composite key)
@@ -246,7 +246,7 @@ func TestTxSearchDeprecatedIndexing(t *testing.T) {
 }
 
 func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -270,7 +270,7 @@ func TestTxSearchOneTxWithMultipleSameTagsButDifferentValues(t *testing.T) {
 }
 
 func TestTxSearchMultipleTxs(t *testing.T) {
-	kvStore, _ := store.NewDefaultInMemoryKVStore()
+	kvStore, _ := store.NewDefaultTestKVStore()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	indexer := NewTxIndex(ctx, kvStore)

--- a/store/kv.go
+++ b/store/kv.go
@@ -14,8 +14,8 @@ import (
 	badger3 "github.com/ipfs/go-ds-badger3"
 )
 
-// NewDefaultInMemoryKVStore builds KVStore that works in-memory (without accessing disk).
-func NewDefaultInMemoryKVStore() (ds.TxnDatastore, error) {
+// NewDefaultTestKVStore builds KVStore that works in-memory (without accessing disk).
+func NewDefaultTestKVStore() (ds.TxnDatastore, error) {
 	inMemoryOptions := &badger3.Options{
 		GcDiscardRatio: 0.2,
 		GcInterval:     15 * time.Minute,

--- a/store/prefix_test.go
+++ b/store/prefix_test.go
@@ -18,7 +18,7 @@ func TestPrefixKV1(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	base, _ := NewDefaultInMemoryKVStore()
+	base, _ := NewDefaultTestKVStore()
 
 	p1 := ktds.Wrap(base, ktds.PrefixTransform{Prefix: ds.NewKey("1")})
 	p2 := ktds.Wrap(base, ktds.PrefixTransform{Prefix: ds.NewKey("2")})
@@ -85,7 +85,7 @@ func TestPrefixKVBatch(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	basekv, _ := NewDefaultInMemoryKVStore()
+	basekv, _ := NewDefaultTestKVStore()
 	prefixkv := ktds.Wrap(basekv, ktds.PrefixTransform{Prefix: ds.NewKey("prefix1")}).Children()[0]
 
 	badgerPrefixkv, _ := prefixkv.(ds.TxnDatastore)

--- a/store/store.md
+++ b/store/store.md
@@ -24,7 +24,7 @@ The Store interface defines the following methods:
 
 The `TxnDatastore` interface inside [go-datastore] is used for constructing different key-value stores for the underlying storage of a full node. The are two different implementations of `TxnDatastore` in [kv.go]:
 
-- `NewDefaultInMemoryKVStore`: Builds a key-value store that uses the [BadgerDB] library and operates in-memory, without accessing the disk. Used only across unit tests and integration tests.
+- `NewDefaultTestKVStore`: Builds a key-value store that uses the [BadgerDB] library and operates in-memory, without accessing the disk. Used only across unit tests and integration tests.
 
 - `NewDefaultKVStore`: Builds a key-value store that uses the [BadgerDB] library and stores the data on disk at the specified path.
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -44,7 +44,7 @@ func TestStoreHeight(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			assert := assert.New(t)
-			ds, _ := NewDefaultInMemoryKVStore()
+			ds, _ := NewDefaultTestKVStore()
 			bstore := New(ctx, ds)
 			assert.Equal(uint64(0), bstore.Height())
 
@@ -89,7 +89,7 @@ func TestStoreLoad(t *testing.T) {
 		}
 	}()
 
-	mKV, _ := NewDefaultInMemoryKVStore()
+	mKV, _ := NewDefaultTestKVStore()
 	dKV, _ := NewDefaultKVStore(tmpDir, "db", "test")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -135,7 +135,7 @@ func TestRestart(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	kv, _ := NewDefaultInMemoryKVStore()
+	kv, _ := NewDefaultTestKVStore()
 	s1 := New(ctx, kv)
 	expectedHeight := uint64(10)
 	err := s1.UpdateState(types.State{
@@ -159,7 +159,7 @@ func TestBlockResponses(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	kv, _ := NewDefaultInMemoryKVStore()
+	kv, _ := NewDefaultTestKVStore()
 	s := New(ctx, kv)
 
 	expected := &cmstate.ABCIResponses{


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Closes #1278

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- The key-value store used across various functions and tests has been switched from the default in-memory store to a new test-specific store. This change enhances the testing environment and does not affect the end-user experience.

Tests:
- Updated multiple test functions to use the new test-specific key-value store, improving the reliability of our testing suite.

Documentation:
- Updated function names in the `store` package documentation to reflect the new test-specific key-value store.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->