### PR TITLE
Bring txsToByteSlices to parity with byteSlicesToTxs

### DIFF
--- a/types/serialization.go
+++ b/types/serialization.go
@@ -307,6 +307,9 @@ func (s *State) FromProto(other *pb.State) error {
 }
 
 func txsToByteSlices(txs Txs) [][]byte {
+	if txs == nil {
+		return nil
+	}
 	bytes := make([][]byte, len(txs))
 	for i := range txs {
 		bytes[i] = txs[i]

--- a/types/serialization_test.go
+++ b/types/serialization_test.go
@@ -199,3 +199,51 @@ func TestStateRoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestTxsRoundtrip(t *testing.T) {
+	// Test the nil case
+	var txs Txs
+	byteSlices := txsToByteSlices(txs)
+	newTxs := byteSlicesToTxs(byteSlices)
+	assert.Nil(t, newTxs)
+
+	// Generate 100 random transactions and convert them to byte slices
+	txs = make(Txs, 100)
+	for i := range txs {
+		txs[i] = []byte{byte(i)}
+	}
+	byteSlices = txsToByteSlices(txs)
+
+	// Convert the byte slices back to transactions
+	newTxs = byteSlicesToTxs(byteSlices)
+
+	// Check that the new transactions match the original transactions
+	assert.Equal(t, len(txs), len(newTxs))
+	for i := range txs {
+		assert.Equal(t, txs[i], newTxs[i])
+	}
+}
+
+func TestSignaturesRoundtrip(t *testing.T) {
+	// Test the nil case
+	var sigs []Signature
+	bytes := signaturesToByteSlices(sigs)
+	newSigs := byteSlicesToSignatures(bytes)
+	assert.Nil(t, newSigs)
+
+	// Generate 100 random signatures and convert them to byte slices
+	sigs = make([]Signature, 100)
+	for i := range sigs {
+		sigs[i] = []byte{byte(i)}
+	}
+	bytes = signaturesToByteSlices(sigs)
+
+	// Convert the byte slices back to signatures
+	newSigs = byteSlicesToSignatures(bytes)
+
+	// Check that the new signatures match the original signatures
+	assert.Equal(t, len(sigs), len(newSigs))
+	for i := range sigs {
+		assert.Equal(t, newSigs[i], sigs[i])
+	}
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Closes #1296
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

Bug Fixes:
- Enhanced stability by adding a safeguard in the `txsToByteSlices` function. This change prevents potential system errors when handling certain types of data, improving overall reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->