### PR TITLE
use a ci setup job to set a go-version 

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -24,15 +24,29 @@ on:
           - major
 
 jobs:
+  setup:
+    runs-on: ubuntu-latest
+    env:
+      # use consistent go version throughout pipeline here
+      GO_VERSION: "1.20"
+    outputs:
+      go-version: ${{ steps.set-vars.outputs.go-version }}
+    steps:
+      - name: Set go version
+        id: set-vars
+        run: echo "go-version=${{env.GO_VERSION}}" >> "$GITHUB_OUTPUT"
+
   lint:
+    needs: [setup]
     uses: ./.github/workflows/lint.yml
     with:
-      GO_VERSION: "1.20"
+      go-version: ${{ needs.setup.outputs.go-version }}
 
   test:
+    needs: [setup]
     uses: ./.github/workflows/test.yml
     with:
-      GO_VERSION: "1.20"
+      go-version: ${{ needs.setup.outputs.go-version }}
 
   proto:
     uses: ./.github/workflows/proto.yml

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,7 +4,7 @@ name: lint
 on:
   workflow_call:
     inputs:
-      GO_VERSION:
+      go-version:
         description: "Go version to use"
         type: string
         required: true
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ inputs.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
         # This steps sets the GIT_DIFF environment variable to true
         # if files defined in PATTERS changed
       - uses: technote-space/get-diff-action@v6.1.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ name: Tests / Code Coverage
 on:
   workflow_call:
     inputs:
-      GO_VERSION:
+      go-version:
         description: "Go version to use"
         type: string
         required: true
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v4
         with:
-          go-version: ${{ inputs.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
       - run: go mod tidy
       - name: check for diff
         run: git diff --exit-code
@@ -30,7 +30,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ inputs.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
       - name: Run unit test
         run: make test
       - name: upload coverage report
@@ -47,6 +47,6 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ inputs.GO_VERSION }}
+          go-version: ${{ inputs.go-version }}
       - name: Integration Tests
         run: echo "No integration tests yet"


### PR DESCRIPTION
Uses a setup job to set a go variable and store as an output to use throughout CI pipeline, using only one place to set the GO_VERSION and use output.go-version throughout.

Some degree of "should work" here, as we can't run locally.