### PR TITLE
Fix typos in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 DOCKER := $(shell which docker)
 DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bufbuild/buf
 
-# Define pkgs, run, and cover vairables for test so that we can override them in
+# Define pkgs, run, and cover variables for test so that we can override them in
 # the terminal more easily.
 pkgs := $(shell go list ./...)
 run := .

--- a/block/header-sync.md
+++ b/block/header-sync.md
@@ -14,7 +14,7 @@ The nodes in the P2P network sync headers using the header sync service that imp
 
 ## Details
 
-All three types of nodes (sequencer, full, and light) run the header sync service to maintain the cannonical view of the rollup chain (with respect to the P2P network).
+All three types of nodes (sequencer, full, and light) run the header sync service to maintain the canonical view of the rollup chain (with respect to the P2P network).
 
 The header sync service inherits the `ConnectionGater` from the node's P2P client which enables blocking and allowing peers as needed by specifying the `P2PConfig.BlockedPeers` and `P2PConfig.AllowedPeers`.
 

--- a/specs/lazy-adr/adr-009-state-fraud-proofs.md
+++ b/specs/lazy-adr/adr-009-state-fraud-proofs.md
@@ -136,7 +136,7 @@ The `GenerateFraudProof` method in the Cosmos SDK app receives this list of stat
 
 // Represents a single-round state fraudProof
 message FraudProof {
-  // The block height during which the fraudulent state transition occured
+  // The block height during which the fraudulent state transition occurred
   uint64 block_height = 1;
   // Intermediate State Root right before the fraudulent state transition
   bytes pre_state_app_hash = 2;

--- a/state/block-executor.md
+++ b/state/block-executor.md
@@ -47,7 +47,7 @@ The `BlockExecutor` is initialized with a proposer address, `namespace ID`, `cha
 - `Commit`: This method commits the block and updates the mempool. Given the updated state, the block, and the ABCI `ResponseFinalizeBlock` as parameters, it:
   - Invokes app commit, basically finalizing the last execution, by  calling ABCI `Commit`.
   - Updates the mempool to inform that the transactions included in the block can be safely discarded.
-  - Publishes the events produced during the block exection for indexing.
+  - Publishes the events produced during the block execution for indexing.
 
 - `updateState`: This method updates the state. Given the current state, the block, the ABCI `ResponseFinalizeBlock` and the validator updates, it validates the updated validator set, updates the state by applying the block and returns the updated state and errors, if any. The state consists of:
   - Version
@@ -99,7 +99,7 @@ The `BlockExecutor` assumes that there is consensus connection available to the 
   - pre-condition:
     - block has been applied
   - post-condition:
-    - block is commited
+    - block is committed
     - mempool is cleared of block transactions
     - block events are published
     - state App Hash is updated with the result from `ResponseCommit`


### PR DESCRIPTION
Fix typos in docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Documentation:
- Corrected typographical errors in various files to improve readability and understanding. Changes include spelling corrections in the Makefile, block/header-sync.md, specs/lazy-adr/adr-009-state-fraud-proofs.md, and state/block-executor.md. These changes do not impact the functionality of the system but enhance the clarity of the documentation and code comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->