### PR TITLE
test: fix genesis validator set helper

### DIFF
--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -482,7 +482,7 @@ func TestTx(t *testing.T) {
 	mockApp := &mocks.Application{}
 	mockApp.On(InitChain, mock.Anything).Return(abci.ResponseInitChain{})
 	key, _, _ := crypto.GenerateEd25519Key(crand.Reader)
-	genesisValidators, signingKey := getGenesisValidatorSetWithSigner(1)
+	genesisValidators, signingKey := getGenesisValidatorSetWithSigner()
 	node, err := newFullNode(context.Background(), config.NodeConfig{
 		DALayer:    "mock",
 		Aggregator: true,
@@ -1115,7 +1115,7 @@ func TestFutureGenesisTime(t *testing.T) {
 	mockApp.On(DeliverTx, mock.Anything).Return(abci.ResponseDeliverTx{})
 	mockApp.On(CheckTx, mock.Anything).Return(abci.ResponseCheckTx{})
 	key, _, _ := crypto.GenerateEd25519Key(crand.Reader)
-	genesisValidators, signingKey := getGenesisValidatorSetWithSigner(1)
+	genesisValidators, signingKey := getGenesisValidatorSetWithSigner()
 	genesisTime := time.Now().Local().Add(time.Second * time.Duration(1))
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -45,7 +45,7 @@ func TestAggregatorMode(t *testing.T) {
 	app.On(Commit, mock.Anything).Return(abci.ResponseCommit{})
 
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	genesisValidators, signingKey := getGenesisValidatorSetWithSigner(1)
+	genesisValidators, signingKey := getGenesisValidatorSetWithSigner()
 	blockManagerConfig := config.BlockManagerConfig{
 		BlockTime:   1 * time.Second,
 		NamespaceID: types.NamespaceID{1, 2, 3, 4, 5, 6, 7, 8},
@@ -141,7 +141,7 @@ func TestLazyAggregator(t *testing.T) {
 	app.On(Commit, mock.Anything).Return(abci.ResponseCommit{})
 
 	key, _, _ := crypto.GenerateEd25519Key(rand.Reader)
-	genesisValidators, signingKey := getGenesisValidatorSetWithSigner(1)
+	genesisValidators, signingKey := getGenesisValidatorSetWithSigner()
 	blockManagerConfig := config.BlockManagerConfig{
 		// After the genesis header is published, the syncer is started
 		// which takes little longer (due to initialization) and the syncer
@@ -548,7 +548,7 @@ func createNode(ctx context.Context, n int, aggregator bool, isLight bool, keys 
 		ctx = context.Background()
 	}
 
-	genesisValidators, signingKey := getGenesisValidatorSetWithSigner(1)
+	genesisValidators, signingKey := getGenesisValidatorSetWithSigner()
 	genesis := &cmtypes.GenesisDoc{ChainID: "test", Validators: genesisValidators}
 	// TODO: need to investigate why this needs to be done for light nodes
 	genesis.InitialHeight = 1

--- a/node/test_helpers.go
+++ b/node/test_helpers.go
@@ -128,7 +128,7 @@ func getGenesisValidatorSetWithSigner() ([]cmtypes.GenesisValidator, crypto.Priv
 		Address: pubKey.Address(),
 		PubKey:  pubKey,
 		Power:   int64(100),
-		Name:    fmt.Sprintf("gen #1"),
+		Name:    "gen #1",
 	}}
 	return genesisValidators, signingKey
 }

--- a/node/test_helpers.go
+++ b/node/test_helpers.go
@@ -117,7 +117,6 @@ func waitForAtLeastNBlocks(node Node, n int, source Source) error {
 	})
 }
 
-// TODO: use n and return n validators
 func getGenesisValidatorSetWithSigner(n int) ([]cmtypes.GenesisValidator, crypto.PrivKey) {
 	nodeKey := &p2p.NodeKey{
 		PrivKey: genesisValidatorKey,
@@ -125,8 +124,14 @@ func getGenesisValidatorSetWithSigner(n int) ([]cmtypes.GenesisValidator, crypto
 	signingKey, _ := GetNodeKey(nodeKey)
 	pubKey := genesisValidatorKey.PubKey()
 
-	genesisValidators := []cmtypes.GenesisValidator{
-		{Address: pubKey.Address(), PubKey: pubKey, Power: int64(100), Name: "gen #1"},
+	genesisValidators := make([]cmtypes.GenesisValidator, n)
+	for i := 0; i < n; i++ {
+		genesisValidators[i] = cmtypes.GenesisValidator{
+			Address: pubKey.Address(),
+			PubKey:  pubKey,
+			Power:   int64(100),
+			Name:    fmt.Sprintf("gen #%d", i+1),
+		}
 	}
 	return genesisValidators, signingKey
 }

--- a/node/test_helpers.go
+++ b/node/test_helpers.go
@@ -117,21 +117,18 @@ func waitForAtLeastNBlocks(node Node, n int, source Source) error {
 	})
 }
 
-func getGenesisValidatorSetWithSigner(n int) ([]cmtypes.GenesisValidator, crypto.PrivKey) {
+func getGenesisValidatorSetWithSigner() ([]cmtypes.GenesisValidator, crypto.PrivKey) {
 	nodeKey := &p2p.NodeKey{
 		PrivKey: genesisValidatorKey,
 	}
 	signingKey, _ := GetNodeKey(nodeKey)
 	pubKey := genesisValidatorKey.PubKey()
 
-	genesisValidators := make([]cmtypes.GenesisValidator, n)
-	for i := 0; i < n; i++ {
-		genesisValidators[i] = cmtypes.GenesisValidator{
-			Address: pubKey.Address(),
-			PubKey:  pubKey,
-			Power:   int64(100),
-			Name:    fmt.Sprintf("gen #%d", i+1),
-		}
-	}
+	genesisValidators := []cmtypes.GenesisValidator{{
+		Address: pubKey.Address(),
+		PubKey:  pubKey,
+		Power:   int64(100),
+		Name:    fmt.Sprintf("gen #1"),
+	}}
 	return genesisValidators, signingKey
 }


### PR DESCRIPTION
## Overview

This PR removes a `TODO` in the test helper `getGenesisValidatorSetWithSigner`. This helper should only ever called with `n=1`. The validator set and key are structs, so they can't be `consts`.

Closes: #860 

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the genesis validator generation process to support multiple validators.
- **Tests**
	- Adjusted test functions to accommodate the updated genesis validator generation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->