### PR TITLE
ci: ignore third_party directory for tests and linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@ DOCKER_BUF := $(DOCKER) run --rm -v $(CURDIR):/workspace --workdir /workspace bu
 
 # Define pkgs, run, and cover variables for test so that we can override them in
 # the terminal more easily.
-pkgs := $(shell go list ./...)
+
+# IGNORE_DIRS is a list of directories to ignore when running tests and linters.
+# This list is space separated.
+IGNORE_DIRS ?= third_party
+pkgs := $(shell go list ./... | grep -vE "$(IGNORE_DIRS)")
 run := .
 count := 1
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Since the `third_party` directory is just copy pasted code from other repos, primarily to avoid circular dependencies, we can ignore it in the testing and coverage reports since we don't want to make any changes here. All changes should be upstreamed and then re-copied in. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced an option to ignore specific directories during testing and linting for more flexible configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->