### PR TITLE
ci: handle shutdown in p2p client peer connect

### DIFF
--- a/p2p/client.go
+++ b/p2p/client.go
@@ -343,7 +343,7 @@ func (c *Client) findPeers(ctx context.Context) error {
 // tryConnect attempts to connect to a peer and logs error if necessary
 func (c *Client) tryConnect(ctx context.Context, peer peer.AddrInfo) {
 	err := c.host.Connect(ctx, peer)
-	if err != nil {
+	if err != nil && ctx.Err() == nil {
 		c.logger.Error("failed to connect to peer", "peer", peer, "error", err)
 	}
 }


### PR DESCRIPTION

## Overview
This should fix one of the file closed panics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling in peer-to-peer connection attempts to prevent logging connection failures when the context error is nil.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->