### PR TITLE
Stop indexer service in full node OnStop method

### DIFF
--- a/node/full.go
+++ b/node/full.go
@@ -362,6 +362,7 @@ func (n *FullNode) OnStop() {
 	err = multierr.Append(err, n.p2pClient.Close())
 	err = multierr.Append(err, n.hSyncService.Stop())
 	err = multierr.Append(err, n.bSyncService.Stop())
+	err = multierr.Append(err, n.IndexerService.Stop())
 	n.Logger.Error("errors while stopping node:", "errors", err)
 }
 

--- a/state/indexer-service.md
+++ b/state/indexer-service.md
@@ -6,7 +6,7 @@ The Indexer service indexes transactions and blocks using events emitted by the 
 
 ## Protocol/Component Description
 
-The Indexer service consists of three main components: an event bus, a transaction indexer and a block indexer.
+The Indexer service is started and stopped along with a Full Node. It consists of three main components: an event bus, a transaction indexer and a block indexer.
 
 ### Event Bus
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Closes: #1352

Fixes write to file after node stopped panics that were leading to flaky failing CI tests.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Ensured that the Indexer Service properly stops when the Full Node is stopped, improving resource management and stability.

- **Documentation**
	- Updated the documentation to reflect the change in lifecycle management of the Indexer Service in relation to the Full Node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->