### PR TITLE
only remove successfully submitted blocks from the pending blocks instead of reset

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -734,11 +734,14 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 func (m *Manager) submitBlocksToDA(ctx context.Context) error {
 	submitted := false
 	backoff := initialBackoff
+	submittedBlocks := make([]*types.Block, 0)
 	for attempt := 1; ctx.Err() == nil && !submitted && attempt <= maxSubmitAttempts; attempt++ {
-		res := m.dalc.SubmitBlocks(ctx, m.pendingBlocks.getPendingBlocks())
+		blocks := m.pendingBlocks.getPendingBlocks()
+		res := m.dalc.SubmitBlocks(ctx, blocks)
 		if res.Code == da.StatusSuccess {
 			m.logger.Info("successfully submitted Rollkit block to DA layer", "daHeight", res.DAHeight)
 			submitted = true
+			submittedBlocks = append(submittedBlocks, blocks...)
 		} else {
 			m.logger.Error("DA layer submission failed", "error", res.Message, "attempt", attempt)
 			time.Sleep(backoff)
@@ -749,7 +752,7 @@ func (m *Manager) submitBlocksToDA(ctx context.Context) error {
 	if !submitted {
 		return fmt.Errorf("failed to submit block to DA layer after %d attempts", maxSubmitAttempts)
 	}
-	m.pendingBlocks.resetPendingBlocks()
+	m.pendingBlocks.removeSubmittedBlocks(submittedBlocks)
 	return nil
 }
 

--- a/block/pending_blocks.go
+++ b/block/pending_blocks.go
@@ -35,8 +35,9 @@ func (pb *PendingBlocks) getPendingBlocks() []*types.Block {
 }
 
 func (pb *PendingBlocks) isEmpty() bool {
-	pendingBlocks := pb.getPendingBlocks()
-	return len(pendingBlocks) == 0
+	pb.mtx.RLock()
+	defer pb.mtx.RUnlock()
+	return len(pb.pendingBlocks) == 0
 }
 
 func (pb *PendingBlocks) addPendingBlock(block *types.Block) {

--- a/block/pending_blocks.go
+++ b/block/pending_blocks.go
@@ -24,7 +24,7 @@ func NewPendingBlocks() *PendingBlocks {
 func (pb *PendingBlocks) getPendingBlocks() []*types.Block {
 	pb.mtx.RLock()
 	defer pb.mtx.RUnlock()
-	blocks := make([]*types.Block, 0)
+	blocks := make([]*types.Block, 0, len(pb.pendingBlocks))
 	for _, block := range pb.pendingBlocks {
 		blocks = append(blocks, block)
 	}

--- a/block/pending_blocks.go
+++ b/block/pending_blocks.go
@@ -21,6 +21,8 @@ func NewPendingBlocks() *PendingBlocks {
 	}
 }
 
+// getPendingBlocks returns a sorted slice of pending blocks
+// that need to be published to DA layer in order of block height
 func (pb *PendingBlocks) getPendingBlocks() []*types.Block {
 	pb.mtx.RLock()
 	defer pb.mtx.RUnlock()

--- a/block/pending_blocks.go
+++ b/block/pending_blocks.go
@@ -1,6 +1,7 @@
 package block
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/rollkit/rollkit/types"
@@ -27,6 +28,9 @@ func (pb *PendingBlocks) getPendingBlocks() []*types.Block {
 	for _, block := range pb.pendingBlocks {
 		blocks = append(blocks, block)
 	}
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].Height() < blocks[j].Height()
+	})
 	return blocks
 }
 

--- a/block/pending_blocks_test.go
+++ b/block/pending_blocks_test.go
@@ -1,0 +1,32 @@
+package block
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/rollkit/rollkit/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPendingBlocks(t *testing.T) {
+	require := require.New(t)
+	pb := NewPendingBlocks()
+	for i := uint64(0); i < 5; i++ {
+		pb.addPendingBlock(types.GetRandomBlock(i, 0))
+	}
+	blocks := pb.getPendingBlocks()
+	require.True(sort.SliceIsSorted(blocks, func(i, j int) bool {
+		return blocks[i].Height() < blocks[j].Height()
+	}), true)
+}
+
+func TestRemoveSubmittedBlocks(t *testing.T) {
+	require := require.New(t)
+	pb := NewPendingBlocks()
+	for i := uint64(0); i < 5; i++ {
+		pb.addPendingBlock(types.GetRandomBlock(i, 0))
+	}
+	blocks := pb.getPendingBlocks()
+	pb.removeSubmittedBlocks(blocks)
+	require.True(pb.isEmpty())
+}

--- a/block/pending_blocks_test.go
+++ b/block/pending_blocks_test.go
@@ -18,7 +18,7 @@ func TestGetPendingBlocks(t *testing.T) {
 	blocks := pb.getPendingBlocks()
 	require.True(sort.SliceIsSorted(blocks, func(i, j int) bool {
 		return blocks[i].Height() < blocks[j].Height()
-	}), true)
+	}))
 }
 
 func TestRemoveSubmittedBlocks(t *testing.T) {
@@ -30,4 +30,45 @@ func TestRemoveSubmittedBlocks(t *testing.T) {
 	blocks := pb.getPendingBlocks()
 	pb.removeSubmittedBlocks(blocks)
 	require.True(pb.isEmpty())
+}
+
+func TestRemoveSubsetOfBlocks(t *testing.T) {
+	require := require.New(t)
+	pb := NewPendingBlocks()
+	for i := uint64(0); i < 5; i++ {
+		pb.addPendingBlock(types.GetRandomBlock(i, 0))
+	}
+	// Remove blocks with height 1 and 2
+	pb.removeSubmittedBlocks([]*types.Block{
+		types.GetRandomBlock(1, 0),
+		types.GetRandomBlock(2, 0),
+	})
+	remainingBlocks := pb.getPendingBlocks()
+	require.Len(remainingBlocks, 3, "There should be 3 blocks remaining")
+	for _, block := range remainingBlocks {
+		require.Contains([]uint64{0, 3, 4}, block.Height(), "Only blocks with height 0, 3, and 4 should remain")
+	}
+}
+
+func TestRemoveAllBlocksAndVerifyEmpty(t *testing.T) {
+	require := require.New(t)
+	pb := NewPendingBlocks()
+	for i := uint64(0); i < 5; i++ {
+		pb.addPendingBlock(types.GetRandomBlock(i, 0))
+	}
+	// Remove all blocks
+	pb.removeSubmittedBlocks(pb.getPendingBlocks())
+	require.True(pb.isEmpty(), "PendingBlocks should be empty after removing all blocks")
+}
+
+func TestRemoveBlocksFromEmptyPendingBlocks(t *testing.T) {
+	require := require.New(t)
+	pb := NewPendingBlocks()
+	// Attempt to remove blocks from an empty PendingBlocks
+	require.NotPanics(func() {
+		pb.removeSubmittedBlocks([]*types.Block{
+			types.GetRandomBlock(1, 0),
+			types.GetRandomBlock(2, 0),
+		})
+	}, "Removing blocks from an empty PendingBlocks should not cause a panic")
 }

--- a/block/pending_blocks_test.go
+++ b/block/pending_blocks_test.go
@@ -4,8 +4,9 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/rollkit/rollkit/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/rollkit/rollkit/types"
 )
 
 func TestGetPendingBlocks(t *testing.T) {

--- a/mempool/mempool.md
+++ b/mempool/mempool.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-The mempool module stores transactions which have not yet been included in a block, and provides an interface to check the validity of incoming transactions. It's defined by an interface [here](https://github.com/rollkit/rollkit/blob/main/mempool/mempool.go#L16), with an implementation [here](https://github.com/rollkit/rollkit/blob/main/mempool/v1/mempool.go).
+The mempool module stores transactions which have not yet been included in a block, and provides an interface to check the validity of incoming transactions. It's defined by an interface [here](https://github.com/rollkit/rollkit/blob/main/mempool/mempool.go#L16), with an implementation [here](https://github.com/rollkit/rollkit/blob/v0.10.x/mempool/v1/mempool.go).
 
 ## Component Description
 

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -356,6 +356,41 @@ func TestHeaderExchange(t *testing.T) {
 	t.Run("SingleAggregatorSingleFullNodeSingleLightNode", testSingleAggregatorSingleFullNodeSingleLightNode)
 }
 
+func TestSubmitBlocksToDA(t *testing.T) {
+	require := require.New(t)
+
+	clientNodes := 1
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	nodes, _ := createNodes(
+		ctx,
+		context.Background(),
+		clientNodes,
+		config.BlockManagerConfig{
+			DABlockTime: 20 * time.Millisecond,
+			BlockTime:   10 * time.Millisecond,
+		},
+		t,
+	)
+	seq := nodes[0]
+	require.NoError(seq.Start())
+	defer func() {
+		require.NoError(seq.Stop())
+	}()
+
+	timer := time.NewTimer(5 * seq.nodeConfig.DABlockTime)
+	<-timer.C
+
+	numberOfBlocksToSyncTill := seq.Store.Height()
+
+	//Make sure all produced blocks made it to DA
+	for i := uint64(1); i <= numberOfBlocksToSyncTill; i++ {
+		block, err := seq.Store.GetBlock(i)
+		require.NoError(err)
+		require.True(seq.blockManager.IsDAIncluded(block.Hash()), block.Height())
+	}
+}
+
 func testSingleAggregatorSingleFullNode(t *testing.T, source Source) {
 	require := require.New(t)
 


### PR DESCRIPTION
Fixes #1241 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Implemented a new system for managing and storing submitted blocks, enhancing the efficiency of block submission and retrieval.

- **Improvements**
  - Optimized the storage of pending blocks by transitioning from a list to a map structure, allowing for faster access and management.
  - Introduced a sorting mechanism for retrieving pending blocks, ensuring a consistent and ordered output.

- **Bug Fixes**
  - Fixed an issue where submitted blocks were not being correctly removed from the pending blocks list.

- **Tests**
  - Updated test cases to reflect the new logic for sorting and removing blocks, ensuring the reliability of these functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->