### PR TITLE
ci: update release flow to handle unique branch name and do patch releases on merge

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -85,13 +85,37 @@ jobs:
         id: set-outputs
         run: echo "has_release_label=${{ fromJSON(steps.get_pr_data.outputs.result).hasReleaseLabel }}" >> "$GITHUB_OUTPUT"
 
-  # Make a release if this is a manually trigger job, i.e. workflow_dispatch, or
-  # there was a merged pr with the create-release label
-  release:
-    needs: [lint, test, proto, get_merged_pr_labels]
+  # branch_name trims ref/heads/ from github.ref to access a clean branch name
+  branch_name:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.trim_ref.outputs.branch }}
+    steps:
+      - name: Trim branch name
+        id: trim_ref
+        run: |
+          echo "branch=$(${${{ github.ref }}:11})" >> $GITHUB_OUTPUT
+
+  # Make a release if this is a manually trigger job, i.e. workflow_dispatch
+  release-dispatch:
+    needs: [lint, test, proto, branch_name]
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    permissions: "write-all"
+    steps:
+      - uses: actions/checkout@v4
+      - name: Version Release
+        uses: rollkit/.github/.github/actions/version-release@v0.2.2
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          version-bump: ${{inputs.version}}
+          release-branch: ${{needs.branch_name.outputs.branch}}
+
+  # Make a release if there was a merged pr with the create-release label
+  release-merge:
+    needs: [lint, test, proto, get_merged_pr_labels, branch_name]
     runs-on: ubuntu-latest
     if: |
-      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'push' &&
       contains(github.ref, 'refs/heads/main') &&
       needs.get_merged_pr_labels.outputs.has_release_label)
@@ -102,4 +126,5 @@ jobs:
         uses: rollkit/.github/.github/actions/version-release@v0.2.2
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
-          version-bump: ${{inputs.version}}
+          version-bump: "patch"
+          release-branch: ${{needs.branch_name.outputs.branch}}


### PR DESCRIPTION


<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->
resolves #1362 

2 changes
1. Accept branch name so that release can be done on multiple branches.
2. separate out release steps since inputs doesn't exist on merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new workflow job to extract the clean branch name for release processes.

- **Refactor**
  - Streamlined release workflow by distributing the `release` job's responsibilities into `release-dispatch` and `release-merge` jobs.
  - Updated job dependencies to incorporate the new `branch_name` job.

- **Chores**
  - Adjusted permissions and conditions for workflow jobs to align with the new workflow structure.

- **Documentation**
  - Updated triage instructions to reflect the changes in the release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->