### PR TITLE
enforce InitialHeight == 1

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -23,8 +23,9 @@ func TestInitialState(t *testing.T) {
 	genesisValidators, _ := types.GetGenesisValidatorSetWithSigner()
 	genesis := &cmtypes.GenesisDoc{
 		ChainID:       "genesis id",
-		InitialHeight: 100,
+		InitialHeight: 1,
 		Validators:    genesisValidators,
+		AppState:      []byte("{'key':'value'}"),
 	}
 	sampleState := types.State{
 		ChainID:         "state id",

--- a/types/state.go
+++ b/types/state.go
@@ -60,9 +60,9 @@ func NewFromGenesisDoc(genDoc *types.GenesisDoc) (State, error) {
 		return State{}, fmt.Errorf("error in genesis doc: %w", err)
 	}
 
-	//if genDoc.InitialHeight != 1 {
-	//	return State{}, fmt.Errorf("genDoc InitialHeight must be 1")
-	//}
+	if genDoc.InitialHeight != 1 {
+		return State{}, fmt.Errorf("genDoc InitialHeight must be 1")
+	}
 
 	if len(genDoc.Validators) != 1 {
 		return State{}, fmt.Errorf("must have exactly 1 validator (the centralized sequencer)")

--- a/types/state.go
+++ b/types/state.go
@@ -60,6 +60,10 @@ func NewFromGenesisDoc(genDoc *types.GenesisDoc) (State, error) {
 		return State{}, fmt.Errorf("error in genesis doc: %w", err)
 	}
 
+	//if genDoc.InitialHeight != 1 {
+	//	return State{}, fmt.Errorf("genDoc InitialHeight must be 1")
+	//}
+
 	if len(genDoc.Validators) != 1 {
 		return State{}, fmt.Errorf("must have exactly 1 validator (the centralized sequencer)")
 	}


### PR DESCRIPTION
closes https://github.com/rollkit/rollkit/issues/1360



## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Enhanced testing for application initialization with new mock components.

- **Bug Fixes**
  - Ensured `NewFromGenesisDoc` function checks for valid `InitialHeight`, improving error handling and application stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->