### PR TITLE
TestTxGossipingAndAggregation fix

### DIFF
--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -182,14 +182,36 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 	for _, node := range nodes {
 		assert.NoError(node.Stop())
 	}
+
+	// Now that the nodes have stopped, it should be safe to access the mock
+	// calls outside of the mutex controlled methods.
+	//
+	// The reason we do this is because in the beginning of the test, we
+	// check that we have produced at least N blocks, which means we could
+	// have over produced. So when checking the calls, we also want to check
+	// that we called FinalizeBlock at least N times.
 	aggApp := apps[0]
 	apps = apps[1:]
 
-	aggApp.AssertNumberOfCalls(t, "FinalizeBlock", numBlocksToWaitFor)
+	checkCalls := func(app *mocks.Application, numBlocks int) error {
+		calls := app.Calls
+		numCalls := 0
+		for call := range calls {
+			if calls[call].Method == "FinalizeBlock" {
+				numCalls++
+			}
+		}
+		if numBlocks > numCalls {
+			return fmt.Errorf("expected at least %d calls to FinalizeBlock, got %d", numBlocks, numCalls)
+		}
+		return nil
+	}
+
+	require.NoError(checkCalls(aggApp, numBlocksToWaitFor))
 	aggApp.AssertExpectations(t)
 
 	for i, app := range apps {
-		app.AssertNumberOfCalls(t, "FinalizeBlock", numBlocksToWaitFor)
+		require.NoError(checkCalls(app, numBlocksToWaitFor))
 		app.AssertExpectations(t)
 
 		// assert that all blocks known to node are same as produced by aggregator

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -196,13 +196,13 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 	checkCalls := func(app *mocks.Application, numBlocks int) error {
 		calls := app.Calls
 		numCalls := 0
-		for call := range calls {
-			if calls[call].Method == "FinalizeBlock" {
+		for _, call := range calls {
+			if call.Method == "FinalizeBlock" {
 				numCalls++
 			}
 		}
 		if numBlocks > numCalls {
-			return fmt.Errorf("expected at least %d calls to FinalizeBlock, got %d", numBlocks, numCalls)
+			return fmt.Errorf("expected at least %d calls to FinalizeBlock, got %d calls", numBlocks, numCalls)
 		}
 		return nil
 	}

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -192,27 +192,6 @@ func TestTxGossipingAndAggregation(t *testing.T) {
 		app.AssertNumberOfCalls(t, "FinalizeBlock", numBlocksToWaitFor)
 		app.AssertExpectations(t)
 
-		// assert that we have most of the blocks from aggregator
-		beginCnt := 0
-		endCnt := 0
-		commitCnt := 0
-		// prepareProposal := 0
-		// processProposal := 0
-		for _, call := range app.Calls {
-			switch call.Method {
-			case "FinalizeBlock":
-				beginCnt++
-			case "CheckTx":
-				endCnt++
-			case "Commit":
-				commitCnt++
-				// case "PrepareProposal":
-				// 	prepareProposal++
-				// case "ProcessProposal":
-				// 	processProposal++
-			}
-		}
-
 		// assert that all blocks known to node are same as produced by aggregator
 		for h := uint64(1); h <= nodes[i].Store.Height(); h++ {
 			aggBlock, err := nodes[0].Store.GetBlock(h)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
This test was failing periodically due to `FinalizeBlock` being called too many times. The test verifies that at least N number of blocks were produced, which means that more than N number of blocks could have been produced which would lead to `FinalizeBlock` being called more than N times. 

This updates the test to check for `FinalizeBlock` being called at least N times as well to match the check for the blocks.

The other alternate fix would be to enforce that only N blocks were produced. I'm not sure if that is the preferred way to write the test or not. 

Unless we can control the block production by manually triggering a block to be produced, checking for at least N blocks an calls will be more robust. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved the test verification process by introducing a new function to streamline the checking of specific method calls during integration tests.

- **Chores**
	- Removed outdated commented code for cleaner and more maintainable codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->