### PR TITLE
chore: remove unnecessary conversions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,6 +21,7 @@ linters:
     - revive
     - staticcheck
     - typecheck
+    - unconvert
     - unused
 
 issues:

--- a/block/manager.go
+++ b/block/manager.go
@@ -337,7 +337,7 @@ func (m *Manager) SyncLoop(ctx context.Context, cancel context.CancelFunc) {
 			block := blockEvent.Block
 			daHeight := blockEvent.DAHeight
 			blockHash := block.Hash().String()
-			blockHeight := uint64(block.Height())
+			blockHeight := block.Height()
 			m.logger.Debug("block body retrieved",
 				"height", blockHeight,
 				"daHeight", daHeight,
@@ -398,7 +398,7 @@ func (m *Manager) trySyncNextBlock(ctx context.Context, daHeight uint64) error {
 			return nil
 		}
 
-		bHeight := uint64(b.Height())
+		bHeight := b.Height()
 		m.logger.Info("Syncing block", "height", bHeight)
 		// Validate the received block before applying
 		if err := m.executor.Validate(m.lastState, b); err != nil {
@@ -417,7 +417,7 @@ func (m *Manager) trySyncNextBlock(ctx context.Context, daHeight uint64) error {
 			return fmt.Errorf("failed to Commit: %w", err)
 		}
 
-		err = m.store.SaveBlockResponses(uint64(bHeight), responses)
+		err = m.store.SaveBlockResponses(bHeight, responses)
 		if err != nil {
 			return fmt.Errorf("failed to save block responses: %w", err)
 		}

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -62,8 +62,8 @@ func TestInitialState(t *testing.T) {
 			name:                    "state_in_store",
 			store:                   fullStore,
 			genesis:                 genesis,
-			expectedInitialHeight:   uint64(sampleState.InitialHeight),
-			expectedLastBlockHeight: uint64(sampleState.LastBlockHeight),
+			expectedInitialHeight:   sampleState.InitialHeight,
+			expectedLastBlockHeight: sampleState.LastBlockHeight,
 			expectedChainID:         sampleState.ChainID,
 		},
 	}

--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -869,12 +869,12 @@ func TestStatus(t *testing.T) {
 
 	earliestBlock := getRandomBlockWithProposer(1, 1, pubKey.Bytes())
 	err = rpc.node.Store.SaveBlock(earliestBlock, &types.Commit{})
-	rpc.node.Store.SetHeight(uint64(earliestBlock.Height()))
+	rpc.node.Store.SetHeight(earliestBlock.Height())
 	require.NoError(err)
 
 	latestBlock := getRandomBlockWithProposer(2, 1, pubKey.Bytes())
 	err = rpc.node.Store.SaveBlock(latestBlock, &types.Commit{})
-	rpc.node.Store.SetHeight(uint64(latestBlock.Height()))
+	rpc.node.Store.SetHeight(latestBlock.Height())
 	require.NoError(err)
 
 	err = node.Start()

--- a/rpc/json/handler.go
+++ b/rpc/json/handler.go
@@ -187,7 +187,7 @@ func (h *handler) encodeAndWriteResponse(w http.ResponseWriter, result interface
 	} else {
 		bytes, err := cmjson.Marshal(result)
 		if err != nil {
-			resp.Error = &json2.Error{Code: json2.ErrorCode(json2.E_INTERNAL), Data: err.Error()}
+			resp.Error = &json2.Error{Code: json2.E_INTERNAL, Data: err.Error()}
 		} else {
 			resp.Result = bytes
 		}

--- a/store/store.go
+++ b/store/store.go
@@ -77,7 +77,7 @@ func (s *DefaultStore) SaveBlock(block *types.Block, commit *types.Commit) error
 
 	err = multierr.Append(err, bb.Put(s.ctx, ds.NewKey(getBlockKey(hash)), blockBlob))
 	err = multierr.Append(err, bb.Put(s.ctx, ds.NewKey(getCommitKey(hash)), commitBlob))
-	err = multierr.Append(err, bb.Put(s.ctx, ds.NewKey(getIndexKey(uint64(block.Height()))), hash[:]))
+	err = multierr.Append(err, bb.Put(s.ctx, ds.NewKey(getIndexKey(block.Height())), hash[:]))
 
 	if err != nil {
 		bb.Discard(s.ctx)
@@ -192,7 +192,7 @@ func (s *DefaultStore) GetState() (types.State, error) {
 
 	var state types.State
 	err = state.FromProto(&pbState)
-	atomic.StoreUint64(&s.height, uint64(state.LastBlockHeight))
+	atomic.StoreUint64(&s.height, state.LastBlockHeight)
 	return state, err
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -49,7 +49,7 @@ func TestStoreHeight(t *testing.T) {
 
 			for _, block := range c.blocks {
 				err := bstore.SaveBlock(block, &types.Commit{})
-				bstore.SetHeight(uint64(block.Height()))
+				bstore.SetHeight(block.Height())
 				assert.NoError(err)
 			}
 
@@ -111,12 +111,12 @@ func TestStoreLoad(t *testing.T) {
 				}
 
 				for _, expected := range c.blocks {
-					block, err := bstore.GetBlock(uint64(expected.Height()))
+					block, err := bstore.GetBlock(expected.Height())
 					assert.NoError(err)
 					assert.NotNil(block)
 					assert.Equal(expected, block)
 
-					commit, err := bstore.GetCommit(uint64(expected.Height()))
+					commit, err := bstore.GetCommit(expected.Height())
 					assert.NoError(err)
 					assert.NotNil(commit)
 				}


### PR DESCRIPTION
Use linter to detect unnecessary type conversions
https://github.com/mdempsky/unconvert

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated a new linter to enhance code quality checks.

- **Refactor**
  - Simplified variable declarations and method calls by removing unnecessary type conversions.
  
- **Bug Fixes**
  - Improved error handling in JSON-RPC responses by correcting type casting.
  
- **Tests**
  - Updated test cases to align with the refactor of type conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->