### PR TITLE
build(deps): bump go-da to v0.2.0

### DIFF
--- a/da/da.go
+++ b/da/da.go
@@ -75,7 +75,7 @@ type DAClient struct {
 func (dac *DAClient) SubmitBlocks(ctx context.Context, blocks []*types.Block) ResultSubmitBlocks {
 	var blobs [][]byte
 	var blobSize uint64
-	maxBlobSize, err := dac.DA.MaxBlobSize()
+	maxBlobSize, err := dac.DA.MaxBlobSize(ctx)
 	if err != nil {
 		return ResultSubmitBlocks{
 			BaseResult: BaseResult{
@@ -111,7 +111,7 @@ func (dac *DAClient) SubmitBlocks(ctx context.Context, blocks []*types.Block) Re
 			},
 		}
 	}
-	ids, _, err := dac.DA.Submit(blobs, dac.GasPrice)
+	ids, _, err := dac.DA.Submit(ctx, blobs, dac.GasPrice)
 	if err != nil {
 		return ResultSubmitBlocks{
 			BaseResult: BaseResult{
@@ -141,7 +141,7 @@ func (dac *DAClient) SubmitBlocks(ctx context.Context, blocks []*types.Block) Re
 
 // RetrieveBlocks retrieves blocks from DA.
 func (dac *DAClient) RetrieveBlocks(ctx context.Context, dataLayerHeight uint64) ResultRetrieveBlocks {
-	ids, err := dac.DA.GetIDs(dataLayerHeight)
+	ids, err := dac.DA.GetIDs(ctx, dataLayerHeight)
 	if err != nil {
 		return ResultRetrieveBlocks{
 			BaseResult: BaseResult{
@@ -161,7 +161,7 @@ func (dac *DAClient) RetrieveBlocks(ctx context.Context, dataLayerHeight uint64)
 		}
 	}
 
-	blobs, err := dac.DA.Get(ids)
+	blobs, err := dac.DA.Get(ctx, ids)
 	if err != nil {
 		return ResultRetrieveBlocks{
 			BaseResult: BaseResult{

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -45,32 +45,32 @@ type MockDA struct {
 	mock.Mock
 }
 
-func (m *MockDA) MaxBlobSize() (uint64, error) {
+func (m *MockDA) MaxBlobSize(ctx context.Context) (uint64, error) {
 	args := m.Called()
 	return args.Get(0).(uint64), args.Error(1)
 }
 
-func (m *MockDA) Get(ids []da.ID) ([]da.Blob, error) {
+func (m *MockDA) Get(ctx context.Context, ids []da.ID) ([]da.Blob, error) {
 	args := m.Called(ids)
 	return args.Get(0).([]da.Blob), args.Error(1)
 }
 
-func (m *MockDA) GetIDs(height uint64) ([]da.ID, error) {
+func (m *MockDA) GetIDs(ctx context.Context, height uint64) ([]da.ID, error) {
 	args := m.Called(height)
 	return args.Get(0).([]da.ID), args.Error(1)
 }
 
-func (m *MockDA) Commit(blobs []da.Blob) ([]da.Commitment, error) {
+func (m *MockDA) Commit(ctx context.Context, blobs []da.Blob) ([]da.Commitment, error) {
 	args := m.Called(blobs)
 	return args.Get(0).([]da.Commitment), args.Error(1)
 }
 
-func (m *MockDA) Submit(blobs []da.Blob, gasPrice float64) ([]da.ID, []da.Proof, error) {
+func (m *MockDA) Submit(ctx context.Context, blobs []da.Blob, gasPrice float64) ([]da.ID, []da.Proof, error) {
 	args := m.Called(blobs, gasPrice)
 	return args.Get(0).([]da.ID), args.Get(1).([]da.Proof), args.Error(2)
 }
 
-func (m *MockDA) Validate(ids []da.ID, proofs []da.Proof) ([]bool, error) {
+func (m *MockDA) Validate(ctx context.Context, ids []da.ID, proofs []da.Proof) ([]bool, error) {
 	args := m.Called(ids, proofs)
 	return args.Get(0).([]bool), args.Error(1)
 }
@@ -218,7 +218,7 @@ func doTestSubmitOversizedBlock(t *testing.T, dalc *DAClient) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	limit, err := dalc.DA.MaxBlobSize()
+	limit, err := dalc.DA.MaxBlobSize(ctx)
 	require.NoError(err)
 	oversizedBlock := types.GetRandomBlock(1, int(limit))
 	resp := dalc.SubmitBlocks(ctx, []*types.Block{oversizedBlock})
@@ -246,7 +246,7 @@ func doTestSubmitLargeBlocksOverflow(t *testing.T, dalc *DAClient) {
 	require := require.New(t)
 	assert := assert.New(t)
 
-	limit, err := dalc.DA.MaxBlobSize()
+	limit, err := dalc.DA.MaxBlobSize(ctx)
 	require.NoError(err)
 
 	// two large blocks, over blob limit to force partial submit

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.12.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.18.0
-	github.com/rollkit/go-da v0.1.0
+	github.com/rollkit/go-da v0.2.0
 	github.com/rs/cors v1.10.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.18.2

--- a/go.sum
+++ b/go.sum
@@ -1350,8 +1350,8 @@ github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTE
 github.com/rogpeppe/go-internal v1.8.1/go.mod h1:JeRgkft04UBgHMgCIwADu4Pn6Mtm5d4nPKWu0nJ5d+o=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/rollkit/go-da v0.1.0 h1:FAEMTNF8mTsPuiUgYt2dQSMzw8iYPjiWq7692CS2mbY=
-github.com/rollkit/go-da v0.1.0/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
+github.com/rollkit/go-da v0.2.0 h1:rNpWBa2inczgZ955ky3wy8FbrMajzVbm0UfbBGzm5UE=
+github.com/rollkit/go-da v0.2.0/go.mod h1:Kef0XI5ecEKd3TXzI8S+9knAUJnZg0svh2DuXoCsPlM=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=


### PR DESCRIPTION
## Overview

This PR updates go-da to v0.2.0 which accepts a context as the first argument to DA interface methods.

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
