### PR TITLE
Fix Inefficient usage of mutex in PendingBlocks

### DIFF
--- a/block/pending_blocks.go
+++ b/block/pending_blocks.go
@@ -24,15 +24,20 @@ func NewPendingBlocks() *PendingBlocks {
 // getPendingBlocks returns a sorted slice of pending blocks
 // that need to be published to DA layer in order of block height
 func (pb *PendingBlocks) getPendingBlocks() []*types.Block {
+	blocks := copyBlocks(pb)
+	sort.Slice(blocks, func(i, j int) bool {
+		return blocks[i].Height() < blocks[j].Height()
+	})
+	return blocks
+}
+
+func copyBlocks(pb *PendingBlocks) []*types.Block {
 	pb.mtx.RLock()
 	defer pb.mtx.RUnlock()
 	blocks := make([]*types.Block, 0, len(pb.pendingBlocks))
 	for _, block := range pb.pendingBlocks {
 		blocks = append(blocks, block)
 	}
-	sort.Slice(blocks, func(i, j int) bool {
-		return blocks[i].Height() < blocks[j].Height()
-	})
 	return blocks
 }
 

--- a/block/pending_blocks.go
+++ b/block/pending_blocks.go
@@ -31,6 +31,8 @@ func (pb *PendingBlocks) getPendingBlocks() []*types.Block {
 	return blocks
 }
 
+// copyBlocks creates a copy of the pending blocks in a thread-safe manner.
+// It returns a slice of pointers to the copied blocks.
 func copyBlocks(pb *PendingBlocks) []*types.Block {
 	pb.mtx.RLock()
 	defer pb.mtx.RUnlock()


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Closes: #1461
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved thread safety in the retrieval of pending blocks with sorting by height.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->