### PR TITLE
Compute empty evidence hash constantly

### DIFF
--- a/types/abci/block.go
+++ b/types/abci/block.go
@@ -5,6 +5,7 @@ import (
 	cmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	cmtypes "github.com/cometbft/cometbft/types"
+
 	"github.com/rollkit/rollkit/types"
 )
 

--- a/types/abci/block.go
+++ b/types/abci/block.go
@@ -5,7 +5,6 @@ import (
 	cmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmversion "github.com/cometbft/cometbft/proto/tendermint/version"
 	cmtypes "github.com/cometbft/cometbft/types"
-
 	"github.com/rollkit/rollkit/types"
 )
 
@@ -31,7 +30,7 @@ func ToABCIHeaderPB(header *types.Header) (cmproto.Header, error) {
 		ConsensusHash:   header.ConsensusHash[:],
 		AppHash:         header.AppHash[:],
 		LastResultsHash: header.LastResultsHash[:],
-		EvidenceHash:    new(cmtypes.EvidenceData).Hash(),
+		EvidenceHash:    types.EmptyEvidenceHash,
 		ProposerAddress: header.ProposerAddress,
 		ChainID:         header.ChainID(),
 	}, nil
@@ -59,7 +58,7 @@ func ToABCIHeader(header *types.Header) (cmtypes.Header, error) {
 		ConsensusHash:   cmbytes.HexBytes(header.ConsensusHash),
 		AppHash:         cmbytes.HexBytes(header.AppHash),
 		LastResultsHash: cmbytes.HexBytes(header.LastResultsHash),
-		EvidenceHash:    new(cmtypes.EvidenceData).Hash(),
+		EvidenceHash:    types.EmptyEvidenceHash,
 		ProposerAddress: header.ProposerAddress,
 		ChainID:         header.ChainID(),
 	}, nil

--- a/types/abci/block_test.go
+++ b/types/abci/block_test.go
@@ -36,7 +36,7 @@ func TestToABCIHeaderPB(t *testing.T) {
 		ConsensusHash:   header.ConsensusHash[:],
 		AppHash:         header.AppHash[:],
 		LastResultsHash: header.LastResultsHash[:],
-		EvidenceHash:    new(cmtypes.EvidenceData).Hash(),
+		EvidenceHash:    types.EmptyEvidenceHash,
 		ProposerAddress: header.ProposerAddress,
 		ChainID:         header.ChainID(),
 	}
@@ -70,7 +70,7 @@ func TestToABCIHeader(t *testing.T) {
 		ConsensusHash:   cmbytes.HexBytes(header.ConsensusHash),
 		AppHash:         cmbytes.HexBytes(header.AppHash),
 		LastResultsHash: cmbytes.HexBytes(header.LastResultsHash),
-		EvidenceHash:    new(cmtypes.EvidenceData).Hash(),
+		EvidenceHash:    types.EmptyEvidenceHash,
 		ProposerAddress: header.ProposerAddress,
 		ChainID:         header.ChainID(),
 	}

--- a/types/hashing.go
+++ b/types/hashing.go
@@ -7,6 +7,10 @@ import (
 	cmtypes "github.com/cometbft/cometbft/types"
 )
 
+var (
+	EmptyEvidenceHash = new(cmtypes.EvidenceData).Hash()
+)
+
 // Hash returns ABCI-compatible hash of a header.
 func (h *Header) Hash() Hash {
 	abciHeader := cmtypes.Header{
@@ -28,7 +32,7 @@ func (h *Header) Hash() Hash {
 		ConsensusHash:   cmbytes.HexBytes(h.ConsensusHash),
 		AppHash:         cmbytes.HexBytes(h.AppHash),
 		LastResultsHash: cmbytes.HexBytes(h.LastResultsHash),
-		EvidenceHash:    new(cmtypes.EvidenceData).Hash(),
+		EvidenceHash:    EmptyEvidenceHash,
 		ProposerAddress: h.ProposerAddress,
 		// Backward compatibility
 		ValidatorsHash:     h.ProposerAddress,

--- a/types/hashing.go
+++ b/types/hashing.go
@@ -8,6 +8,7 @@ import (
 )
 
 var (
+	// EmptyEvidenceHash is the hash of an empty EvidenceData
 	EmptyEvidenceHash = new(cmtypes.EvidenceData).Hash()
 )
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Closes: #1456

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Standardized the use of `EmptyEvidenceHash` for the `EvidenceHash` field in block-related functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->