### PR TITLE
refactor: Use atomic.Uint64 for height in DefaultStore

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -26,9 +26,7 @@ var (
 
 // DefaultStore is a default store implmementation.
 type DefaultStore struct {
-	db ds.TxnDatastore
-
-	// height uint64
+	db     ds.TxnDatastore
 	height atomic.Uint64
 }
 
@@ -44,7 +42,6 @@ func New(ds ds.TxnDatastore) Store {
 // SetHeight sets the height saved in the Store if it is higher than the existing height
 func (s *DefaultStore) SetHeight(ctx context.Context, height uint64) {
 	for {
-		// storeHeight := atomic.LoadUint64(&s.height)
 		storeHeight := s.height.Load()
 		if height <= storeHeight {
 			break
@@ -52,16 +49,11 @@ func (s *DefaultStore) SetHeight(ctx context.Context, height uint64) {
 		if s.height.CompareAndSwap(storeHeight, height) {
 			break
 		}
-		// if atomic.CompareAndSwapUint64(&s.height,
-		// 	storeHeight, height) {
-		// 	break
-		// }
 	}
 }
 
 // Height returns height of the highest block saved in the Store.
 func (s *DefaultStore) Height() uint64 {
-	// return atomic.LoadUint64(&s.height)
 	return s.height.Load()
 }
 
@@ -208,7 +200,6 @@ func (s *DefaultStore) GetState(ctx context.Context) (types.State, error) {
 
 	var state types.State
 	err = state.FromProto(&pbState)
-	// atomic.StoreUint64(&s.height, state.LastBlockHeight)
 	s.height.Store(state.LastBlockHeight)
 	return state, err
 }


### PR DESCRIPTION
Closes #1491

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved thread safety of the height attribute in the data store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->