### PR TITLE
ignore validation failed error for the genesis block

### DIFF
--- a/block/block_sync.go
+++ b/block/block_sync.go
@@ -117,7 +117,7 @@ func (bSyncService *BlockSyncService) WriteToBlockStoreAndBroadcast(ctx context.
 		// for the genesis header, broadcast error is expected as we have already initialized the store
 		// for starting the syncer. Hence, we ignore the error.
 		// exact reason: validation failed, err header verification failed: known header: '1' <= current '1'
-		if isGenesis {
+		if isGenesis && errors.Is(err, pubsub.ValidationError{Reason: pubsub.RejectValidationFailed}) {
 			return nil
 		}
 		return fmt.Errorf("failed to broadcast block: %w", err)

--- a/block/block_sync.go
+++ b/block/block_sync.go
@@ -100,8 +100,9 @@ func (bSyncService *BlockSyncService) initBlockStoreAndStartSyncer(ctx context.C
 // Note: Only returns an error in case block store can't be initialized. Logs
 // error if there's one while broadcasting.
 func (bSyncService *BlockSyncService) WriteToBlockStoreAndBroadcast(ctx context.Context, block *types.Block) error {
+	isGenesis := int64(block.Height()) == bSyncService.genesis.InitialHeight
 	// For genesis block initialize the store and start the syncer
-	if int64(block.Height()) == bSyncService.genesis.InitialHeight {
+	if isGenesis {
 		if err := bSyncService.blockStore.Init(ctx, block); err != nil {
 			return fmt.Errorf("failed to initialize block store")
 		}
@@ -113,7 +114,13 @@ func (bSyncService *BlockSyncService) WriteToBlockStoreAndBroadcast(ctx context.
 
 	// Broadcast for subscribers
 	if err := bSyncService.sub.Broadcast(ctx, block); err != nil {
-		bSyncService.logger.Error("failed to broadcast block", "error", err)
+		// for the genesis header, broadcast error is expected as we have already initialized the store
+		// for starting the syncer. Hence, we ignore the error.
+		// exact reason: validation failed, err header verification failed: known header: '1' <= current '1'
+		if isGenesis {
+			return nil
+		}
+		return fmt.Errorf("failed to broadcast block header: %w", err)
 	}
 	return nil
 }

--- a/block/block_sync.go
+++ b/block/block_sync.go
@@ -120,7 +120,7 @@ func (bSyncService *BlockSyncService) WriteToBlockStoreAndBroadcast(ctx context.
 		if isGenesis {
 			return nil
 		}
-		return fmt.Errorf("failed to broadcast block header: %w", err)
+		return fmt.Errorf("failed to broadcast block: %w", err)
 	}
 	return nil
 }

--- a/block/header_sync.go
+++ b/block/header_sync.go
@@ -116,7 +116,7 @@ func (hSyncService *HeaderSyncService) WriteToHeaderStoreAndBroadcast(ctx contex
 		// for the genesis header, broadcast error is expected as we have already initialized the store
 		// for starting the syncer. Hence, we ignore the error.
 		// exact reason: validation failed, err header verification failed: known header: '1' <= current '1'
-		if isGenesis {
+		if isGenesis && errors.Is(err, pubsub.ValidationError{Reason: pubsub.RejectValidationFailed}) {
 			return nil
 		}
 		return fmt.Errorf("failed to broadcast block header: %w", err)

--- a/block/header_sync.go
+++ b/block/header_sync.go
@@ -99,8 +99,9 @@ func (hSyncService *HeaderSyncService) initHeaderStoreAndStartSyncer(ctx context
 // WriteToHeaderStoreAndBroadcast initializes header store if needed and broadcasts provided header.
 // Note: Only returns an error in case header store can't be initialized. Logs error if there's one while broadcasting.
 func (hSyncService *HeaderSyncService) WriteToHeaderStoreAndBroadcast(ctx context.Context, signedHeader *types.SignedHeader) error {
+	isGenesis := int64(signedHeader.Height()) == hSyncService.genesis.InitialHeight
 	// For genesis header initialize the store and start the syncer
-	if int64(signedHeader.Height()) == hSyncService.genesis.InitialHeight {
+	if isGenesis {
 		if err := hSyncService.headerStore.Init(ctx, signedHeader); err != nil {
 			return fmt.Errorf("failed to initialize header store")
 		}
@@ -112,7 +113,13 @@ func (hSyncService *HeaderSyncService) WriteToHeaderStoreAndBroadcast(ctx contex
 
 	// Broadcast for subscribers
 	if err := hSyncService.sub.Broadcast(ctx, signedHeader); err != nil {
-		hSyncService.logger.Error("failed to broadcast block header", "error", err)
+		// for the genesis header, broadcast error is expected as we have already initialized the store
+		// for starting the syncer. Hence, we ignore the error.
+		// exact reason: validation failed, err header verification failed: known header: '1' <= current '1'
+		if isGenesis {
+			return nil
+		}
+		return fmt.Errorf("failed to broadcast block header: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #969 

This PR fixes the `validation failed` error that is thrown by header and block sync, which happens when the sequencer calls `Broadcast` which also does publish the header/block locally for updating the store. This happens because the sequencer before broadcasting, for the genesis header, already does the store initialization and double store update causes this error. The prior initialization is required to start the syncer and there is no easier way to skip one of the two initializations. In future, can refactor the code to move syncer start to its own thread. But for now, ignoring the error is easier solution without adding any safety concerns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved handling of genesis blocks and headers during synchronization, enhancing the app's stability and reducing unnecessary error logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->