### PR TITLE
Update auto_request_review.yml

### DIFF
--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -6,7 +6,6 @@ reviewers:
       - Manav-Aggarwal
       - tzdybal
       - gupadhyaya
-      - S1nus
       - tuxcanfly
       - MSevey
 files:

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -3,11 +3,10 @@ reviewers:
     - code-owners
   groups:
     code-owners:
-      - Nashqueue
+      - Manav-Aggarwal
       - tzdybal
       - gupadhyaya
     rollkit:
-      - Manav-Aggarwal
       - S1nus
       - tuxcanfly
     devops:

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -1,29 +1,19 @@
 reviewers:
   defaults:
-    - code-owners
+    - rollkit
   groups:
-    code-owners:
+    rollkit:
       - Manav-Aggarwal
       - tzdybal
       - gupadhyaya
-    rollkit:
       - S1nus
       - tuxcanfly
-    devops:
-      - smuu
-      - sysrex
-      - jrmanes
-      - Bidon15
-    celestia:
-      - team:celestia
 files:
-  '**':
-    - code-owners
+  "**":
     - rollkit
-  '**/*Dockerfile':
-    - devops
-  '.github/**':
-    - devops
+  ".github/**":
+    - MSevey
+    - rollkit
 options:
   ignore_draft: true
   ignored_keywords:

--- a/.github/auto_request_review.yml
+++ b/.github/auto_request_review.yml
@@ -8,6 +8,7 @@ reviewers:
       - gupadhyaya
       - S1nus
       - tuxcanfly
+      - MSevey
 files:
   "**":
     - rollkit


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

I'm proposing the following updates to the auto review assignments.

1. Simplifying it down to just a rollkit group
2. Removing Gabriel, Connor
3. Removing devops
4. Add me under `.github` repos specifically

This should result in:
1. Every PR being assigned to 3 people
2. Any PRs touching `.github` assigning to me and 2 others.

If there are other parts of the code base that we want owners of, so that they always review those PRs, we can duplicate the `.github` example for those. 


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated reviewer groups for pull requests to enhance the review process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->