### PR TITLE
mempool: Add metric size of pool in bytes

### DIFF
--- a/mempool/clist_mempool.go
+++ b/mempool/clist_mempool.go
@@ -277,6 +277,7 @@ func (mem *CListMempool) globalCb(req *abci.Request, res *abci.Response) {
 
 	// update metrics
 	mem.metrics.Size.Set(float64(mem.Size()))
+	mem.metrics.SizeBytes.Set(float64(mem.SizeBytes()))
 }
 
 // Request specific callback that should be set on individual reqRes objects
@@ -304,6 +305,7 @@ func (mem *CListMempool) reqResCb(
 
 		// update metrics
 		mem.metrics.Size.Set(float64(mem.Size()))
+		mem.metrics.SizeBytes.Set(float64(mem.SizeBytes()))
 
 		// passed in by the caller of CheckTx, eg. the RPC
 		if externalCb != nil {
@@ -634,6 +636,7 @@ func (mem *CListMempool) Update(
 
 	// Update metrics
 	mem.metrics.Size.Set(float64(mem.Size()))
+	mem.metrics.SizeBytes.Set(float64(mem.SizeBytes()))
 
 	return nil
 }

--- a/mempool/metrics.go
+++ b/mempool/metrics.go
@@ -19,6 +19,9 @@ type Metrics struct {
 	// Size of the mempool.
 	Size metrics.Gauge
 
+	// Total size of the mempool in bytes.
+	SizeBytes metrics.Gauge
+
 	// Histogram of transaction sizes, in bytes.
 	TxSizeBytes metrics.Histogram
 
@@ -55,6 +58,13 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 			Subsystem: MetricsSubsystem,
 			Name:      "size",
 			Help:      "Size of the mempool (number of uncommitted transactions).",
+		}, labels).With(labelsAndValues...),
+
+		SizeBytes: prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "size_bytes",
+			Help:      "Total size of the mempool in bytes.",
 		}, labels).With(labelsAndValues...),
 
 		TxSizeBytes: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
@@ -99,6 +109,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 func NopMetrics() *Metrics {
 	return &Metrics{
 		Size:         discard.NewGauge(),
+		SizeBytes:    discard.NewGauge(),
 		TxSizeBytes:  discard.NewHistogram(),
 		FailedTxs:    discard.NewCounter(),
 		RejectedTxs:  discard.NewCounter(),


### PR DESCRIPTION
This PR exposes a new metric SizeBytes for the total size of the mempool in bytes. We already keep track of this value internally, in the variable txsBytes. Currently there is the metric Size for the size of the mempool in number of transactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced memory pool metrics to include the size in bytes, improving monitoring and analysis capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->