### PR TITLE
Cast to uint64 from int64 instead of other way

### DIFF
--- a/block/block_sync.go
+++ b/block/block_sync.go
@@ -99,7 +99,7 @@ func (bSyncService *BlockSyncService) initBlockStoreAndStartSyncer(ctx context.C
 // Note: Only returns an error in case block store can't be initialized. Logs
 // error if there's one while broadcasting.
 func (bSyncService *BlockSyncService) WriteToBlockStoreAndBroadcast(ctx context.Context, block *types.Block) error {
-	isGenesis := int64(block.Height()) == bSyncService.genesis.InitialHeight
+	isGenesis := block.Height() == uint64(bSyncService.genesis.InitialHeight)
 	// For genesis block initialize the store and start the syncer
 	if isGenesis {
 		if err := bSyncService.blockStore.Init(ctx, block); err != nil {

--- a/block/header_sync.go
+++ b/block/header_sync.go
@@ -98,7 +98,7 @@ func (hSyncService *HeaderSyncService) initHeaderStoreAndStartSyncer(ctx context
 // WriteToHeaderStoreAndBroadcast initializes header store if needed and broadcasts provided header.
 // Note: Only returns an error in case header store can't be initialized. Logs error if there's one while broadcasting.
 func (hSyncService *HeaderSyncService) WriteToHeaderStoreAndBroadcast(ctx context.Context, signedHeader *types.SignedHeader) error {
-	isGenesis := int64(signedHeader.Height()) == hSyncService.genesis.InitialHeight
+	isGenesis := signedHeader.Height() == uint64(hSyncService.genesis.InitialHeight)
 	// For genesis header initialize the store and start the syncer
 	if isGenesis {
 		if err := hSyncService.headerStore.Init(ctx, signedHeader); err != nil {

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -23,7 +23,7 @@ func TestInitialStateClean(t *testing.T) {
 	es, _ := store.NewDefaultInMemoryKVStore()
 	emptyStore := store.New(es)
 	s, err := getInitialState(emptyStore, genesis)
-	require.Equal(int64(s.LastBlockHeight), genesis.InitialHeight-1)
+	require.Equal(s.LastBlockHeight, uint64(genesis.InitialHeight-1))
 	require.NoError(err)
 	require.Equal(uint64(genesis.InitialHeight), s.InitialHeight)
 }
@@ -49,7 +49,7 @@ func TestInitialStateStored(t *testing.T) {
 	err := store.UpdateState(ctx, sampleState)
 	require.NoError(err)
 	s, err := getInitialState(store, genesis)
-	require.Equal(int64(s.LastBlockHeight), int64(100))
+	require.Equal(s.LastBlockHeight, uint64(100))
 	require.NoError(err)
 	require.Equal(s.InitialHeight, uint64(1))
 }

--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -190,8 +190,8 @@ func verifyTransactions(node *FullNode, peerID peer.ID, assert *assert.Assertion
 // verifyMempoolSize checks if the mempool size is as expected
 func verifyMempoolSize(node *FullNode, assert *assert.Assertions) {
 	assert.NoError(testutils.Retry(300, 100*time.Millisecond, func() error {
-		expectedSize := int64(4 * len("tx*"))
-		actualSize := node.Mempool.SizeBytes()
+		expectedSize := uint64(4 * len("tx*"))
+		actualSize := uint64(node.Mempool.SizeBytes())
 		if expectedSize == actualSize {
 			return nil
 		}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Closes: #1517

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated the data types for block and header heights to `uint64` across various components, enhancing consistency and logic related to genesis block initialization.
	- Adjusted the types for height, gasWanted, and size in mempool and node components to `uint64`, aligning with the updated data representation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->