### PR TITLE
Refactor: Make GenerateKey more robust

### DIFF
--- a/store/kv.go
+++ b/store/kv.go
@@ -41,15 +41,17 @@ func PrefixEntries(ctx context.Context, store ds.Datastore, prefix string) (dsq.
 }
 
 // GenerateKey ...
-func GenerateKey(fields []interface{}) string {
-	var b bytes.Buffer
+func GenerateKey(fields []string) (string, error) {
+	var b strings.Builder
 	b.WriteString("/")
 	for _, f := range fields {
-		b.Write([]byte(fmt.Sprintf("%v", f) + "/"))
+		_, err := b.WriteString(f + "/")
+		if err != nil {
+			return "", err
+		}
 	}
-	return path.Clean(b.String())
+	return path.Clean(b.String()), nil
 }
-
 // rootify works just like in cosmos-sdk
 func rootify(rootDir, dbPath string) string {
 	if filepath.IsAbs(dbPath) {


### PR DESCRIPTION
The GenerateKey function has been refactored to improve its robustness and efficiency. The function now only accepts a slice of strings as input, preventing non-string values from being passed. The strings.Builder type is used for more efficient string concatenation. The function also handles potential errors that may occur during the string concatenation process.

Fixes https://github.com/rollkit/rollkit/issues/1492

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the `GenerateKey` function for better performance and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->