### PR TITLE
fix(block/manager): limit block size to da max blob size

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -48,6 +48,9 @@ const channelLength = 100
 // Applies to the blockInCh, 10000 is a large enough number for blocks per DA block.
 const blockInChLength = 10000
 
+// blockProtocolOverhead is the overhead in bytes of serializing the block into blob.
+const blockProtocolOverhead = 100
+
 // initialBackoff defines initial value for block submission backoff
 var initialBackoff = 100 * time.Millisecond
 
@@ -170,6 +173,16 @@ func NewManager(
 	if conf.DAMempoolTTL == 0 {
 		logger.Info("Using default mempool ttl", "MempoolTTL", defaultMempoolTTL)
 		conf.DAMempoolTTL = defaultMempoolTTL
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	maxBlobSize, err := dalc.DA.MaxBlobSize(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if genesis.ConsensusParams.Block.MaxBytes >= int64(maxBlobSize) {
+		genesis.ConsensusParams.Block.MaxBytes = int64(maxBlobSize) - blockProtocolOverhead
 	}
 
 	proposerAddress, err := getAddress(proposerKey)

--- a/block/manager.go
+++ b/block/manager.go
@@ -184,6 +184,9 @@ func NewManager(
 	if genesis.ConsensusParams.Block.MaxBytes >= int64(maxBlobSize) {
 		genesis.ConsensusParams.Block.MaxBytes = int64(maxBlobSize) - blockProtocolOverhead
 	}
+	if err := genesis.ConsensusParams.ValidateBasic(); err != nil {
+		return nil, err
+	}
 
 	proposerAddress, err := getAddress(proposerKey)
 	if err != nil {


### PR DESCRIPTION
## Overview

This PR limits the block max bytes to DA max blob size. Fixes #1428 

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
