### PR TITLE
fix(sync): check height bound to avoid overflow

### DIFF
--- a/block/block_sync.go
+++ b/block/block_sync.go
@@ -99,6 +99,9 @@ func (bSyncService *BlockSyncService) initBlockStoreAndStartSyncer(ctx context.C
 // Note: Only returns an error in case block store can't be initialized. Logs
 // error if there's one while broadcasting.
 func (bSyncService *BlockSyncService) WriteToBlockStoreAndBroadcast(ctx context.Context, block *types.Block) error {
+	if bSyncService.genesis.InitialHeight < 0 || block.Height() < 0 {
+		return fmt.Errorf("invalid block height; cannot be negative")
+	}
 	isGenesis := block.Height() == uint64(bSyncService.genesis.InitialHeight)
 	// For genesis block initialize the store and start the syncer
 	if isGenesis {

--- a/block/header_sync.go
+++ b/block/header_sync.go
@@ -98,6 +98,9 @@ func (hSyncService *HeaderSyncService) initHeaderStoreAndStartSyncer(ctx context
 // WriteToHeaderStoreAndBroadcast initializes header store if needed and broadcasts provided header.
 // Note: Only returns an error in case header store can't be initialized. Logs error if there's one while broadcasting.
 func (hSyncService *HeaderSyncService) WriteToHeaderStoreAndBroadcast(ctx context.Context, signedHeader *types.SignedHeader) error {
+	if hSyncService.genesis.InitialHeight < 0 || signedHeader.Height() < 0 {
+		return fmt.Errorf("invalid block height; cannot be negative")
+	}
 	isGenesis := signedHeader.Height() == uint64(hSyncService.genesis.InitialHeight)
 	// For genesis header initialize the store and start the syncer
 	if isGenesis {


### PR DESCRIPTION
## Overview

This PR adds an additional check to block height during sync. This avoids potential integer overflow. Fixes #1455 

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
