### PR TITLE
[DA] Fix error check for no blocks found in RetrieveBlocks()

### DIFF
--- a/da/da.go
+++ b/da/da.go
@@ -163,12 +163,14 @@ func (dac *DAClient) RetrieveBlocks(ctx context.Context, dataLayerHeight uint64)
 			},
 		}
 	}
-	// ids can be nil if there are no blocks at the requested height.
-	if ids == nil {
+
+	// If no blocks are found, return a non-blocking error.
+	if len(ids) == 0 {
 		return ResultRetrieveBlocks{
 			BaseResult: BaseResult{
-				Code:    StatusNotFound,
-				Message: ErrBlobNotFound.Error(),
+				Code:     StatusNotFound,
+				Message:  ErrBlobNotFound.Error(),
+				DAHeight: dataLayerHeight,
 			},
 		}
 	}

--- a/da/da.go
+++ b/da/da.go
@@ -164,7 +164,7 @@ func (dac *DAClient) RetrieveBlocks(ctx context.Context, dataLayerHeight uint64)
 		}
 	}
 
-	// If no blocks are found, return a non-blocking error.
+	// If no blobs are found, return a non-blocking error.
 	if len(ids) == 0 {
 		return ResultRetrieveBlocks{
 			BaseResult: BaseResult{

--- a/da/da.go
+++ b/da/da.go
@@ -164,7 +164,7 @@ func (dac *DAClient) RetrieveBlocks(ctx context.Context, dataLayerHeight uint64)
 		}
 	}
 
-	// If no blobs are found, return a non-blocking error.
+	// If no blocks are found, return a non-blocking error.
 	if len(ids) == 0 {
 		return ResultRetrieveBlocks{
 			BaseResult: BaseResult{

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -322,6 +322,6 @@ func doTestRetrieveNoBlocksFound(t *testing.T, dalc *DAClient) {
 
 	assert := assert.New(t)
 	result := dalc.RetrieveBlocks(ctx, 123)
-	assert.Equal(StatusNotFound, result.Code, "should return not found error")
+	assert.Equal(StatusNotFound, result.Code)
 	assert.Contains(result.Message, ErrBlobNotFound.Error())
 }

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -131,7 +131,7 @@ func TestSubmitRetrieve(t *testing.T) {
 		{"submit_over_sized_block", doTestSubmitOversizedBlock},
 		{"submit_small_blocks_batch", doTestSubmitSmallBlocksBatch},
 		{"submit_large_blocks_overflow", doTestSubmitLargeBlocksOverflow},
-		{"retrieve_no_blobs_found", doTestRetrieveNoBlobsFound},
+		{"retrieve_no_blocks_found", doTestRetrieveNoBlocksFound},
 	}
 	for name, dalc := range clients {
 		for _, tc := range tests {
@@ -316,7 +316,7 @@ func doTestSubmitLargeBlocksOverflow(t *testing.T, dalc *DAClient) {
 	assert.EqualValues(resp.SubmittedCount, 1, "submitted count should match")
 }
 
-func doTestRetrieveNoBlobsFound(t *testing.T, dalc *DAClient) {
+func doTestRetrieveNoBlocksFound(t *testing.T, dalc *DAClient) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -322,6 +322,6 @@ func doTestRetrieveNoBlocksFound(t *testing.T, dalc *DAClient) {
 
 	assert := assert.New(t)
 	result := dalc.RetrieveBlocks(ctx, 123)
-	assert.Equal(StatusNotFound, result.Code, "should return not found")
-	assert.Contains(result.Message, "blob: not found")
+	assert.Equal(StatusNotFound, result.Code, "should return not found error")
+	assert.Contains(result.Message, ErrBlobNotFound.Error())
 }

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -141,6 +141,22 @@ func TestSubmitRetrieve(t *testing.T) {
 	}
 }
 
+func TestRetrieveNoBlocksFound(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	assert := assert.New(t)
+
+	mockDA := &MockDA{}
+	dalc := &DAClient{DA: mockDA}
+
+	// Set Mock DA to return empty IDs
+	mockDA.On("GetIDs", mock.Anything, mock.Anything).Return([]da.ID{}, nil)
+	result := dalc.RetrieveBlocks(ctx, 123)
+	assert.Equal(StatusNotFound, result.Code, "should return not found")
+	assert.Contains(result.Message, "blob: not found")
+}
+
 func startMockGRPCServ() *grpc.Server {
 	srv := proxy.NewServer(goDATest.NewDummyDA(), grpc.Creds(insecure.NewCredentials()))
 	lis, err := net.Listen("tcp", "127.0.0.1"+":"+strconv.Itoa(7980))


### PR DESCRIPTION
## Overview

Closes: https://github.com/rollkit/rollkit/issues/1540 

_TL;DR:_ In da.go, when no blocks are found via RetrieveBlocks(), this [check](https://github.com/rollkit/rollkit/blob/main/da/da.go#L166) for `ids == nil` needs to be `if len(ids) == 0` to properly handle an initialized empty slice.

Tested and saw logs showing up:
```
8:19PM DBG no block found daHeight=35384 module=BlockManager reason="blob: not found"
8:19PM DBG trying to retrieve block from DA daHeight=35385 module=BlockManager
```

Followed current test file structure. Will add some more test cases for RetrieveBlocks() in `da_test.go` in a separate PR.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
        - Requires bug, da label, don't seem to have access
        - Doesn't recognize my Github
        - Lint + Tests pass on local
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Improved error handling in the data access layer when retrieving blocks with empty IDs, providing more informative feedback.
- **Tests**
	- Added tests to ensure robust handling of scenarios where no blocks are found during retrieval.
	- Implemented a new test case and function to handle scenarios with no blocks found during retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->