### PR TITLE
Status rpc

### DIFF
--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -976,45 +976,65 @@ func TestStatus(t *testing.T) {
 	resp, err := rpc.Status(context.Background())
 	assert.NoError(err)
 
-	assert.Equal(int64(1), resp.SyncInfo.EarliestBlockHeight)
-	assert.Equal(int64(2), resp.SyncInfo.LatestBlockHeight)
+	t.Run("SyncInfo", func(t *testing.T) {
+		assert.EqualValues(earliestBlock.Height(), resp.SyncInfo.EarliestBlockHeight)
+		assert.EqualValues(latestBlock.Height(), resp.SyncInfo.LatestBlockHeight)
+		assert.Equal(
+			hex.EncodeToString(earliestBlock.SignedHeader.AppHash),
+			hex.EncodeToString(resp.SyncInfo.EarliestAppHash))
+		assert.Equal(
+			hex.EncodeToString(latestBlock.SignedHeader.AppHash),
+			hex.EncodeToString(resp.SyncInfo.LatestAppHash))
 
-	// Changed the RPC method to get this from the genesis.
-	assert.Equal(genesisDoc.Validators[0].Address, resp.ValidatorInfo.Address)
-	assert.Equal(genesisDoc.Validators[0].PubKey, resp.ValidatorInfo.PubKey)
-	// hardcode to 1, shouldn't matter because it's a centralized sequencer
-	assert.Equal(int64(1), resp.ValidatorInfo.VotingPower)
+		assert.Equal(hex.EncodeToString(earliestBlock.SignedHeader.DataHash), hex.EncodeToString(resp.SyncInfo.EarliestBlockHash))
+		assert.Equal(hex.EncodeToString(latestBlock.SignedHeader.DataHash), hex.EncodeToString(resp.SyncInfo.LatestBlockHash))
+		assert.Equal(true, resp.SyncInfo.CatchingUp)
+	})
+	t.Run("ValidatorInfo", func(t *testing.T) {
+		assert.Equal(genesisDoc.Validators[0].Address, resp.ValidatorInfo.Address)
+		assert.Equal(genesisDoc.Validators[0].PubKey, resp.ValidatorInfo.PubKey)
+		assert.EqualValues(int64(1), resp.ValidatorInfo.VotingPower)
+	})
+	t.Run("NodeInfo", func(t *testing.T) {
+		// Changed the RPC method to get this from the genesis.
+		// specific validation
+		state, err := rpc.node.Store.GetState(ctx)
+		assert.NoError(err)
 
-	// specific validation
-	assert.Equal(cmconfig.DefaultBaseConfig().Moniker, resp.NodeInfo.Moniker)
-	state, err := rpc.node.Store.GetState(ctx)
-	assert.NoError(err)
-	defaultProtocolVersion := p2p.NewProtocolVersion(
-		version.P2PProtocol,
-		state.Version.Consensus.Block,
-		state.Version.Consensus.App,
-	)
-	assert.Equal(defaultProtocolVersion, resp.NodeInfo.ProtocolVersion)
+		defaultProtocolVersion := p2p.NewProtocolVersion(
+			version.P2PProtocol,
+			state.Version.Consensus.Block,
+			state.Version.Consensus.App,
+		)
+		assert.Equal(defaultProtocolVersion, resp.NodeInfo.ProtocolVersion)
 
-	assert.NotNil(resp.NodeInfo.Other.TxIndex)
-	cases := []struct {
-		expected bool
-		other    p2p.DefaultNodeInfoOther
-	}{
+		// check that NodeInfo DefaultNodeID matches the ID derived from p2p key
+		rawKey, err := key.GetPublic().Raw()
+		assert.NoError(err)
+		assert.Equal(p2p.ID(hex.EncodeToString(cmcrypto.AddressHash(rawKey))), resp.NodeInfo.DefaultNodeID)
 
-		{false, p2p.DefaultNodeInfoOther{}},
-		{false, p2p.DefaultNodeInfoOther{TxIndex: "aa"}},
-		{false, p2p.DefaultNodeInfoOther{TxIndex: "off"}},
-		{true, p2p.DefaultNodeInfoOther{TxIndex: "on"}},
-	}
-	for _, tc := range cases {
-		res := resp.NodeInfo.Other.TxIndex == tc.other.TxIndex
-		assert.Equal(tc.expected, res, tc)
-	}
-	// check that NodeInfo DefaultNodeID matches the ID derived from p2p key
-	rawKey, err := key.GetPublic().Raw()
-	assert.NoError(err)
-	assert.Equal(p2p.ID(hex.EncodeToString(cmcrypto.AddressHash(rawKey))), resp.NodeInfo.DefaultNodeID)
+		assert.Equal(rpc.node.nodeConfig.P2P.ListenAddress, resp.NodeInfo.ListenAddr)
+		assert.Equal(rpc.node.genesis.ChainID, resp.NodeInfo.Network)
+		// TODO: version match.
+		assert.Equal(cmconfig.DefaultBaseConfig().Moniker, resp.NodeInfo.Moniker)
+
+		assert.NotNil(resp.NodeInfo.Other.TxIndex)
+		cases := []struct {
+			expected bool
+			other    p2p.DefaultNodeInfoOther
+		}{
+
+			{false, p2p.DefaultNodeInfoOther{}},
+			{false, p2p.DefaultNodeInfoOther{TxIndex: "aa"}},
+			{false, p2p.DefaultNodeInfoOther{TxIndex: "off"}},
+			{true, p2p.DefaultNodeInfoOther{TxIndex: "on"}},
+		}
+		for _, tc := range cases {
+			res := resp.NodeInfo.Other.TxIndex == tc.other.TxIndex
+			assert.Equal(tc.expected, res, tc)
+		}
+		assert.Equal(rpc.config.ListenAddress, resp.NodeInfo.Other.RPCAddress)
+	})
 }
 
 func TestFutureGenesisTime(t *testing.T) {

--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -988,7 +988,7 @@ func TestStatus(t *testing.T) {
 
 		assert.Equal(hex.EncodeToString(earliestBlock.SignedHeader.DataHash), hex.EncodeToString(resp.SyncInfo.EarliestBlockHash))
 		assert.Equal(hex.EncodeToString(latestBlock.SignedHeader.DataHash), hex.EncodeToString(resp.SyncInfo.LatestBlockHash))
-		assert.Equal(true, resp.SyncInfo.CatchingUp)
+		assert.Equal(false, resp.SyncInfo.CatchingUp)
 	})
 	t.Run("ValidatorInfo", func(t *testing.T) {
 		assert.Equal(genesisDoc.Validators[0].Address, resp.ValidatorInfo.Address)


### PR DESCRIPTION
`TestStatus` is updated to use the new default (`false`, after the ibc support) for `SyncInfo.CatchingUp` field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced testing for node synchronization, validation, and general information.
	- Introduced specific tests for network address, network type, and RPC address within node information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->