### PR TITLE
fix(manager): reduce the number of isProposer checks in manager

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -675,8 +675,7 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 	}
 
 	if !m.isProposer {
-		m.logger.Debug("not a proposer, skipping block proposal")
-		return nil
+		return errors.New("publishBlock: not a proposer")
 	}
 
 	var (

--- a/block/manager.go
+++ b/block/manager.go
@@ -51,6 +51,14 @@ const blockInChLength = 10000
 // initialBackoff defines initial value for block submission backoff
 var initialBackoff = 100 * time.Millisecond
 
+var (
+	// ErrNoValidatorsInGenesis is used when no validators/proposers are found in genesis state
+	ErrNoValidatorsInGenesis = errors.New("no validators found in genesis")
+
+	// ErrNotProposer is used when the manager is not a proposer
+	ErrNotProposer = errors.New("not a proposer")
+)
+
 // NewBlockEvent is used to pass block and DA height to blockInCh
 type NewBlockEvent struct {
 	Block    *types.Block
@@ -255,7 +263,7 @@ func (m *Manager) SetDALC(dalc *da.DAClient) {
 // isProposer returns whether or not the manager is a proposer
 func isProposer(genesis *cmtypes.GenesisDoc, signerPrivKey crypto.PrivKey) (bool, error) {
 	if len(genesis.Validators) == 0 {
-		return false, errors.New("no validators found in genesis")
+		return false, ErrNoValidatorsInGenesis
 	}
 	signerPubBytes, err := signerPrivKey.GetPublic().Raw()
 	if err != nil {
@@ -690,7 +698,7 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 	}
 
 	if !m.isProposer {
-		return errors.New("publishBlock: not a proposer")
+		return ErrNotProposer
 	}
 
 	var (

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -356,7 +356,7 @@ func Test_isProposer(t *testing.T) {
 
 func Test_publishBlock_ManagerNotProposer(t *testing.T) {
 	require := require.New(t)
-	m := getManager(t)
+	m := getManager(t, &mock.MockDA{})
 	m.isProposer = false
 	err := m.publishBlock(context.Background())
 	require.ErrorContains(err, "not a proposer")

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -353,3 +353,11 @@ func Test_isProposer(t *testing.T) {
 		})
 	}
 }
+
+func Test_publishBlock_ManagerNotProposer(t *testing.T) {
+	require := require.New(t)
+	m := getManager(t)
+	m.isProposer = false
+	err := m.publishBlock(context.Background())
+	require.ErrorContains(err, "not a proposer")
+}

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	ds "github.com/ipfs/go-datastore"
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	cmtypes "github.com/cometbft/cometbft/types"
+	ds "github.com/ipfs/go-datastore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Previously, IsProposal() was called to check if the validator key from Genesis data matches the proposer's public key every time `publishBlock` is called. Although cheap to compute, this call was redundant. This PR has simple changes to cache it at the manager struct level during instantiation.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

Closes https://github.com/rollkit/rollkit/issues/1452

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
  - Improved block publishing logic by utilizing a new internal flag to determine if the current node is the proposer.
- **Tests**
  - Added tests to validate proposer determination and block publishing behavior for both proposer and non-proposer scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->