### PR TITLE
fix: make TestStatus stable

### DIFF
--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -972,6 +972,7 @@ func TestStatus(t *testing.T) {
 	defer func() {
 		assert.NoError(node.Stop())
 	}()
+	node.Cancel()
 
 	resp, err := rpc.Status(context.Background())
 	assert.NoError(err)


### PR DESCRIPTION
Calling `Cancel` on the node makes sure that goroutines are stopped without processing random blocks pushed into store for the test.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #1556 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved reliability of status checks by ensuring cancellation of previous operations before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->