### PR TITLE
fix: remove unnecessary node start in full client test

### DIFF
--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -928,6 +928,7 @@ func TestStatus(t *testing.T) {
 	require.NoError(err)
 	pubKey := genesisDoc.Validators[0].PubKey
 
+	// note that node is never started - we only need to ensure that node is properly initialized (newFullNode)
 	node, err := newFullNode(
 		context.Background(),
 		config.NodeConfig{
@@ -967,13 +968,6 @@ func TestStatus(t *testing.T) {
 	err = rpc.node.Store.SaveBlock(ctx, latestBlock, &types.Commit{})
 	rpc.node.Store.SetHeight(ctx, latestBlock.Height())
 	require.NoError(err)
-
-	err = node.Start()
-	require.NoError(err)
-	defer func() {
-		assert.NoError(node.Stop())
-	}()
-	node.Cancel()
 
 	resp, err := rpc.Status(context.Background())
 	assert.NoError(err)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The `node.Start()` command in the full client test file has been removed along with its accompanying error checks and stopping mechanism. This change reflects the fact that we only need to ensure the node is properly initialized (with the `newFullNode` function), not actually started, for the purposes of this test.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the efficiency of status checking in tests by removing unnecessary start, stop, and cancel operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->