### PR TITLE
test : Use IsType assertions in test

### DIFF
--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -27,13 +27,15 @@ import (
 // simply check that node is starting and stopping without panicking
 func TestStartup(t *testing.T) {
 	ctx := context.Background()
-	_ = initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
+	node := initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
+	require.IsType(t, new(FullNode), node)
 }
 
 func TestMempoolDirectly(t *testing.T) {
 	ctx := context.Background()
 
 	node := initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
+	require.IsType(t, new(FullNode), node)
 
 	assert := assert.New(t)
 	peerID := getPeerID(assert)

--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -27,16 +27,17 @@ import (
 // simply check that node is starting and stopping without panicking
 func TestStartup(t *testing.T) {
 	ctx := context.Background()
-	node := initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
+	node := initAndStartNodeWithCleanup(ctx, t, "full")
 	require.IsType(t, new(FullNode), node)
 }
 
 func TestMempoolDirectly(t *testing.T) {
 	ctx := context.Background()
 
-	node := initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
-	require.IsType(t, new(FullNode), node)
+	fn := initAndStartNodeWithCleanup(ctx, t, "full")
+	require.IsType(t, new(FullNode), fn)
 
+	node := fn.(*FullNode)
 	assert := assert.New(t)
 	peerID := getPeerID(assert)
 	verifyTransactions(node, peerID, assert)

--- a/node/light_client_test.go
+++ b/node/light_client_test.go
@@ -17,7 +17,7 @@ import (
 func TestLightClient_Panics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ln := initAndStartNodeWithCleanup(ctx, t, "light").(*LightNode)
+	ln := initAndStartNodeWithCleanup(ctx, t, "light")
 	require.IsType(t, new(LightNode), ln)
 
 	tests := []struct {

--- a/node/light_client_test.go
+++ b/node/light_client_test.go
@@ -6,6 +6,7 @@ import (
 
 	rpcclient "github.com/cometbft/cometbft/rpc/client"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestLightClient_Panics tests that all methods of LightClient and ensures that
@@ -17,6 +18,7 @@ func TestLightClient_Panics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	ln := initAndStartNodeWithCleanup(ctx, t, "light").(*LightNode)
+	require.IsType(t, new(LightNode), ln)
 
 	tests := []struct {
 		name string

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -81,6 +81,8 @@ func newTestNode(ctx context.Context, t *testing.T, nodeType string) (Node, ed25
 func TestNewNode(t *testing.T) {
 	ctx := context.Background()
 
-	_ = initAndStartNodeWithCleanup(ctx, t, "light").(*LightNode)
-	_ = initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
+	ln := initAndStartNodeWithCleanup(ctx, t, "light").(*LightNode)
+	require.IsType(t, new(LightNode), ln)
+	fn := initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
+	require.IsType(t, new(FullNode), fn)
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -81,8 +81,8 @@ func newTestNode(ctx context.Context, t *testing.T, nodeType string) (Node, ed25
 func TestNewNode(t *testing.T) {
 	ctx := context.Background()
 
-	ln := initAndStartNodeWithCleanup(ctx, t, "light").(*LightNode)
+	ln := initAndStartNodeWithCleanup(ctx, t, "light")
 	require.IsType(t, new(LightNode), ln)
-	fn := initAndStartNodeWithCleanup(ctx, t, "full").(*FullNode)
+	fn := initAndStartNodeWithCleanup(ctx, t, "full")
 	require.IsType(t, new(FullNode), fn)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
closes : #1570 
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Tests**
	- Enhanced testing for both Full and Light Node types to ensure correct object types are created and utilized.
	- Added assertions using `require.IsType` in various test functions to check object types.
	- Added assertion in `TestStartup` and `TestMempoolDirectly` to validate the type of the node object as `FullNode`.
	- Introduced a new assertion in `TestLightClient_Panics` to verify the type of `ln`.
	- Updated `TestNewNode` to include assertions using `require.IsType` to validate the types of nodes created, specifically for `LightNode` and `FullNode`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->