### PR TITLE
Refactor GenerateKey to make it more robust

### DIFF
--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -184,7 +184,7 @@ func (idx *BlockerIndexer) Search(ctx context.Context, q *query.Query) ([]int64,
 			continue
 		}
 
-		startKey := store.GenerateKey([]interface{}{c.Tag, c.Arg.Value()})
+		startKey := store.GenerateKey([]string{c.Tag, c.Arg.Value()})
 
 		if !heightsInitialized {
 			filteredHeights, err = idx.match(ctx, c, ds.NewKey(startKey).String(), filteredHeights, true)

--- a/state/indexer/block/kv/util.go
+++ b/state/indexer/block/kv/util.go
@@ -44,11 +44,11 @@ func int64ToBytes(i int64) []byte {
 }
 
 func heightKey(height int64) string {
-	return store.GenerateKey([]interface{}{types.BlockHeightKey, height})
+	return store.GenerateKey([]string{types.BlockHeightKey, strconv.FormatInt(height, 10)})
 }
 
 func eventKey(compositeKey, typ, eventValue string, height int64) string {
-	return store.GenerateKey([]interface{}{compositeKey, eventValue, height, typ})
+	return store.GenerateKey([]string{compositeKey, eventValue, strconv.FormatInt(height, 10), typ})
 }
 
 func parseValueFromPrimaryKey(key string) string {

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -255,9 +255,6 @@ func (txi *TxIndex) Search(ctx context.Context, q *query.Query) ([]*abci.TxResul
 		}
 	}
 
-	// if there is a height condition ("tx.height=3"), extract it
-	// height := lookForHeight(conditions)
-
 	// for all other conditions
 	for i, c := range conditions {
 		if intInSlice(i, skipIndexes) {
@@ -311,21 +308,6 @@ func lookForHash(conditions []syntax.Condition) (hash []byte, ok bool, err error
 		}
 	}
 	return
-}
-
-// lookForHeight returns a height if there is an "height=X" condition.
-func lookForHeight(conditions []syntax.Condition) (height int64) {
-	for _, c := range conditions {
-		if c.Tag == types.TxHeightKey && c.Op == syntax.TEq {
-			hFloat := c.Arg.Number()
-			if hFloat == nil {
-				return 0
-			}
-			h, _ := hFloat.Int64()
-			return h
-		}
-	}
-	return 0
 }
 
 // match returns all matching txs by hash that meet a given condition and start
@@ -634,11 +616,11 @@ func keyForHeight(result *abci.TxResult) string {
 
 func startKeyForCondition(c syntax.Condition, height int64) string {
 	if height > 0 {
-		return startKey(c.Tag, c.Arg.Value(), height)
+		return startKey(c.Tag, c.Arg.Value(), strconv.FormatInt(height, 10))
 	}
 	return startKey(c.Tag, c.Arg.Value())
 }
 
-func startKey(fields ...interface{}) string {
+func startKey(fields ...string) string {
 	return store.GenerateKey(fields)
 }

--- a/store/kv.go
+++ b/store/kv.go
@@ -1,11 +1,10 @@
 package store
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"path"
 	"path/filepath"
+	"strings"
 	"time"
 
 	ds "github.com/ipfs/go-datastore"
@@ -40,14 +39,10 @@ func PrefixEntries(ctx context.Context, store ds.Datastore, prefix string) (dsq.
 	return results, nil
 }
 
-// GenerateKey ...
-func GenerateKey(fields []interface{}) string {
-	var b bytes.Buffer
-	b.WriteString("/")
-	for _, f := range fields {
-		b.Write([]byte(fmt.Sprintf("%v", f) + "/"))
-	}
-	return path.Clean(b.String())
+// GenerateKey creates a key from a slice of string fields, joining them with slashes.
+func GenerateKey(fields []string) string {
+	key := "/" + strings.Join(fields, "/")
+	return path.Clean(key)
 }
 
 // rootify works just like in cosmos-sdk

--- a/store/store.go
+++ b/store/store.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"strconv"
 	"sync/atomic"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -242,15 +243,15 @@ func (s *DefaultStore) loadHashFromIndex(ctx context.Context, height uint64) (he
 }
 
 func getBlockKey(hash types.Hash) string {
-	return GenerateKey([]interface{}{blockPrefix, hex.EncodeToString(hash[:])})
+	return GenerateKey([]string{blockPrefix, hex.EncodeToString(hash[:])})
 }
 
 func getCommitKey(hash types.Hash) string {
-	return GenerateKey([]interface{}{commitPrefix, hex.EncodeToString(hash[:])})
+	return GenerateKey([]string{commitPrefix, hex.EncodeToString(hash[:])})
 }
 
 func getIndexKey(height uint64) string {
-	return GenerateKey([]interface{}{indexPrefix, height})
+	return GenerateKey([]string{indexPrefix, strconv.FormatUint(height, 10)})
 }
 
 func getStateKey() string {
@@ -258,7 +259,7 @@ func getStateKey() string {
 }
 
 func getResponsesKey(height uint64) string {
-	return GenerateKey([]interface{}{responsesPrefix, height})
+	return GenerateKey([]string{responsesPrefix, strconv.FormatUint(height, 10)})
 }
 
 func getMetaKey(key string) string {

--- a/store/store.go
+++ b/store/store.go
@@ -263,5 +263,5 @@ func getResponsesKey(height uint64) string {
 }
 
 func getMetaKey(key string) string {
-	return GenerateKey([]interface{}{metaPrefix, key})
+	return GenerateKey([]string{metaPrefix, key})
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
Resolves #1492
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
    - Enhanced type safety and clarity in key generation processes across various components by transitioning from interface slices to string slices and incorporating `strconv.FormatInt` for integer to string conversion.
    - Simplified the key generation logic by refactoring the `GenerateKey` function to accept a slice of strings and using `strings.Join` for string manipulation.
    - Removed outdated logic related to height conditions in query processing for a cleaner and more efficient approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->