### PR TITLE
Create an enum for "nodetype" instead of passing "light" and "full" as string literals to functions

### DIFF
--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -27,14 +27,14 @@ import (
 // simply check that node is starting and stopping without panicking
 func TestStartup(t *testing.T) {
 	ctx := context.Background()
-	node := initAndStartNodeWithCleanup(ctx, t, "full")
+	node := initAndStartNodeWithCleanup(ctx, t, Full)
 	require.IsType(t, new(FullNode), node)
 }
 
 func TestMempoolDirectly(t *testing.T) {
 	ctx := context.Background()
 
-	fn := initAndStartNodeWithCleanup(ctx, t, "full")
+	fn := initAndStartNodeWithCleanup(ctx, t, Full)
 	require.IsType(t, new(FullNode), fn)
 
 	node := fn.(*FullNode)
@@ -48,7 +48,7 @@ func TestMempoolDirectly(t *testing.T) {
 func TestTrySyncNextBlockMultiple(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	node, signingKey := setupTestNode(ctx, t, "full")
+	node, signingKey := setupTestNode(ctx, t, Full)
 	fullNode, ok := node.(*FullNode)
 	require.True(t, ok)
 	store := fullNode.Store
@@ -92,7 +92,7 @@ func TestTrySyncNextBlockMultiple(t *testing.T) {
 func TestInvalidBlocksIgnored(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	node, signingKey := setupTestNode(ctx, t, "full")
+	node, signingKey := setupTestNode(ctx, t, Full)
 	fullNode, ok := node.(*FullNode)
 	require.True(t, ok)
 	store := fullNode.Store

--- a/node/light_client_test.go
+++ b/node/light_client_test.go
@@ -17,7 +17,7 @@ import (
 func TestLightClient_Panics(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	ln := initAndStartNodeWithCleanup(ctx, t, "light")
+	ln := initAndStartNodeWithCleanup(ctx, t, Light)
 	require.IsType(t, new(LightNode), ln)
 
 	tests := []struct {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -20,6 +20,13 @@ var MockServerAddr = ":7980"
 
 var MockNamespace = "00000000000000000000000000000000000000000000000000deadbeef"
 
+type NodeType int
+
+const (
+	Full NodeType = iota
+	Light
+)
+
 // startNode starts the full node and stops it when the test is done
 func startNodeWithCleanup(t *testing.T, node Node) {
 	require.False(t, node.IsRunning())
@@ -37,7 +44,7 @@ func cleanUpNode(node Node, t *testing.T) {
 }
 
 // initializeAndStartNode initializes and starts a node of the specified type.
-func initAndStartNodeWithCleanup(ctx context.Context, t *testing.T, nodeType string) Node {
+func initAndStartNodeWithCleanup(ctx context.Context, t *testing.T, nodeType NodeType) Node {
 	node, _ := setupTestNode(ctx, t, nodeType)
 	startNodeWithCleanup(t, node)
 
@@ -45,7 +52,7 @@ func initAndStartNodeWithCleanup(ctx context.Context, t *testing.T, nodeType str
 }
 
 // setupTestNode sets up a test node based on the NodeType.
-func setupTestNode(ctx context.Context, t *testing.T, nodeType string) (Node, ed25519.PrivKey) {
+func setupTestNode(ctx context.Context, t *testing.T, nodeType NodeType) (Node, ed25519.PrivKey) {
 	node, privKey, err := newTestNode(ctx, t, nodeType)
 	require.NoError(t, err)
 	require.NotNil(t, node)
@@ -54,12 +61,12 @@ func setupTestNode(ctx context.Context, t *testing.T, nodeType string) (Node, ed
 }
 
 // newTestNode creates a new test node based on the NodeType.
-func newTestNode(ctx context.Context, t *testing.T, nodeType string) (Node, ed25519.PrivKey, error) {
+func newTestNode(ctx context.Context, t *testing.T, nodeType NodeType) (Node, ed25519.PrivKey, error) {
 	config := config.NodeConfig{DAAddress: MockServerAddr, DANamespace: MockNamespace}
 	switch nodeType {
-	case "light":
+	case Light:
 		config.Light = true
-	case "full":
+	case Full:
 		config.Light = false
 	default:
 		panic(fmt.Sprintf("invalid node type: %v", nodeType))
@@ -81,8 +88,8 @@ func newTestNode(ctx context.Context, t *testing.T, nodeType string) (Node, ed25
 func TestNewNode(t *testing.T) {
 	ctx := context.Background()
 
-	ln := initAndStartNodeWithCleanup(ctx, t, "light")
+	ln := initAndStartNodeWithCleanup(ctx, t, Light)
 	require.IsType(t, new(LightNode), ln)
-	fn := initAndStartNodeWithCleanup(ctx, t, "full")
+	fn := initAndStartNodeWithCleanup(ctx, t, Full)
 	require.IsType(t, new(FullNode), fn)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

```golang
type NodeType int

const (
	Full NodeType = iota
	Light
)
```

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced test code maintainability by replacing hard-coded string literals with constants and introducing a `NodeType` enum for clarity in node-related tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->