### PR TITLE
fix(store): avoid set height when GetState() to fix randomly block height mismatch error when start gm rollup

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -120,6 +120,8 @@ type Manager struct {
 func getInitialState(store store.Store, genesis *cmtypes.GenesisDoc) (types.State, error) {
 	// Load the state from store.
 	s, err := store.GetState(context.Background())
+	store.SetHeight(context.Background(), s.LastBlockHeight)
+
 	if errors.Is(err, ds.ErrNotFound) {
 		// If the user is starting a fresh chain (or hard-forking), we assume the stored state is empty.
 		s, err = types.NewFromGenesisDoc(genesis)

--- a/block/manager.go
+++ b/block/manager.go
@@ -120,7 +120,6 @@ type Manager struct {
 func getInitialState(store store.Store, genesis *cmtypes.GenesisDoc) (types.State, error) {
 	// Load the state from store.
 	s, err := store.GetState(context.Background())
-	store.SetHeight(context.Background(), s.LastBlockHeight)
 
 	if errors.Is(err, ds.ErrNotFound) {
 		// If the user is starting a fresh chain (or hard-forking), we assume the stored state is empty.
@@ -128,7 +127,6 @@ func getInitialState(store store.Store, genesis *cmtypes.GenesisDoc) (types.Stat
 		if err != nil {
 			return types.State{}, err
 		}
-		store.SetHeight(context.Background(), s.LastBlockHeight)
 	} else if err != nil {
 		return types.State{}, err
 	} else {
@@ -159,6 +157,9 @@ func NewManager(
 	execMetrics *state.Metrics,
 ) (*Manager, error) {
 	s, err := getInitialState(store, genesis)
+	//set block height in store
+	store.SetHeight(context.Background(), s.LastBlockHeight)
+
 	if err != nil {
 		return nil, err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -205,7 +205,6 @@ func (s *DefaultStore) GetState(ctx context.Context) (types.State, error) {
 
 	var state types.State
 	err = state.FromProto(&pbState)
-	s.height.Store(state.LastBlockHeight)
 	return state, err
 }
 

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -158,13 +158,15 @@ func TestRestart(t *testing.T) {
 	require.NoError(err)
 
 	s2 := New(kv)
-	_, err = s2.GetState(ctx)
+	assert.NoError(err)
+
+	state2, err := s2.GetState(ctx)
 	assert.NoError(err)
 
 	err = s2.Close()
 	assert.NoError(err)
 
-	assert.Equal(expectedHeight, s2.Height())
+	assert.Equal(expectedHeight, state2.LastBlockHeight)
 }
 
 func TestBlockResponses(t *testing.T) {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview
resolve https://github.com/rollkit/rollkit/issues/1573
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

[Store height](https://github.com/vuong177/rollkit/blob/18dc8d32555ecfb754d2327dc3ff2711bc7851f1/store/store.go#L30) can be set to current state [LastBlockHeight](https://github.com/vuong177/rollkit/blob/18dc8d32555ecfb754d2327dc3ff2711bc7851f1/types/state.go#L37) by call [GetState()](https://github.com/vuong177/rollkit/blob/18dc8d32555ecfb754d2327dc3ff2711bc7851f1/store/store.go#L193).  

So there's a potential vectors that make rollkit sequence halt :
 1. When publish block n, between [update store height](https://github.com/vuong177/rollkit/blob/18dc8d32555ecfb754d2327dc3ff2711bc7851f1/block/manager.go#L775) and  update new state via [updateState](https://github.com/vuong177/rollkit/blob/18dc8d32555ecfb754d2327dc3ff2711bc7851f1/block/manager.go#L806),it's possible to set the `store height` to old state height (n-1) by call `GetState`.
 2. When publish block n+1, current block height is `n-1` instead of `n`. It lead to block mismatch err `block.Height() != state.LastBlockHeight+1`
 
This PR is to remove setHeight in GetState() function, which fix the problem above.


## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved the initial state setup process for enhanced reliability during state retrieval.
	- Modified the `TestRestart` test function for more accurate state comparison.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->