### PR TITLE
add header and header by hash methods to jsonrpc

### DIFF
--- a/rpc/json/service.go
+++ b/rpc/json/service.go
@@ -67,6 +67,8 @@ func newService(c rpcclient.Client, l log.Logger) *service {
 		"block_by_hash":        newMethod(s.BlockByHash),
 		"block_results":        newMethod(s.BlockResults),
 		"commit":               newMethod(s.Commit),
+		"header":               newMethod(s.Header),
+		"header_by_hash":       newMethod(s.HeaderByHash),
 		"check_tx":             newMethod(s.CheckTx),
 		"tx":                   newMethod(s.Tx),
 		"tx_search":            newMethod(s.TxSearch),
@@ -190,6 +192,14 @@ func (s *service) BlockResults(req *http.Request, args *blockResultsArgs) (*ctyp
 
 func (s *service) Commit(req *http.Request, args *commitArgs) (*ctypes.ResultCommit, error) {
 	return s.client.Commit(req.Context(), (*int64)(&args.Height))
+}
+
+func (s *service) Header(req *http.Request, args *headerArgs) (*ctypes.ResultHeader, error) {
+	return s.client.Header(req.Context(), (*int64)(&args.Height))
+}
+
+func (s *service) HeaderByHash(req *http.Request, args *headerByHashArgs) (*ctypes.ResultHeader, error) {
+	return s.client.HeaderByHash(req.Context(), args.Hash)
 }
 
 func (s *service) CheckTx(req *http.Request, args *checkTxArgs) (*ctypes.ResultCheckTx, error) {

--- a/rpc/json/types.go
+++ b/rpc/json/types.go
@@ -47,6 +47,12 @@ type blockResultsArgs struct {
 type commitArgs struct {
 	Height StrInt64 `json:"height"`
 }
+type headerArgs struct {
+	Height StrInt64 `json:"height"`
+}
+type headerByHashArgs struct {
+	Hash []byte `json:"hash"`
+}
 type checkTxArgs struct {
 	Tx types.Tx `json:"tx"`
 }


### PR DESCRIPTION
fixes #1268 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Added functionality to query block headers by height and hash in the service.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->