### PR TITLE
fix(executor): limit block to da max blob size

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 A modular framework for rollups, with an ABCI-compatible client interface. For more in-depth information about Rollkit, please visit our [website](https://rollkit.dev).
 
 <!-- markdownlint-disable MD013 -->
-[![build-and-test](https://github.com/rollkit/rollkit/actions/workflows/test.yml/badge.svg)](https://github.com/rollkit/rollkit/actions/workflows/test.yml)  
-[![golangci-lint](https://github.com/rollkit/rollkit/actions/workflows/lint.yml/badge.svg)](https://github.com/rollkit/rollkit/actions/workflows/lint.yml)  
-[![Go Report Card](https://goreportcard.com/badge/github.com/rollkit/rollkit)](https://goreportcard.com/report/github.com/rollkit/rollkit)  
-[![codecov](https://codecov.io/gh/rollkit/rollkit/branch/main/graph/badge.svg?token=CWGA4RLDS9)](https://codecov.io/gh/rollkit/rollkit)  
+[![build-and-test](https://github.com/rollkit/rollkit/actions/workflows/test.yml/badge.svg)](https://github.com/rollkit/rollkit/actions/workflows/test.yml)
+[![golangci-lint](https://github.com/rollkit/rollkit/actions/workflows/lint.yml/badge.svg)](https://github.com/rollkit/rollkit/actions/workflows/lint.yml)
+[![Go Report Card](https://goreportcard.com/badge/github.com/rollkit/rollkit)](https://goreportcard.com/report/github.com/rollkit/rollkit)
+[![codecov](https://codecov.io/gh/rollkit/rollkit/branch/main/graph/badge.svg?token=CWGA4RLDS9)](https://codecov.io/gh/rollkit/rollkit)
 [![GoDoc](https://godoc.org/github.com/rollkit/rollkit?status.svg)](https://godoc.org/github.com/rollkit/rollkit)
 <!-- markdownlint-enable MD013 -->
 
@@ -88,7 +88,7 @@ it is recommended to Rollkit v0.11.x.
 
 ### Tools
 
-1. Install [golangci-lint](https://golangci-lint.run/usage/install/)
+1. Install [golangci-lint](https://golangci-lint.run/welcome/install/)
 1. Install [markdownlint](https://github.com/DavidAnson/markdownlint)
 1. Install [hadolint](https://github.com/hadolint/hadolint)
 1. Install [yamllint](https://yamllint.readthedocs.io/en/stable/quickstart.html)

--- a/block/manager.go
+++ b/block/manager.go
@@ -196,7 +196,12 @@ func NewManager(
 		return nil, err
 	}
 
-	exec := state.NewBlockExecutor(proposerAddress, genesis.ChainID, mempool, proxyApp, eventBus, logger, execMetrics, valSet.Hash())
+	maxBlobSize, err := dalc.DA.MaxBlobSize(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	exec := state.NewBlockExecutor(proposerAddress, genesis.ChainID, mempool, proxyApp, eventBus, maxBlobSize, logger, execMetrics, valSet.Hash())
 	if s.LastBlockHeight+1 == uint64(genesis.InitialHeight) {
 		res, err := exec.InitChain(genesis)
 		if err != nil {

--- a/block/manager.go
+++ b/block/manager.go
@@ -38,6 +38,10 @@ const defaultBlockTime = 1 * time.Second
 // defaultMempoolTTL is the number of blocks until transaction is dropped from mempool
 const defaultMempoolTTL = 25
 
+// blockProtocolOverhead is the protocol overhead when marshaling the block to blob
+// see: https://gist.github.com/tuxcanfly/80892dde9cdbe89bfb57a6cb3c27bae2
+const blockProtocolOverhead = 1 << 16
+
 // maxSubmitAttempts defines how many times Rollkit will re-try to publish block to DA layer.
 // This is temporary solution. It will be removed in future versions.
 const maxSubmitAttempts = 30
@@ -200,6 +204,8 @@ func NewManager(
 	if err != nil {
 		return nil, err
 	}
+	// allow buffer for the block header and protocol encoding
+	maxBlobSize -= blockProtocolOverhead
 
 	exec := state.NewBlockExecutor(proposerAddress, genesis.ChainID, mempool, proxyApp, eventBus, maxBlobSize, logger, execMetrics, valSet.Hash())
 	if s.LastBlockHeight+1 == uint64(genesis.InitialHeight) {

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -27,7 +27,7 @@ import (
 
 // MockServerAddr is the address used by the mock gRPC service
 // NOTE: this should be unique per test package to avoid
-// "bind: listen address alreaady in use" because multiple packages
+// "bind: listen address already in use" because multiple packages
 // are tested in parallel
 var MockServerAddr = "127.0.0.1:7990"
 

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -84,6 +84,16 @@ func doTestCreateBlock(t *testing.T) {
 	require.NoError(err)
 	require.NotNil(block)
 	assert.Len(block.Data.Txs, 2)
+
+	// limit max bytes
+	mpool.Flush()
+	executor.maxBytes = 10
+	err = mpool.CheckTx(make([]byte, 10), func(r *abci.ResponseCheckTx) {}, mempool.TxInfo{})
+	require.NoError(err)
+	block, err = executor.CreateBlock(4, &types.Commit{}, []byte{}, state)
+	require.NoError(err)
+	require.NotNil(block)
+	assert.Empty(block.Data.Txs)
 }
 
 func TestCreateBlockWithFraudProofsDisabled(t *testing.T) {

--- a/state/executor_test.go
+++ b/state/executor_test.go
@@ -50,7 +50,7 @@ func doTestCreateBlock(t *testing.T) {
 	fmt.Println("Made NID")
 	mpool := mempool.NewCListMempool(cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client, proxy.NopMetrics()), 0)
 	fmt.Println("Made a NewTxMempool")
-	executor := NewBlockExecutor([]byte("test address"), "test", mpool, proxy.NewAppConnConsensus(client, proxy.NopMetrics()), nil, logger, NopMetrics(), types.GetRandomBytes(32))
+	executor := NewBlockExecutor([]byte("test address"), "test", mpool, proxy.NewAppConnConsensus(client, proxy.NopMetrics()), nil, 100, logger, NopMetrics(), types.GetRandomBytes(32))
 	fmt.Println("Made a New Block Executor")
 
 	state := types.State{}
@@ -157,7 +157,7 @@ func doTestApplyBlock(t *testing.T) {
 	state.ConsensusParams.Block.MaxBytes = 100
 	state.ConsensusParams.Block.MaxGas = 100000
 	chainID := "test"
-	executor := NewBlockExecutor(vKey.PubKey().Address().Bytes(), chainID, mpool, proxy.NewAppConnConsensus(client, proxy.NopMetrics()), eventBus, logger, NopMetrics(), types.GetRandomBytes(32))
+	executor := NewBlockExecutor(vKey.PubKey().Address().Bytes(), chainID, mpool, proxy.NewAppConnConsensus(client, proxy.NopMetrics()), eventBus, 100, logger, NopMetrics(), types.GetRandomBytes(32))
 
 	err = mpool.CheckTx([]byte{1, 2, 3, 4}, func(r *abci.ResponseCheckTx) {}, mempool.TxInfo{})
 	require.NoError(err)
@@ -260,7 +260,7 @@ func TestUpdateStateConsensusParams(t *testing.T) {
 	mpool := mempool.NewCListMempool(cfg.DefaultMempoolConfig(), proxy.NewAppConnMempool(client, proxy.NopMetrics()), 0)
 	eventBus := cmtypes.NewEventBus()
 	require.NoError(t, eventBus.Start())
-	executor := NewBlockExecutor([]byte("test address"), chainID, mpool, proxy.NewAppConnConsensus(client, proxy.NopMetrics()), eventBus, logger, NopMetrics(), types.GetRandomBytes(32))
+	executor := NewBlockExecutor([]byte("test address"), chainID, mpool, proxy.NewAppConnConsensus(client, proxy.NopMetrics()), eventBus, 100, logger, NopMetrics(), types.GetRandomBytes(32))
 
 	state := types.State{
 		ConsensusParams: cmproto.ConsensusParams{


### PR DESCRIPTION
## Overview

This PR adds a check on `createBlock` to make sure we never create a block which can never be submitted to the DA because of it's size. Fixes #1428 

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced block management by incorporating maximum block size configuration.
	- Added a mock gRPC server setup for improved testing capabilities.
	- Updated the README with new installation instructions for `golangci-lint`.

- **Improvements**
	- Updated block creation logic to enforce a maximum byte size limit, enhancing network efficiency and stability.

- **Tests**
	- Extended testing framework to include new scenarios testing the block size limit enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->