### PR TITLE
feat: Add limit for pending DA submission blocks

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -715,6 +715,10 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 		return ErrNotProposer
 	}
 
+	if m.conf.MaxPendingBlocks != 0 && m.pendingBlocks.numPendingBlocks() >= m.conf.MaxPendingBlocks {
+		return fmt.Errorf("number of blocks pending DA submission (%d) reached configured limit (%d)", m.pendingBlocks.numPendingBlocks(), m.conf.MaxPendingBlocks)
+	}
+
 	var (
 		lastCommit     *types.Commit
 		lastHeaderHash types.Hash

--- a/block/pending_blocks.go
+++ b/block/pending_blocks.go
@@ -79,6 +79,10 @@ func (pb *PendingBlocks) isEmpty() bool {
 	return pb.store.Height() == pb.lastSubmittedHeight.Load()
 }
 
+func (pb *PendingBlocks) numPendingBlocks() uint64 {
+	return pb.store.Height() - pb.lastSubmittedHeight.Load()
+}
+
 func (pb *PendingBlocks) setLastSubmittedHeight(ctx context.Context, newLastSubmittedHeight uint64) {
 	lsh := pb.lastSubmittedHeight.Load()
 

--- a/block/pending_blocks_test.go
+++ b/block/pending_blocks_test.go
@@ -97,6 +97,7 @@ func checkRequirements(ctx context.Context, t *testing.T, pb *PendingBlocks, nBl
 	blocks, err := pb.getPendingBlocks(ctx)
 	require.NoError(t, err)
 	require.Len(t, blocks, nBlocks)
+	require.Equal(t, uint64(len(blocks)), pb.numPendingBlocks())
 	require.True(t, sort.SliceIsSorted(blocks, func(i, j int) bool {
 		return blocks[i].Height() < blocks[j].Height()
 	}))

--- a/cmd/rollkit/docs/rollkit_start.md
+++ b/cmd/rollkit/docs/rollkit_start.md
@@ -40,6 +40,7 @@ rollkit start [flags]
       --rollkit.da_start_height uint                    starting DA block height (for syncing)
       --rollkit.lazy_aggregator                         wait for transactions, don't build empty blocks
       --rollkit.light                                   run light client
+      --rollkit.max_pending_blocks uint                 limit of blocks pending DA submission (0 for no limit)
       --rollkit.trusted_hash string                     initial trusted hash to start the header exchange service
       --rpc.grpc_laddr string                           GRPC listen address (BroadcastTx only). Port required
       --rpc.laddr string                                RPC listen address. Port required (default "tcp://127.0.0.1:26657")

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,8 @@ const (
 	FlagTrustedHash = "rollkit.trusted_hash"
 	// FlagLazyAggregator is a flag for enabling lazy aggregation
 	FlagLazyAggregator = "rollkit.lazy_aggregator"
+	// FlagMaxPendingBlocks is a flag to pause aggregator in case of large number of blocks pending DA submission
+	FlagMaxPendingBlocks = "rollkit.max_pending_blocks"
 )
 
 // NodeConfig stores Rollkit node configuration.
@@ -74,6 +76,9 @@ type BlockManagerConfig struct {
 	DAStartHeight uint64 `mapstructure:"da_start_height"`
 	// DAMempoolTTL is the number of DA blocks until transaction is dropped from the mempool.
 	DAMempoolTTL uint64 `mapstructure:"da_mempool_ttl"`
+	// MaxPendingBlocks defines limit of blocks pending DA submission. 0 means no limit.
+	// When limit is reached, aggregator pauses block production.
+	MaxPendingBlocks uint64 `mapstructure:"max_pending_blocks"`
 }
 
 // GetNodeConfig translates Tendermint's configuration into Rollkit configuration.
@@ -120,6 +125,7 @@ func (nc *NodeConfig) GetViperConfig(v *viper.Viper) error {
 	nc.Light = v.GetBool(FlagLight)
 	nc.TrustedHash = v.GetString(FlagTrustedHash)
 	nc.TrustedHash = v.GetString(FlagTrustedHash)
+	nc.MaxPendingBlocks = v.GetUint64(FlagMaxPendingBlocks)
 	return nil
 }
 
@@ -140,4 +146,5 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String(FlagDANamespace, def.DANamespace, "DA namespace to submit blob transactions")
 	cmd.Flags().Bool(FlagLight, def.Light, "run light client")
 	cmd.Flags().String(FlagTrustedHash, def.TrustedHash, "initial trusted hash to start the header exchange service")
+	cmd.Flags().Uint64(FlagMaxPendingBlocks, def.MaxPendingBlocks, "limit of blocks pending DA submission (0 for no limit)")
 }


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

A new function has been added to determine the number of pending blocks for DA submission, alongside a new config parameter to set a limit on this. If this limit is reached, the block production process gets paused. The necessary tests and command flags have also been included.

Resolves #1524

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a limit on the number of blocks pending submission to enhance system stability and manageability.
	- Added a new configuration option to set the maximum number of pending blocks during system initialization.
- **Tests**
	- Implemented new integration tests to verify the block submission limit functionality.
- **Documentation**
	- Updated documentation to include guidance on configuring the maximum number of pending blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->