### PR TITLE
test: add test for multiple rollups using the same namespace

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -634,6 +634,9 @@ func (m *Manager) processNextDABlock(ctx context.Context) error {
 			for _, block := range blockResp.Blocks {
 				// early validation to reject junk blocks
 				if !m.isUsingExpectedCentralizedSequencer(block) {
+					m.logger.Debug("skipping block from unexpected sequencer",
+						"blockHeight", block.Height(),
+						"blockHash", block.Hash().String())
 					continue
 				}
 				blockHash := block.Hash().String()

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
-	"github.com/rollkit/rollkit/types"
 	"testing"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 
 	goDATest "github.com/rollkit/go-da/test"
 	"github.com/rollkit/rollkit/da"
+	"github.com/rollkit/rollkit/types"
 )
 
 func getMockDA(t *testing.T) *da.DAClient {

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"github.com/rollkit/rollkit/types"
 	"testing"
 	"time"
 
@@ -44,7 +45,7 @@ func TestGetNodeHeight(t *testing.T) {
 	}
 	bmConfig := getBMConfig()
 	fullNode, _ := createAndConfigureNode(ctx, 0, true, false, keys, bmConfig, dalc, t)
-	lightNode, _ := createNode(ctx, 1, true, true, keys, bmConfig, t)
+	lightNode, _ := createNode(ctx, 1, true, true, keys, bmConfig, types.TestChainID, t)
 
 	startNodeWithCleanup(t, fullNode)
 	startNodeWithCleanup(t, lightNode)


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

A new test has been added to `full_node_integration_test.go` to simulate multiple rollups within the same namespace. This helps validate the operation of the app in a more complex environment. Additional debugging information is also now logged in `manager.go` if a block from an unexpected sequencer is skipped.

Resolves #883 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new integration test for validating the functionality of two rollup networks within a single namespace.
- **Bug Fixes**
	- Enhanced block processing logic to skip blocks from unexpected sequencers under specific conditions.
- **Tests**
	- Added support for `chainID` parameter in test setup functions to facilitate more comprehensive testing scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->