### PR TITLE
test: test P2P catchup

### DIFF
--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -710,17 +710,13 @@ func TestCatchUp(t *testing.T) {
 		name string
 		n    int
 	}{
-		//{
-		//	name: "small catch-up",
-		//	n:    10,
-		//},
-		//{
-		//	name: "medium catch-up",
-		//	n:    100,
-		//},
+		{
+			name: "small catch-up",
+			n:    200,
+		},
 		{
 			name: "large catch-up",
-			n:    1000,
+			n:    3000,
 		},
 	}
 
@@ -732,7 +728,7 @@ func TestCatchUp(t *testing.T) {
 }
 
 func doTestCatchup(t *testing.T, n int) {
-	t.Parallel()
+	//t.Parallel()
 	require := require.New(t)
 
 	const (
@@ -751,6 +747,8 @@ func doTestCatchup(t *testing.T, n int) {
 			DABlockTime: daBlockTime,
 			BlockTime:   blockTime,
 		},
+		types.TestChainID,
+		false,
 		t,
 	)
 	seq := nodes[0]

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -716,7 +716,7 @@ func TestCatchUp(t *testing.T) {
 		},
 		{
 			name: "large catch-up",
-			n:    3000,
+			n:    1000,
 		},
 	}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Resolves #1213.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added `doTestCatchup` function to ensure the system can catch up with a specified number of blocks during integration tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->