### PR TITLE
da: handle tx too large

### DIFF
--- a/da/da.go
+++ b/da/da.go
@@ -43,6 +43,9 @@ var (
 	// ErrTxSizeTooBig is the error message returned by the DA when tx size is too big
 	ErrTxSizeTooBig = errors.New("tx size is too big")
 
+	//ErrTxTooLarge is the err message returned by the DA when tx size is too large
+	ErrTxTooLarge = errors.New("tx too large")
+
 	// ErrContextDeadline is the error message returned by the DA when context deadline exceeds
 	ErrContextDeadline = errors.New("context deadline")
 )
@@ -160,7 +163,8 @@ func (dac *DAClient) SubmitBlocks(ctx context.Context, blocks []*types.Block, ma
 			status = StatusAlreadyInMempool
 		case strings.Contains(err.Error(), ErrTxIncorrectAccountSequence.Error()):
 			status = StatusAlreadyInMempool
-		case strings.Contains(err.Error(), ErrTxSizeTooBig.Error()):
+		case strings.Contains(err.Error(), ErrTxSizeTooBig.Error()),
+			strings.Contains(err.Error(), ErrTxTooLarge.Error()):
 			status = StatusTooBig
 		case strings.Contains(err.Error(), ErrContextDeadline.Error()):
 			status = StatusContextDeadline


### PR DESCRIPTION
## Overview

This PR updates the block submission loop to additionally handle `tx too large` error.

## Checklist

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced handling for transactions exceeding the maximum size limit.
- **Bug Fixes**
	- Updated logic to correctly handle oversized transactions.
- **Tests**
	- Added new test cases to verify the handling of transactions that are too large.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->