### PR TITLE
feat(ci): add running the cli on all supported os

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -53,7 +53,10 @@ jobs:
   cli:
     name: Test CLI
     needs: [setup]
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: set up go

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/url"
 	"os"
+	"time"
 
 	cmtcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
 	cometconf "github.com/cometbft/cometbft/config"
@@ -167,11 +168,18 @@ func NewRunNodeCmd() *cobra.Command {
 				return err
 			}
 			if !inCI {
-				// Block forever
+				// Block forever to force user to stop node
 				select {}
 			}
 
-			return nil
+			// CI mode. Wait for 5s and then verify the node is running before calling stop node.
+			time.Sleep(5 * time.Second)
+			if !rollnode.IsRunning() {
+				return fmt.Errorf("node is not running")
+
+			}
+
+			return rollnode.Stop()
 		},
 	}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

As a precursor to pushing `rollkit start` to more users, I'm adding multiple os testing to the cli ci testing.

Additionally, I extended the CI mode for `rollkit start` so that it runs for 5s, verifies it is still running, and then checks the error on stop to have better coverage.

NOTE: This will require an update to the branch protection rules for the updated CI names.