### PR TITLE
test: accept testing.T instead of assert.Assertion

### DIFF
--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -49,8 +49,7 @@ func TestMempoolDirectly(t *testing.T) {
 	require.IsType(t, new(FullNode), fn)
 
 	node := fn.(*FullNode)
-	assert := assert.New(t)
-	peerID := getPeerID(assert)
+	peerID := getPeerID(t)
 	verifyTransactions(node, peerID, t)
 	verifyMempoolSize(node, t)
 }
@@ -325,11 +324,11 @@ func generateSingleKey() crypto.PrivKey {
 }
 
 // getPeerID generates a peer ID
-func getPeerID(assert *assert.Assertions) peer.ID {
+func getPeerID(t *testing.T) peer.ID {
 	key := generateSingleKey()
 
 	peerID, err := peer.IDFromPrivateKey(key)
-	assert.NoError(err)
+	assert.NoError(t, err)
 	return peerID
 }
 

--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -51,8 +51,8 @@ func TestMempoolDirectly(t *testing.T) {
 	node := fn.(*FullNode)
 	assert := assert.New(t)
 	peerID := getPeerID(assert)
-	verifyTransactions(node, peerID, assert)
-	verifyMempoolSize(node, assert)
+	verifyTransactions(node, peerID, t)
+	verifyMempoolSize(node, t)
 }
 
 // Tests that the node is able to sync multiple blocks even if blocks arrive out of order
@@ -334,19 +334,20 @@ func getPeerID(assert *assert.Assertions) peer.ID {
 }
 
 // verifyTransactions checks if transactions are valid
-func verifyTransactions(node *FullNode, peerID peer.ID, assert *assert.Assertions) {
+func verifyTransactions(node *FullNode, peerID peer.ID, t *testing.T) {
 	transactions := []string{"tx1", "tx2", "tx3", "tx4"}
 	for _, tx := range transactions {
 		err := node.Mempool.CheckTx([]byte(tx), func(r *abci.ResponseCheckTx) {}, mempool.TxInfo{
 			SenderID: node.mempoolIDs.GetForPeer(peerID),
 		})
-		assert.NoError(err)
+		assert.NoError(t, err)
 	}
+
 }
 
 // verifyMempoolSize checks if the mempool size is as expected
-func verifyMempoolSize(node *FullNode, assert *assert.Assertions) {
-	assert.NoError(testutils.Retry(300, 100*time.Millisecond, func() error {
+func verifyMempoolSize(node *FullNode, t *testing.T) {
+	assert.NoError(t, testutils.Retry(300, 100*time.Millisecond, func() error {
 		expectedSize := uint64(4 * len("tx*"))
 		actualSize := uint64(node.Mempool.SizeBytes())
 		if expectedSize == actualSize {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Close #1320
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Updated test functions for better error handling in full node testing.
	- Modified function signatures in full_node_test.go to use *testing.T instead of *assert.Assertions.
	- Updated assertion calls within verifyTransactions and verifyMempoolSize functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->