### PR TITLE
feat: add goreleaser for prebuilt binaries

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -68,40 +68,6 @@ jobs:
       - name: Run cli
         run: rollkit start --ci
 
-  # get_merged_pr_labels uses the listPullRequestsAssociatedWithCommit API
-  # endpoint to get the PR information for the commit during a push event. Once
-  # the PR information is received, we check to see if the create-release label
-  # was added to the pr.
-  get_merged_pr_labels:
-    runs-on: ubuntu-latest
-    outputs:
-      has_release_label: ${{ steps.set-outputs.outputs.has_release_label }}
-    steps:
-      # We only want to run this step on a push event, otherwise this will error
-      # out as the result is null. We have the if condition here as to not block
-      # steps that rely on this step and others if this step is skipped.
-      - name: Query listPullRequestsAssociatedWithCommit for the PR information
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/github-script@v7
-        id: get_pr_data
-        with:
-          script: |
-            const prData = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              commit_sha: context.sha,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-            const pr = prData.data[0];
-            const prLabels = pr ? pr.labels.map(label => label.name) : [];
-            const hasReleaseLabel = prLabels.includes('create-release');
-            return { hasReleaseLabel };
-      # Only run if the result is not null. We add this check so that the CI
-      # does not show a failure when the previous step is skipped.
-      - name: Set the outputs
-        if: steps.get_pr_data.outputs.result != null
-        id: set-outputs
-        run: echo "has_release_label=${{ fromJSON(steps.get_pr_data.outputs.result).hasReleaseLabel }}" >> "$GITHUB_OUTPUT"
-
   # branch_name trims ref/heads/ from github.ref to access a clean branch name
   branch_name:
     runs-on: ubuntu-latest
@@ -114,7 +80,7 @@ jobs:
           echo "branch=$(${${{ github.ref }}:11})" >> $GITHUB_OUTPUT
 
   # Make a release if this is a manually trigger job, i.e. workflow_dispatch
-  release-dispatch:
+  release:
     needs: [lint, test, proto, branch_name]
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -126,22 +92,4 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           version-bump: ${{inputs.version}}
-          release-branch: ${{needs.branch_name.outputs.branch}}
-
-  # Make a release if there was a merged pr with the create-release label
-  release-merge:
-    needs: [lint, test, proto, get_merged_pr_labels, branch_name]
-    runs-on: ubuntu-latest
-    if: |
-      (github.event_name == 'push' &&
-      contains(github.ref, 'refs/heads/main') &&
-      needs.get_merged_pr_labels.outputs.has_release_label == 'true')
-    permissions: "write-all"
-    steps:
-      - uses: actions/checkout@v4
-      - name: Version Release
-        uses: rollkit/.github/.github/actions/version-release@v0.3.0
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          version-bump: "patch"
           release-branch: ${{needs.branch_name.outputs.branch}}

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,35 @@
+name: goreleaser
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  # Checks that the .goreleaser.yaml file is valid
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: check
+
+  goreleaser:
+    needs: goreleaser-check
+    runs-on: ubuntu-latest
+    permissions: write-all
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+      - name: Create .release-env file
+        run: |-
+          echo 'GITHUB_TOKEN=${{secrets.GORELEASER_TOKEN}}' >> .release-env
+      - name: Create prebuilt binaries and attach them to the GitHub release
+        run: make prebuilt-binary

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ types/pb/tendermint
 .vscode/launch.json
 */**.html
 *.idea
+*.env
+.*env

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,56 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+before:
+  hooks:
+    - go mod tidy
+builds:
+  - main: ./cmd/rollkit
+    binary: rollkit
+    env:
+      # NOTE: goreleaser doesn't fully support CGO natively. If CGO is needed
+      # for any node features, this should be removed and a workaround might
+      # need to be created.
+      # REF: https://goreleaser.com/limitations/cgo/
+      - CGO_ENABLED=0
+      - VersioningPath={{ "github.com/rollkit/rollkit/cmd/rollkit/commands" }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+    ldflags:
+      # Ref: https://goreleaser.com/customization/templates/#common-fields
+      #
+      # .CommitDate is used to help with reproducible builds, ensuring that the
+      # same date is always used
+      #
+      # .FullCommit is git commit hash goreleaser is using for the release
+      #
+      # .Version is the version being released
+      - -X "{{ .Env.VersioningPath }}.GitSHA={{ .FullCommit }}"
+      - -X "{{ .Env.VersioningPath }}.Version={{ .Version }}"
+dist: ./build/goreleaser
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of
+    # uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+checksum:
+  name_template: "checksums.txt"
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+git:
+  prerelease_suffix: "-"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Closes #1683 

This PR copies over how celestia-app has implemented the goreleaser. 
The goreleaser CI calls a makefile command so that in the event the CI fails, we can manually trigger the builds. 

Tested on a temp repo:
1. Pushing a tag locally triggers goreleaser to generate the release with the binaries.
2. Creating a release via the github ui triggers goreleaser to update the release with the binaries. 
3. Deleted the binaries from v0.2.0 release to mimic the github action failing and pushed new ones locally with the makefile command. 

https://github.com/MSevey/rollkit-temp/actions/workflows/goreleaser.yml
https://github.com/MSevey/rollkit-temp/releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to exclude `.env` and `.*env` files.
  - Refined GitHub Actions workflows for better release management.
  - Introduced a new Goreleaser configuration for automated Go project releases.

- **New Features**
  - Added support for creating prebuilt binaries for GitHub releases using Docker in the Makefile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->