### PR TITLE
fix: golangci and markdown lint errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,6 @@
 run:
   timeout: 5m
   modules-download-mode: readonly
-  # mempool and indexer code is borrowed from Tendermint
-  skip-dirs:
-    - mempool
-    - state/indexer
-    - state/txindex
-    - third_party
 
 linters:
   enable:
@@ -27,6 +21,12 @@ linters:
 
 issues:
   exclude-use-default: false
+  # mempool and indexer code is borrowed from Tendermint
+  exclude-dirs:
+    - mempool
+    - state/indexer
+    - state/txindex
+    - third_party
   include:
     - EXC0012 # EXC0012 revive: Annoying issue about not having a comment. The rare codebase has such comments
     - EXC0014 # EXC0014 revive: Annoying issue about not having a comment. The rare codebase has such comments

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A modular framework for rollups, with an ABCI-compatible client interface. For m
 <!-- markdownlint-enable MD013 -->
 
 ## Using Rollkit
+
 ### Rollkit CLI
 
 The easiest way to use rollkit is via the rollkit CLI.
@@ -52,7 +53,6 @@ range of data availability layers, settlement layers, and execution
 environments.
 
 Check out our tutorials on our [website][docs].
-
 
 ## Contributing
 
@@ -104,10 +104,9 @@ Graph](https://github.com/rollkit/rollkit/blob/main/specs/src/specs/rollkit-depe
 
 ## Audits
 
-| Date       | Auditor                                       | Version                                                                             | Report                                                  |
-|------------|-----------------------------------------------|-------------------------------------------------------------------------------------|---------------------------------------------------------|
-| 2024/01/12  | [Informal Systems](https://informal.systems/) | [eccdd...bcb9d](https://github.com/rollkit/rollkit/commit/eccdd0f1793a5ac532011ef4d896de9e0d8bcb9d)   | [informal-systems.pdf](specs/audit/informal-systems.pdf) |
+| Date | Auditor | Version | Report |
+|---|---|---|---|
+| 2024/01/12 | [Informal Systems](https://informal.systems/) | [eccdd...bcb9d](https://github.com/rollkit/rollkit/commit/eccdd0f1793a5ac532011ef4d896de9e0d8bcb9d) | [informal-systems.pdf](specs/audit/informal-systems.pdf) |
 | 2024/01/10 | [Binary Builders](https://binary.builders/)   | [eccdd...bcb9d](https://github.com/rollkit/rollkit/commit/eccdd0f1793a5ac532011ef4d896de9e0d8bcb9d) | [binary-builders.pdf](specs/audit/binary-builders.pdf)   |
-
 
 [docs]: https://rollkit.dev

--- a/cmd/rollkit/commands/version.go
+++ b/cmd/rollkit/commands/version.go
@@ -29,9 +29,9 @@ var VersionCmd = &cobra.Command{
 			return errors.New("version not set")
 		}
 		w := tabwriter.NewWriter(os.Stdout, 2, 0, 2, ' ', 0)
-		fmt.Fprintf(w, "\nrollkit version:\t%v\n", Version)
-		fmt.Fprintf(w, "rollkit git sha:\t%v\n", GitSHA)
-		fmt.Fprintln(w, "")
-		return w.Flush()
+		_, err1 := fmt.Fprintf(w, "\nrollkit version:\t%v\n", Version)
+		_, err2 := fmt.Fprintf(w, "rollkit git sha:\t%v\n", GitSHA)
+		_, err3 := fmt.Fprintln(w, "")
+		return errors.Join(err1, err2, err3, w.Flush())
 	},
 }


### PR DESCRIPTION
golangci-lint uses v1.59 in the ci so developers need to ensure they have 1.59+ installed locally to catch lint errors.


Fixes: https://github.com/rollkit/rollkit/actions/runs/9260526579/job/25474463023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Reorganized sections and improved formatting in the README for better clarity.

- **Bug Fixes**
  - Enhanced error handling in the version command output to ensure errors are captured and reported properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->