### PR TITLE
feat: `rollkit rebuild` - helper command to use in between `toml init` and `start`

### DIFF
--- a/cmd/rollkit/commands/rebuild.go
+++ b/cmd/rollkit/commands/rebuild.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	rollconf "github.com/rollkit/rollkit/config"
+
+	"github.com/spf13/cobra"
+)
+
+// RebuildCmd is a command to rebuild rollup entrypoint
+var RebuildCmd = &cobra.Command{
+	Use:   "rebuild",
+	Short: "Rebuild rollup entrypoint",
+	Long:  "Rebuild rollup entrypoint specified in the rollkit.toml",
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+		rollkitConfig, err = rollconf.ReadToml()
+		if err != nil {
+			fmt.Printf("Could not read rollkit.toml file: %s", err)
+			os.Exit(1)
+		}
+
+		if _, err := buildEntrypoint(rollkitConfig.RootDir, rollkitConfig.Entrypoint, true); err != nil {
+			fmt.Printf("Could not rebuild rollup entrypoint: %s", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/cmd/rollkit/docs/rollkit.md
+++ b/cmd/rollkit/docs/rollkit.md
@@ -23,6 +23,7 @@ If a path is not specified for RKHOME, the rollkit command will create a folder 
 
 * [rollkit completion](rollkit_completion.md)	 - Generate the autocompletion script for the specified shell
 * [rollkit docs-gen](rollkit_docs-gen.md)	 - Generate documentation for rollkit CLI
+* [rollkit rebuild](rollkit_rebuild.md)	 - Rebuild rollup entrypoint
 * [rollkit start](rollkit_start.md)	 - Run the rollkit node
 * [rollkit toml](rollkit_toml.md)	 - TOML file operations
 * [rollkit version](rollkit_version.md)	 - Show version info

--- a/cmd/rollkit/docs/rollkit_rebuild.md
+++ b/cmd/rollkit/docs/rollkit_rebuild.md
@@ -1,0 +1,29 @@
+## rollkit rebuild
+
+Rebuild rollup entrypoint
+
+### Synopsis
+
+Rebuild rollup entrypoint specified in the rollkit.toml
+
+```
+rollkit rebuild [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rebuild
+```
+
+### Options inherited from parent commands
+
+```
+      --home string        directory for config and data (default "HOME/.rollkit")
+      --log_level string   set the log level; default is info. other options include debug, info, error, none (default "info")
+      --trace              print out full stack trace on errors
+```
+
+### SEE ALSO
+
+* [rollkit](rollkit.md)	 - A modular framework for rollups, with an ABCI-compatible client interface.

--- a/cmd/rollkit/main.go
+++ b/cmd/rollkit/main.go
@@ -21,6 +21,7 @@ func main() {
 		cmd.NewRunNodeCmd(),
 		cmd.VersionCmd,
 		cmd.NewTomlCmd(),
+		cmd.RebuildCmd,
 	)
 
 	// In case there is a rollkit.toml file in the current dir or somewhere up the


### PR DESCRIPTION
Will make a PR after #1680 is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced the `rollkit rebuild` command to the CLI tool, allowing users to rebuild a rollup entrypoint based on the configuration in `rollkit.toml`.
  - Added detailed documentation for the new `rollkit rebuild` command.
  
- **Documentation**
  - Updated `rollkit.md` to include information about the new `rollkit rebuild` command.
  - Added `rollkit_rebuild.md` to provide comprehensive details and options for the `rollkit rebuild` command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->