### PR TITLE
chore: bump goreleaser version

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
-      - uses: goreleaser/goreleaser-action@v5
+      - uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -81,3 +81,14 @@ jobs:
             echo "$DIFF"
             exit 1
           fi
+
+  # Checks that the .goreleaser.yaml file is valid
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: check

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,6 @@
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+version: 2
 before:
   hooks:
     - go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ lint: vet
 	@hadolint test/docker/mockserv.Dockerfile
 	@echo "--> Running yamllint"
 	@yamllint --no-warnings . -c .yamllint.yml
+	@echo "--> Running goreleaser check"
+	@goreleaser check
+	@echo "--> Running actionlint"
+	@actionlint
 
 .PHONY: lint
 


### PR DESCRIPTION


<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
This is a breaking change for developers running make lint locally. Developers need to have goreleaser and actionlint installed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `goreleaser/goreleaser-action` GitHub Action from v5 to v6 for improved functionality.

- **New Features**
  - Added a job to validate the `.goreleaser.yaml` file in the lint workflow.
  - Introduced a `version` field and a `before` section with `go mod tidy` hook in `.goreleaser.yaml`.

- **Refactor**
  - Enhanced the `lint` target in the Makefile with new commands: `goreleaser check` and `actionlint`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->