### PR TITLE
test: add extra error handling to startNodes helper function

### DIFF
--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -730,6 +730,14 @@ func getMockApplication() *mocks.Application {
 // Starts the given nodes using the given wait group to synchronize them
 // and wait for them to gossip transactions
 func startNodes(nodes []*FullNode, apps []*mocks.Application, t *testing.T) {
+	// stop the nodes in case of a failure during start procedure
+	defer func() {
+		if t.Failed() {
+			for _, n := range nodes {
+				assert.NoError(t, n.Stop())
+			}
+		}
+	}()
 
 	// Wait for aggregator node to publish the first block for full nodes to initialize header exchange service
 	require.NoError(t, nodes[0].Start())


### PR DESCRIPTION
In the full node integration test, a defer function has been added to stop all nodes if an error occurs during the start procedure. This ensures that all initiated nodes are properly stopped.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Resolves #1685.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
