### PR TITLE
fix(executor): nil error is passed as %w to fmt.Errrof

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -209,7 +209,7 @@ func (e *BlockExecutor) ApplyBlock(ctx context.Context, state types.State, block
 		return types.State{}, nil, err
 	}
 	if !isAppValid {
-		return types.State{}, nil, fmt.Errorf("error while processing the proposal: %w", err)
+		return types.State{}, nil, fmt.Errorf("proposal processing resulted in an invalid application state")
 	}
 
 	err = e.Validate(state, block)


### PR DESCRIPTION
This PR updates the error message in ApplyBlock to prevent passing a nil error with %w to fmt.Errorf. Fixes https://github.com/rollkit/rollkit/issues/1695

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error message clarity for proposal processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->