### PR TITLE
feat: rollkit rebuild command to update entrypoint

### DIFF
--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -71,7 +71,7 @@ func buildEntrypoint(rootDir, entrypointSourceFile string, forceRebuild bool) (s
 
 	if !cometos.FileExists(entrypointBinaryFile) || forceRebuild {
 		if !cometos.FileExists(entrypointSourceFile) {
-			return "", fmt.Errorf("no entrypoint file: %s", entrypointSourceFile)
+			return "", fmt.Errorf("no entrypoint source file: %s", entrypointSourceFile)
 		}
 
 		// try to build the entrypoint as a go binary

--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -65,7 +65,7 @@ readTOML:
 	return true, runEntrypoint(&rollkitConfig, flags)
 }
 
-func entrypointBinaryFilePath(rootDir, entrypointSourceFile string, forceRebuild bool) (string, error) {
+func buildEntrypoint(rootDir, entrypointSourceFile string, forceRebuild bool) (string, error) {
 	// The entrypoint binary file is always in the same directory as the rollkit.toml file.
 	entrypointBinaryFile := filepath.Join(rootDir, rollupBinEntrypoint)
 
@@ -101,7 +101,7 @@ func RunRollupEntrypoint(rollkitConfig *rollconf.TomlConfig, args []string) erro
 		entrypointSourceFile = rollkitConfig.Entrypoint
 	}
 
-	entrypointBinary, err := entrypointBinaryFilePath(rollkitConfig.RootDir, entrypointSourceFile, false)
+	entrypointBinary, err := buildEntrypoint(rollkitConfig.RootDir, entrypointSourceFile, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -65,7 +65,7 @@ readTOML:
 	return true, runEntrypoint(&rollkitConfig, flags)
 }
 
-func buildEntrypoint(rootDir, entrypointSourceFile string, forceRebuild bool) (string, error) {
+func entrypointBinaryFilePath(rootDir, entrypointSourceFile string, forceRebuild bool) (string, error) {
 	// The entrypoint binary file is always in the same directory as the rollkit.toml file.
 	entrypointBinaryFile := filepath.Join(rootDir, rollupBinEntrypoint)
 
@@ -101,7 +101,7 @@ func RunRollupEntrypoint(rollkitConfig *rollconf.TomlConfig, args []string) erro
 		entrypointSourceFile = rollkitConfig.Entrypoint
 	}
 
-	entrypointBinary, err := buildEntrypoint(rollkitConfig.RootDir, entrypointSourceFile, false)
+	entrypointBinary, err := entrypointBinaryFilePath(rollkitConfig.RootDir, entrypointSourceFile, false)
 	if err != nil {
 		return err
 	}

--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -101,7 +101,7 @@ func RunRollupEntrypoint(rollkitConfig *rollconf.TomlConfig, args []string) erro
 		entrypointSourceFile = rollkitConfig.Entrypoint
 	}
 
-	entrypointBinary, err := buildEntrypoint(rollkitConfig.RootDir, entrypointSourceFile, false)
+	entrypointBinaryFilePath, err := buildEntrypoint(rollkitConfig.RootDir, entrypointSourceFile, false)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func RunRollupEntrypoint(rollkitConfig *rollconf.TomlConfig, args []string) erro
 		runArgs = append(runArgs, "--home", rollkitConfig.Chain.ConfigDir)
 	}
 
-	entrypointCmd := exec.Command(entrypointBinary, runArgs...) //nolint:gosec
+	entrypointCmd := exec.Command(entrypointBinaryFilePath, runArgs...) //nolint:gosec
 	entrypointCmd.Stdout = os.Stdout
 	entrypointCmd.Stderr = os.Stderr
 

--- a/cmd/rollkit/commands/rebuild.go
+++ b/cmd/rollkit/commands/rebuild.go
@@ -1,8 +1,7 @@
 package commands
 
 import (
-	"fmt"
-	"os"
+	"log"
 
 	rollconf "github.com/rollkit/rollkit/config"
 

--- a/cmd/rollkit/commands/rebuild.go
+++ b/cmd/rollkit/commands/rebuild.go
@@ -18,8 +18,7 @@ var RebuildCmd = &cobra.Command{
 		var err error
 		rollkitConfig, err = rollconf.ReadToml()
 		if err != nil {
-			fmt.Printf("Could not read rollkit.toml file: %s", err)
-			os.Exit(1)
+			log.Fatalf("Could not read rollkit.toml file: %s", err)
 		}
 
 		if _, err := buildEntrypoint(rollkitConfig.RootDir, rollkitConfig.Entrypoint, true); err != nil {

--- a/cmd/rollkit/commands/rebuild.go
+++ b/cmd/rollkit/commands/rebuild.go
@@ -1,0 +1,30 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	rollconf "github.com/rollkit/rollkit/config"
+
+	"github.com/spf13/cobra"
+)
+
+// RebuildCmd is a command to rebuild rollup entrypoint
+var RebuildCmd = &cobra.Command{
+	Use:   "rebuild",
+	Short: "Rebuild rollup entrypoint",
+	Long:  "Rebuild rollup entrypoint specified in the rollkit.toml",
+	Run: func(cmd *cobra.Command, args []string) {
+		var err error
+		rollkitConfig, err = rollconf.ReadToml()
+		if err != nil {
+			fmt.Printf("Could not read rollkit.toml file: %s", err)
+			os.Exit(1)
+		}
+
+		if _, err := buildEntrypoint(rollkitConfig.RootDir, rollkitConfig.Entrypoint, true); err != nil {
+			fmt.Printf("Could not rebuild rollup entrypoint: %s", err)
+			os.Exit(1)
+		}
+	},
+}

--- a/cmd/rollkit/commands/rebuild.go
+++ b/cmd/rollkit/commands/rebuild.go
@@ -22,8 +22,7 @@ var RebuildCmd = &cobra.Command{
 		}
 
 		if _, err := buildEntrypoint(rollkitConfig.RootDir, rollkitConfig.Entrypoint, true); err != nil {
-			fmt.Printf("Could not rebuild rollup entrypoint: %s", err)
-			os.Exit(1)
+			log.Fatalf("Could not rebuild rollup entrypoint: %s", err)
 		}
 	},
 }

--- a/cmd/rollkit/docs/rollkit.md
+++ b/cmd/rollkit/docs/rollkit.md
@@ -23,6 +23,7 @@ If a path is not specified for RKHOME, the rollkit command will create a folder 
 
 * [rollkit completion](rollkit_completion.md)	 - Generate the autocompletion script for the specified shell
 * [rollkit docs-gen](rollkit_docs-gen.md)	 - Generate documentation for rollkit CLI
+* [rollkit rebuild](rollkit_rebuild.md)	 - Rebuild rollup entrypoint
 * [rollkit start](rollkit_start.md)	 - Run the rollkit node
 * [rollkit toml](rollkit_toml.md)	 - TOML file operations
 * [rollkit version](rollkit_version.md)	 - Show version info

--- a/cmd/rollkit/docs/rollkit_rebuild.md
+++ b/cmd/rollkit/docs/rollkit_rebuild.md
@@ -26,4 +26,4 @@ rollkit rebuild [flags]
 
 ### SEE ALSO
 
-* [rollkit](rollkit.md)	 - A modular framework for rollups, with an ABCI-compatible client interface.
+* [rollkit](rollkit.md)	 - The first sovereign rollup framework that allows you to launch a sovereign, customizable blockchain as easily as a smart contract.

--- a/cmd/rollkit/docs/rollkit_rebuild.md
+++ b/cmd/rollkit/docs/rollkit_rebuild.md
@@ -1,0 +1,29 @@
+## rollkit rebuild
+
+Rebuild rollup entrypoint
+
+### Synopsis
+
+Rebuild rollup entrypoint specified in the rollkit.toml
+
+```
+rollkit rebuild [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for rebuild
+```
+
+### Options inherited from parent commands
+
+```
+      --home string        directory for config and data (default "HOME/.rollkit")
+      --log_level string   set the log level; default is info. other options include debug, info, error, none (default "info")
+      --trace              print out full stack trace on errors
+```
+
+### SEE ALSO
+
+* [rollkit](rollkit.md)	 - A modular framework for rollups, with an ABCI-compatible client interface.

--- a/cmd/rollkit/main.go
+++ b/cmd/rollkit/main.go
@@ -21,6 +21,7 @@ func main() {
 		cmd.NewRunNodeCmd(),
 		cmd.VersionCmd,
 		cmd.NewTomlCmd(),
+		cmd.RebuildCmd,
 	)
 
 	// In case there is a rollkit.toml file in the current dir or somewhere up the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `rebuild` command to the CLI for rebuilding the rollup entrypoint based on configuration in `rollkit.toml`.

- **Refactor**
  - Improved the logic for building and running entrypoint binaries by introducing a dedicated function to handle the build process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->