### PR TITLE
fix: intercepting stdin

### DIFF
--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -117,6 +117,7 @@ func RunRollupEntrypoint(rollkitConfig *rollconf.TomlConfig, args []string) erro
 	entrypointCmd := exec.Command(entrypointBinaryFilePath, runArgs...) //nolint:gosec
 	entrypointCmd.Stdout = os.Stdout
 	entrypointCmd.Stderr = os.Stderr
+	entrypointCmd.Stdin = os.Stdin
 
 	if err := entrypointCmd.Run(); err != nil {
 		return fmt.Errorf("failed to run entrypoint: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where command execution did not correctly handle user input by setting the standard input for command execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->