### PR TITLE
refactor: return types.State{} instead of state for err != nil case

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -299,7 +299,7 @@ func (e *BlockExecutor) updateState(state types.State, block *types.Block, final
 	if finalizeBlockResponse.ConsensusParamUpdates != nil {
 		nextParamsProto, appVersion, err := e.updateConsensusParams(height, types.ConsensusParamsFromProto(state.ConsensusParams), finalizeBlockResponse.ConsensusParamUpdates)
 		if err != nil {
-			return state, err
+			return types.State{}, err
 		}
 		// Change results from this height but only applies to the next height.
 		state.LastHeightConsensusParamsChanged = height + 1


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview
Closes: #1734 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling in state updates to ensure a clean state is returned in error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->