### PR TITLE
fix(ci): update error checking for CLI ci to catch errors

### DIFF
--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -179,6 +179,13 @@ func NewRunNodeCmd() *cobra.Command {
 
 			// CI mode. Wait for 5s and then verify the node is running before calling stop node.
 			time.Sleep(5 * time.Second)
+			res, err := rollnode.GetClient().ABCIInfo(context.Background())
+			if err != nil {
+				return err
+			}
+			if res.Response.LastBlockHeight == 0 {
+				return fmt.Errorf("node hasn't produced any blocks")
+			}
 			if !rollnode.IsRunning() {
 				return fmt.Errorf("node is not running")
 

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -179,11 +179,11 @@ func NewRunNodeCmd() *cobra.Command {
 
 			// CI mode. Wait for 5s and then verify the node is running before calling stop node.
 			time.Sleep(5 * time.Second)
-			res, err := rollnode.GetClient().ABCIInfo(context.Background())
+			res, err := rollnode.GetClient().Block(context.Background(), nil)
 			if err != nil {
 				return err
 			}
-			if res.Response.LastBlockHeight == 0 {
+			if res.Block.Height  == 0 {
 				return fmt.Errorf("node hasn't produced any blocks")
 			}
 			if !rollnode.IsRunning() {

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -188,7 +188,7 @@ func NewRunNodeCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if res.Block.Height  == 0 {
+			if res.Block.Height == 0 {
 				return fmt.Errorf("node hasn't produced any blocks")
 			}
 			if !rollnode.IsRunning() {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Related to #1736

CI wasn't catching errors when the node can't start but also can't stop. 

Note: this is uncovering a bug on main so the CI is expected to now be failing until the fix is corrected. 

```
rollkit % rollkit start --ci
Error intercepting command:  Reading rollkit.toml: no rollkit.toml found
I[2024-06-27|11:27:00.328] Found private validator                      module=main keyFile=/Users/matt/.rollkit/config/priv_validator_key.json stateFile=/Users/matt/.rollkit/data/priv_validator_state.json
I[2024-06-27|11:27:00.328] Found node key                               module=main path=/Users/matt/.rollkit/config/node_key.json
I[2024-06-27|11:27:00.328] Found genesis file                           module=main path=/Users/matt/.rollkit/config/genesis.json
I[2024-06-27|11:27:00.331] service start                                module=proxy msg="Starting multiAppConn service" impl=multiAppConn
I[2024-06-27|11:27:00.331] service start                                module=abci-client connection=query msg="Starting localClient service" impl=localClient
I[2024-06-27|11:27:00.332] service start                                module=abci-client connection=snapshot msg="Starting localClient service" impl=localClient
I[2024-06-27|11:27:00.332] service start                                module=abci-client connection=mempool msg="Starting localClient service" impl=localClient
I[2024-06-27|11:27:00.332] service start                                module=abci-client connection=consensus msg="Starting localClient service" impl=localClient
I[2024-06-27|11:27:00.332] service start                                module=events msg="Starting EventBus service" impl=EventBus
I[2024-06-27|11:27:00.332] service start                                module=pubsub msg="Starting PubSub service" impl=PubSub
I[2024-06-27|11:27:00.370] Using default mempool ttl                    module=BlockManager MempoolTTL=25
I[2024-06-27|11:27:00.373] service start                                module=txindex msg="Starting IndexerService service" impl=IndexerService
I[2024-06-27|11:27:00.373] service start                                module=main msg="Starting RPC service" impl=RPC
I[2024-06-27|11:27:00.373] service start                                module=main msg="Starting Node service" impl=Node
I[2024-06-27|11:27:00.373] starting P2P client                          module=main
I[2024-06-27|11:27:00.373] serving HTTP                                 module=main listenaddress=127.0.0.1:26657
I[2024-06-27|11:27:00.381] listening on                                 module=p2p address=/ip4/127.0.0.1/tcp/26656/p2p/12D3KooWA5tb8TCm9i2rBxEE7gwKRxWi5afrAXLKCsca12V8d3Y4
I[2024-06-27|11:27:00.381] listening on                                 module=p2p address=/ip4/192.168.1.160/tcp/26656/p2p/12D3KooWA5tb8TCm9i2rBxEE7gwKRxWi5afrAXLKCsca12V8d3Y4
I[2024-06-27|11:27:00.381] no seed nodes - only listening for connections module=p2p
E[2024-06-27|11:27:00.382] failed to parse peer                         module=HeaderSyncService address= error="failed to parse multiaddr \"\": empty multiaddr"
E[2024-06-27|11:27:00.382] failed to parse peer                         module=BlockSyncService address= error="failed to parse multiaddr \"\": empty multiaddr"
I[2024-06-27|11:27:00.383] Started node                                 module=main
ERROR: node hasn't produced any blocks
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Added a check to ensure nodes have produced blocks before stopping, to prevent errors during the shutdown process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->