### PR TITLE
fix: revert using agg mode by default

### DIFF
--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -58,6 +58,11 @@ func NewRunNodeCmd() *cobra.Command {
 				return err
 			}
 
+			// use aggregator by default
+			if !cmd.Flags().Lookup("rollkit.aggregator").Changed {
+				nodeConfig.Aggregator = true
+			}
+
 			// Update log format if the flag is set
 			if config.LogFormat == cometconf.LogFormatJSON {
 				logger = cometlog.NewTMJSONLogger(cometlog.NewSyncWriter(os.Stdout))


### PR DESCRIPTION
Closes #1736 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a default setting for the aggregator, making `nodeConfig.Aggregator` true by default if the `"rollkit.aggregator"` flag is not specified. This simplifies the configuration process for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->