### PR TITLE
docs: update links to sync_service.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Explore the CLI documentation [here](./cmd/rollkit/docs/rollkit.md)
 
 ## Building with Rollkit
 
-Rollkit is the first sovereign rollup framework that allows you to launch a sovereign, customizable blockchain as easily as a smart contract.
+Rollkit is the first sovereign rollup framework that allows you to launch
+a sovereign, customizable blockchain as easily as a smart contract.
 
 Check out our tutorials on our [website][docs].
 

--- a/block/block-manager.md
+++ b/block/block-manager.md
@@ -185,7 +185,7 @@ See [tutorial] for running a multi-node network with both sequencer and non-sequ
 [defaultLazyBlockTime]: https://github.com/rollkit/rollkit/blob/main/block/manager.go#L39
 [initialBackoff]: https://github.com/rollkit/rollkit/blob/main/block/manager.go#L59
 [go-header]: https://github.com/celestiaorg/go-header
-[block-sync]: https://github.com/rollkit/rollkit/blob/main/block/block_sync.go
+[block-sync]: https://github.com/rollkit/rollkit/blob/main/block/sync_service.go
 [full-node]: https://github.com/rollkit/rollkit/blob/main/node/full.go
 [block-manager]: https://github.com/rollkit/rollkit/blob/main/block/manager.go
 [tutorial]: https://rollkit.dev/guides/full-and-sequencer-node

--- a/block/header-sync.md
+++ b/block/header-sync.md
@@ -36,11 +36,11 @@ The sequencer node, upon successfully creating the block, publishes the signed b
 
 ## Implementation
 
-The header sync implementation can be found in [node/header_sync.go][header sync]. The full and light nodes create and start the header sync service under [full][fullnode] and [light][lightnode].
+The header sync implementation can be found in [block/sync_service.go][sync-service]. The full and light nodes create and start the header sync service under [full][fullnode] and [light][lightnode].
 
 ## References
 
-[1] [Header Sync][header sync]
+[1] [Header Sync][sync-service]
 
 [2] [Full Node][fullnode]
 
@@ -48,7 +48,7 @@ The header sync implementation can be found in [node/header_sync.go][header sync
 
 [4] [go-header][go-header]
 
-[header sync]: https://github.com/rollkit/rollkit/blob/main/block/header_sync.go
+[sync-service]: https://github.com/rollkit/rollkit/blob/main/block/sync_service.go
 [fullnode]: https://github.com/rollkit/rollkit/blob/main/node/full.go
 [lightnode]: https://github.com/rollkit/rollkit/blob/main/node/light.go
 [go-header]: https://github.com/celestiaorg/go-header

--- a/node/full_node.md
+++ b/node/full_node.md
@@ -102,5 +102,5 @@ See [full node]
 [store interface]: https://github.com/rollkit/rollkit/blob/main/store/types.go
 [Block Manager]: https://github.com/rollkit/rollkit/blob/main/block/manager.go
 [dalc]: https://github.com/rollkit/rollkit/blob/main/da/da.go
-[Header Sync Service]: https://github.com/rollkit/rollkit/blob/main/block/header_sync.go
-[Block Sync Service]: https://github.com/rollkit/rollkit/blob/main/block/block_sync.go
+[Header Sync Service]: https://github.com/rollkit/rollkit/blob/main/block/sync_service.go
+[Block Sync Service]: https://github.com/rollkit/rollkit/blob/main/block/sync_service.go


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

After the `block_sync.go` and `header_sync.go` was removed (merged into `sync_service.go`, links in `.md` files are dead.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated descriptions in README to emphasize Rollkit's role in launching customizable blockchains.
  - Fixed broken links in `block-manager.md` and `header-sync.md` to point to the correct sync service files.
  - Adjusted file paths for `Header Sync Service` and `Block Sync Service` links in `full_node.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->