### PR TITLE
Proposer address should be from node's proposerKey when create new block manager

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -195,7 +195,10 @@ func NewManager(
 		conf.DAMempoolTTL = defaultMempoolTTL
 	}
 
-	proposerAddress := s.Validators.Proposer.Address.Bytes()
+	proposerAddress, err := getAddress(proposerKey)
+	if err != nil {
+		return nil, err
+	}
 
 	maxBlobSize, err := dalc.DA.MaxBlobSize(context.Background())
 	if err != nil {
@@ -262,6 +265,13 @@ func NewManager(
 		isProposer:    isProposer,
 	}
 	return agg, nil
+}
+func getAddress(key crypto.PrivKey) ([]byte, error) {
+	rawKey, err := key.GetPublic().Raw()
+	if err != nil {
+		return nil, err
+	}
+	return cmcrypto.AddressHash(rawKey), nil
 }
 
 // SetDALC is used to set DataAvailabilityLayerClient used by Manager.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview
Since we re-enable ABCI change valset,  proposer address should be from node's proposerKey rather than from state when create new block manager. 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved error handling and address retrieval logic within manager initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->