### PR TITLE
fix(rpc): allow query latest block

### DIFF
--- a/rpc/json/service.go
+++ b/rpc/json/service.go
@@ -179,7 +179,12 @@ func (s *service) GenesisChunked(req *http.Request, args *genesisChunkedArgs) (*
 }
 
 func (s *service) Block(req *http.Request, args *blockArgs) (*ctypes.ResultBlock, error) {
-	return s.client.Block(req.Context(), (*int64)(&args.Height))
+	var height *int64
+	if args.Height != nil {
+		h := int64(*args.Height)
+		height = &h
+	}
+	return s.client.Block(req.Context(), height)
 }
 
 func (s *service) BlockByHash(req *http.Request, args *blockByHashArgs) (*ctypes.ResultBlock, error) {

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -64,10 +64,11 @@ func TestREST(t *testing.T) {
 		bodyContains string
 	}{
 
-		{"invalid/malformed request", "/block?so{}wrong!", http.StatusOK, int(json2.E_INVALID_REQ), ``},
-		{"invalid/missing param", "/block", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'height'`},
-		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
+		{"valid/malformed request", "/block?so{}wrong!", http.StatusOK, int(json2.E_INTERNAL), ``},
 		// to keep test simple, allow returning application error in following case
+		{"invalid/missing required param", "/header", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'height'`},
+		{"valid/missing optional param", "/block", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
+		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
 		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
 		{"invalid/int param", "/block?height=foo", http.StatusOK, int(json2.E_PARSE), "failed to parse param 'height'"},
 		{"valid/bool int string params",

--- a/rpc/json/types.go
+++ b/rpc/json/types.go
@@ -36,7 +36,7 @@ type genesisChunkedArgs struct {
 	ID StrInt `json:"chunk"`
 }
 type blockArgs struct {
-	Height StrInt64 `json:"height"`
+	Height *StrInt64 `json:"height"`
 }
 type blockByHashArgs struct {
 	Hash []byte `json:"hash"`


### PR DESCRIPTION
## Overview

Allow querying latest `/block` without requiring `?height=` param for CometBFT compat.

Fixes #1758 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced parameter handling to support `*StrInt64` type with improved error handling.

- **Bug Fixes**
  - Fixed handling of nullable `Height` parameter in `Block` function to prevent potential dereference issues.

- **Tests**
  - Updated test cases to cover scenarios for valid/malformed requests and different parameter conditions.

- **Refactor**
  - Modified `Height` field in `blockArgs` struct to use `*StrInt64` for better nullability support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->