### PR TITLE
chore(ci): use go.mod go version in CI

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -25,13 +25,9 @@ on:
 jobs:
   lint:
     uses: ./.github/workflows/lint.yml
-    with:
-      go-version: ./go.mod
 
   test:
     uses: ./.github/workflows/test.yml
-    with:
-      go-version: ./go.mod
 
   proto:
     uses: ./.github/workflows/proto.yml

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ./go.mod
+          go-version-file: ./go.mod
       - name: Build cli
         run: make install
       - name: Run cli

--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -23,36 +23,21 @@ on:
           - major
 
 jobs:
-  setup:
-    runs-on: ubuntu-latest
-    env:
-      # use consistent go version throughout pipeline here
-      GO_VERSION: "1.22"
-    outputs:
-      go-version: ${{ steps.set-vars.outputs.go-version }}
-    steps:
-      - name: Set go version
-        id: set-vars
-        run: echo "go-version=${{env.GO_VERSION}}" >> "$GITHUB_OUTPUT"
-
   lint:
-    needs: [setup]
     uses: ./.github/workflows/lint.yml
     with:
-      go-version: ${{ needs.setup.outputs.go-version }}
+      go-version: ./go.mod
 
   test:
-    needs: [setup]
     uses: ./.github/workflows/test.yml
     with:
-      go-version: ${{ needs.setup.outputs.go-version }}
+      go-version: ./go.mod
 
   proto:
     uses: ./.github/workflows/proto.yml
 
   cli:
     name: Test CLI
-    needs: [setup]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -62,7 +47,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ needs.setup.outputs.go-version }}
+          go-version: ./go.mod
       - name: Build cli
         run: make install
       - name: Run cli

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,6 @@
 name: lint
 on:
   workflow_call:
-    inputs:
-      go-version:
-        description: "Go version to use"
-        type: string
-        required: true
 
 jobs:
   golangci-lint:
@@ -17,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ./go.mod
         # This steps sets the GIT_DIFF environment variable to true
         # if files defined in PATTERS changed
       - uses: technote-space/get-diff-action@v6.1.2
@@ -69,7 +64,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ./go.mod
       - name: install rollkit cli
         run: make install
       - name: Generate Docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ./go.mod
+          go-version-file: ./go.mod
         # This steps sets the GIT_DIFF environment variable to true
         # if files defined in PATTERS changed
       - uses: technote-space/get-diff-action@v6.1.2
@@ -64,7 +64,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ./go.mod
+          go-version-file: ./go.mod
       - name: install rollkit cli
         run: make install
       - name: Generate Docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,6 @@
 name: Tests / Code Coverage
 on:
   workflow_call:
-    inputs:
-      go-version:
-        description: "Go version to use"
-        type: string
-        required: true
 
 jobs:
   go_mod_tidy_check:
@@ -17,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ./go.mod
       - run: go mod tidy
       - name: check for diff
         run: git diff --exit-code
@@ -30,7 +25,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ./go.mod
       - name: Run unit test
         run: make test
       - name: upload coverage report
@@ -47,6 +42,6 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ inputs.go-version }}
+          go-version: ./go.mod
       - name: Integration Tests
         run: echo "No integration tests yet"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ./go.mod
+          go-version-file: ./go.mod
       - run: go mod tidy
       - name: check for diff
         run: git diff --exit-code
@@ -25,7 +25,7 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ./go.mod
+          go-version-file: ./go.mod
       - name: Run unit test
         run: make test
       - name: upload coverage report
@@ -42,6 +42,6 @@ jobs:
       - name: set up go
         uses: actions/setup-go@v5
         with:
-          go-version: ./go.mod
+          go-version-file: ./go.mod
       - name: Integration Tests
         run: echo "No integration tests yet"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Ramin found a nice update, reapplying here. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub workflows to use the Go version specified in `./go.mod` instead of a separate `go-version` input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->