### PR TITLE
feat(rpc): add block tags

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -295,6 +295,21 @@ func (m *Manager) GetStoreHeight() uint64 {
 	return m.store.Height()
 }
 
+// GetDAIncludedHeight returns the manager's da included height
+// FIXME(tuxcanfly): this is in accurate before first retrieve loop
+func (m *Manager) GetDAIncludedHeight(ctx context.Context) uint64 {
+	for height := m.store.Height(); height > 0; height-- {
+		block, err := m.store.GetBlock(ctx, height)
+		if err != nil {
+			return 0
+		}
+		if m.IsDAIncluded(block.Hash()) {
+			return height
+		}
+	}
+	return 0
+}
+
 // GetBlockInCh returns the manager's blockInCh
 func (m *Manager) GetBlockInCh() chan NewBlockEvent {
 	return m.blockInCh

--- a/block/manager.go
+++ b/block/manager.go
@@ -275,8 +275,7 @@ func NewManager(
 
 func (m *Manager) init(ctx context.Context) {
 	// initialize da included height
-	height, err := m.store.GetMetadata(ctx, DAIncludedHeightKey)
-	if err == nil && len(height) == 8 {
+	if height, err := m.store.GetMetadata(ctx, DAIncludedHeightKey); err == nil && len(height) == 8 {
 		m.daIncludedHeight.Store(binary.BigEndian.Uint64(height))
 	}
 }

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -414,8 +414,8 @@ func Test_submitBlocksToDA_BlockMarshalErrorCase2(t *testing.T) {
 
 	store := mocks.NewStore(t)
 	invalidateBlockHeader(block3)
-	store.On("SetMetadata", ctx, DAIncludedKey, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}).Return(nil)
-	store.On("SetMetadata", ctx, DAIncludedKey, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}).Return(nil)
+	store.On("SetMetadata", ctx, DAIncludedHeightKey, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}).Return(nil)
+	store.On("SetMetadata", ctx, DAIncludedHeightKey, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}).Return(nil)
 	store.On("SetMetadata", ctx, LastSubmittedHeightKey, []byte(strconv.FormatUint(2, 10))).Return(nil)
 	store.On("GetMetadata", ctx, LastSubmittedHeightKey).Return(nil, ds.ErrNotFound)
 	store.On("GetBlock", ctx, uint64(1)).Return(block1, nil)

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -406,6 +406,8 @@ func Test_submitBlocksToDA_BlockMarshalErrorCase2(t *testing.T) {
 
 	store := mocks.NewStore(t)
 	invalidateBlockHeader(block3)
+	store.On("SetMetadata", ctx, DAIncludedKey, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}).Return(nil)
+	store.On("SetMetadata", ctx, DAIncludedKey, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}).Return(nil)
 	store.On("SetMetadata", ctx, LastSubmittedHeightKey, []byte(strconv.FormatUint(2, 10))).Return(nil)
 	store.On("GetMetadata", ctx, LastSubmittedHeightKey).Return(nil, ds.ErrNotFound)
 	store.On("GetBlock", ctx, uint64(1)).Return(block1, nil)

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -259,12 +259,38 @@ func TestSubmitBlocksToDA(t *testing.T) {
 		blocks                      []*types.Block
 		isErrExpected               bool
 		expectedPendingBlocksLength int
+		expectedDAIncludedHeight    uint64
 	}{
 		{
-			name:                        "happy path, all blocks A, B, C combine to less than maxDABlobSize",
-			blocks:                      []*types.Block{types.GetRandomBlock(1, 5), types.GetRandomBlock(2, 5), types.GetRandomBlock(3, 5)},
-			isErrExpected:               false,
-			expectedPendingBlocksLength: 0,
+			name: "B is too big on its own. So A gets submitted but, B and C never get submitted",
+			blocks: func() []*types.Block {
+				numBlocks, numTxs := 3, 5
+				blocks := make([]*types.Block, numBlocks)
+				blocks[0] = types.GetRandomBlock(uint64(1), numTxs)
+				blocks[1], err = getBlockBiggerThan(2, maxDABlobSizeLimit)
+				require.NoError(err)
+				blocks[2] = types.GetRandomBlock(uint64(3), numTxs)
+				return blocks
+			}(),
+			isErrExpected:               true,
+			expectedPendingBlocksLength: 2,
+			expectedDAIncludedHeight:    1,
+		},
+		{
+			name: "A and B are submitted successfully but C is too big on its own, so C never gets submitted",
+			blocks: func() []*types.Block {
+				numBlocks, numTxs := 3, 5
+				blocks := make([]*types.Block, numBlocks)
+				for i := 0; i < numBlocks-1; i++ {
+					blocks[i] = types.GetRandomBlock(uint64(i+1), numTxs)
+				}
+				blocks[2], err = getBlockBiggerThan(3, maxDABlobSizeLimit)
+				require.NoError(err)
+				return blocks
+			}(),
+			isErrExpected:               true,
+			expectedPendingBlocksLength: 1,
+			expectedDAIncludedHeight:    2,
 		},
 		{
 			name: "blocks A and B are submitted together without C because including C triggers blob size limit. C is submitted in a separate round",
@@ -286,35 +312,14 @@ func TestSubmitBlocksToDA(t *testing.T) {
 			}(),
 			isErrExpected:               false,
 			expectedPendingBlocksLength: 0,
+			expectedDAIncludedHeight:    3,
 		},
 		{
-			name: "A and B are submitted successfully but C is too big on its own, so C never gets submitted",
-			blocks: func() []*types.Block {
-				numBlocks, numTxs := 3, 5
-				blocks := make([]*types.Block, numBlocks)
-				for i := 0; i < numBlocks-1; i++ {
-					blocks[i] = types.GetRandomBlock(uint64(i+1), numTxs)
-				}
-				blocks[2], err = getBlockBiggerThan(3, maxDABlobSizeLimit)
-				require.NoError(err)
-				return blocks
-			}(),
-			isErrExpected:               true,
-			expectedPendingBlocksLength: 1,
-		},
-		{
-			name: "B is too big on its own. So A gets submitted but, B and C never get submitted",
-			blocks: func() []*types.Block {
-				numBlocks, numTxs := 3, 5
-				blocks := make([]*types.Block, numBlocks)
-				blocks[0] = types.GetRandomBlock(uint64(1), numTxs)
-				blocks[1], err = getBlockBiggerThan(2, maxDABlobSizeLimit)
-				require.NoError(err)
-				blocks[2] = types.GetRandomBlock(uint64(3), numTxs)
-				return blocks
-			}(),
-			isErrExpected:               true,
-			expectedPendingBlocksLength: 2,
+			name:                        "happy path, all blocks A, B, C combine to less than maxDABlobSize",
+			blocks:                      []*types.Block{types.GetRandomBlock(1, 5), types.GetRandomBlock(2, 5), types.GetRandomBlock(3, 5)},
+			isErrExpected:               false,
+			expectedPendingBlocksLength: 0,
+			expectedDAIncludedHeight:    3,
 		},
 	}
 
@@ -343,6 +348,9 @@ func TestSubmitBlocksToDA(t *testing.T) {
 			lshInKV, err := strconv.ParseUint(string(raw), 10, 64)
 			require.NoError(err)
 			assert.Equal(m.store.Height(), lshInKV+uint64(tc.expectedPendingBlocksLength))
+
+			// ensure that da included height is updated in KV store
+			assert.Equal(tc.expectedDAIncludedHeight, m.GetDAIncludedHeight())
 		})
 	}
 }

--- a/node/full_client.go
+++ b/node/full_client.go
@@ -420,7 +420,7 @@ func (c *FullClient) Block(ctx context.Context, height *int64) (*ctypes.ResultBl
 	switch {
 	// block tag = included
 	case height != nil && *height == -1:
-		heightValue = c.node.blockManager.GetDAIncludedHeight(ctx)
+		heightValue = c.node.blockManager.GetDAIncludedHeight()
 	default:
 		heightValue = c.normalizeHeight(height)
 	}

--- a/rpc/json/handler.go
+++ b/rpc/json/handler.go
@@ -215,6 +215,14 @@ func setPointerParam(rawVal string, args *reflect.Value, i int) error {
 	}
 	field := args.Elem().Field(i)
 	switch field.Type() {
+	case reflect.TypeOf((*BlockNumber)(nil)):
+		var bn BlockNumber
+		err := bn.UnmarshalJSON([]byte(rawVal))
+		if err != nil {
+			return err
+		}
+		args.Elem().Field(i).Set(reflect.ValueOf(&bn))
+		return nil
 	case reflect.TypeOf((*StrInt64)(nil)):
 		val, err := strconv.ParseInt(rawVal, 10, 64)
 		if err != nil {

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -68,6 +68,7 @@ func TestREST(t *testing.T) {
 		// to keep test simple, allow returning application error in following case
 		{"invalid/missing required param", "/tx", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'hash'`},
 		{"valid/missing optional param", "/block", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
+		{"valid/included block tag param", "/block?height=included", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
 		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
 		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
 		{"invalid/int param", "/block?height=foo", http.StatusOK, int(json2.E_PARSE), "failed to parse param 'height'"},

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -394,39 +394,6 @@ func TestRESTSerialization(t *testing.T) {
 	}
 }
 
-func TestUnmarshalBlockNumber(t *testing.T) {
-	tests := []struct {
-		name    string
-		input   []byte
-		want    BlockNumber
-		wantErr bool
-	}{
-		{"Earliest", []byte(`"earliest"`), EarliestBlockNumber, false},
-		{"Included", []byte(`"included"`), IncludedBlockNumber, false},
-		{"PositiveInteger", []byte(`42`), BlockNumber(42), false},
-		{"NegativeInteger", []byte(`-10`), BlockNumber(-10), false},
-		{"Zero", []byte(`0`), BlockNumber(0), false},
-		{"QuotedInteger", []byte(`"123"`), BlockNumber(123), false},
-		{"InvalidString", []byte(`"invalid"`), BlockNumber(0), true},
-		{"InvalidJSON", []byte(`{`), BlockNumber(0), true},
-		{"UnsupportedType", []byte(`true`), BlockNumber(0), true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var got BlockNumber
-			err := unmarshalBlockNumber(tt.input, &got)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("unmarshalBlockNumber() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if !tt.wantErr && got != tt.want {
-				t.Errorf("unmarshalBlockNumber() got = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestBlockNumber_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -394,6 +394,72 @@ func TestRESTSerialization(t *testing.T) {
 	}
 }
 
+func TestUnmarshalBlockNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []byte
+		want    BlockNumber
+		wantErr bool
+	}{
+		{"Earliest", []byte(`"earliest"`), EarliestBlockNumber, false},
+		{"Included", []byte(`"included"`), IncludedBlockNumber, false},
+		{"PositiveInteger", []byte(`42`), BlockNumber(42), false},
+		{"NegativeInteger", []byte(`-10`), BlockNumber(-10), false},
+		{"Zero", []byte(`0`), BlockNumber(0), false},
+		{"QuotedInteger", []byte(`"123"`), BlockNumber(123), false},
+		{"InvalidString", []byte(`"invalid"`), BlockNumber(0), true},
+		{"InvalidJSON", []byte(`{`), BlockNumber(0), true},
+		{"UnsupportedType", []byte(`true`), BlockNumber(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got BlockNumber
+			err := unmarshalBlockNumber(tt.input, &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("unmarshalBlockNumber() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("unmarshalBlockNumber() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBlockNumber_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    BlockNumber
+		wantErr bool
+	}{
+		{"Earliest", `"earliest"`, EarliestBlockNumber, false},
+		{"Included", `"included"`, IncludedBlockNumber, false},
+		{"PositiveInteger", `42`, BlockNumber(42), false},
+		{"NegativeInteger", `-10`, BlockNumber(-10), false},
+		{"Zero", `0`, BlockNumber(0), false},
+		{"QuotedInteger", `"123"`, BlockNumber(123), false},
+		{"InvalidString", `"invalid"`, BlockNumber(0), true},
+		{"InvalidJSON", `{`, BlockNumber(0), true},
+		{"UnsupportedType", `true`, BlockNumber(0), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got BlockNumber
+			err := json.Unmarshal([]byte(tt.input), &got)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("BlockNumber.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got != tt.want {
+				t.Errorf("BlockNumber.UnmarshalJSON() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func mustGetPubKey(b64 string) ed25519.PubKey {
 	decodeString, err := base64.StdEncoding.DecodeString(b64)
 	if err != nil {

--- a/rpc/json/types.go
+++ b/rpc/json/types.go
@@ -172,7 +172,8 @@ const (
 	EarliestBlockNumber = BlockNumber(1)
 )
 
-func unmarshalBlockNumber(b []byte, bn *BlockNumber) error {
+// UnmarshalJSON parses JSON (int or block tag quoted as string) into BlockNumber
+func (bn *BlockNumber) UnmarshalJSON(b []byte) error {
 	input := strings.TrimSpace(string(b))
 	if len(input) >= 2 && input[0] == '"' && input[len(input)-1] == '"' {
 		input = input[1 : len(input)-1]
@@ -202,11 +203,6 @@ func unmarshalBlockNumber(b []byte, bn *BlockNumber) error {
 	}
 
 	return nil
-}
-
-// UnmarshalJSON parses JSON (int or block tag quoted as string) into BlockNumber
-func (bn *BlockNumber) UnmarshalJSON(b []byte) error {
-	return unmarshalBlockNumber(b, bn)
 }
 
 func unmarshalStrInt64(b []byte, s *StrInt64) error {


### PR DESCRIPTION
## Overview

Partially fixes #762 

This PR allows RPC to query for the DA included block height by using the block tag `included`, similar to eth tags like `finalized`, `safe`, `pending` etc. For simplicity, we use only 2 tags:

- `earliest` - literal 1
- `included` - highest DA included rollup block

Example request:

```sh
    curl localhost:26657/block\?height=included
``` 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
    - Introduced functionality to persist and retrieve a specific height value in the Manager.
    - Added handling for BlockNumber type parameters in JSON RPC requests.

- **Enhancements**
    - Updated block handling to manage block tags and height values more effectively.
    - Enhanced test cases to cover various block submission scenarios based on size and constraints.

- **Bug Fixes**
    - Improved error handling and added new test cases for the /block endpoint in JSON RPC to ensure accurate responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->