### PR TITLE
fix(rpc): optional params

### DIFF
--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -66,7 +66,7 @@ func TestREST(t *testing.T) {
 
 		{"valid/malformed request", "/block?so{}wrong!", http.StatusOK, int(json2.E_INTERNAL), ``},
 		// to keep test simple, allow returning application error in following case
-		{"invalid/missing required param", "/header", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'height'`},
+		{"invalid/missing required param", "/tx", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'hash'`},
 		{"valid/missing optional param", "/block", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
 		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
 		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
@@ -148,31 +148,31 @@ func TestSubscription(t *testing.T) {
 	assert := assert.New(t)
 	require := require.New(t)
 
-	const (
+	var (
 		query        = "message.sender='cosmos1njr26e02fjcq3schxstv458a3w5szp678h23dh'"
 		query2       = "message.sender CONTAINS 'cosmos1njr26e02fjcq3schxstv458a3w5szp678h23dh'"
 		invalidQuery = "message.sender='broken"
 	)
 	subscribeReq, err := json2.EncodeClientRequest("subscribe", &subscribeArgs{
-		Query: query,
+		Query: &query,
 	})
 	require.NoError(err)
 	require.NotEmpty(subscribeReq)
 
 	subscribeReq2, err := json2.EncodeClientRequest("subscribe", &subscribeArgs{
-		Query: query2,
+		Query: &query2,
 	})
 	require.NoError(err)
 	require.NotEmpty(subscribeReq2)
 
 	invalidSubscribeReq, err := json2.EncodeClientRequest("subscribe", &subscribeArgs{
-		Query: invalidQuery,
+		Query: &invalidQuery,
 	})
 	require.NoError(err)
 	require.NotEmpty(invalidSubscribeReq)
 
 	unsubscribeReq, err := json2.EncodeClientRequest("unsubscribe", &unsubscribeArgs{
-		Query: query,
+		Query: &query,
 	})
 	require.NoError(err)
 	require.NotEmpty(unsubscribeReq)

--- a/rpc/json/types.go
+++ b/rpc/json/types.go
@@ -11,13 +11,14 @@ import (
 )
 
 type subscribeArgs struct {
-	Query string `json:"query"`
+	Query *string `json:"query"`
 }
+
 type unsubscribeArgs struct {
-	Query string `json:"query"`
+	Query *string `json:"query"`
 }
-type unsubscribeAllArgs struct {
-}
+
+type unsubscribeAllArgs struct{}
 
 // info API
 type healthArgs struct {
@@ -27,69 +28,83 @@ type statusArgs struct {
 type netInfoArgs struct {
 }
 type blockchainInfoArgs struct {
-	MinHeight StrInt64
-	MaxHeight StrInt64
+	MinHeight *StrInt64 `json:"minHeight"`
+	MaxHeight *StrInt64 `json:"maxHeight"`
 }
-type genesisArgs struct {
-}
+
+type genesisArgs struct{}
+
 type genesisChunkedArgs struct {
 	ID StrInt `json:"chunk"`
 }
+
 type blockArgs struct {
 	Height *StrInt64 `json:"height"`
 }
+
 type blockByHashArgs struct {
 	Hash []byte `json:"hash"`
 }
+
 type blockResultsArgs struct {
-	Height StrInt64 `json:"height"`
+	Height *StrInt64 `json:"height"`
 }
+
 type commitArgs struct {
-	Height StrInt64 `json:"height"`
+	Height *StrInt64 `json:"height"`
 }
+
 type headerArgs struct {
-	Height StrInt64 `json:"height"`
+	Height *StrInt64 `json:"height"`
 }
+
 type headerByHashArgs struct {
 	Hash []byte `json:"hash"`
 }
+
 type checkTxArgs struct {
 	Tx types.Tx `json:"tx"`
 }
+
 type txArgs struct {
 	Hash  []byte `json:"hash"`
 	Prove bool   `json:"prove"`
 }
+
 type txSearchArgs struct {
-	Query   string `json:"query"`
-	Prove   bool   `json:"prove"`
-	Page    StrInt `json:"page"`
-	PerPage StrInt `json:"per_page"`
-	OrderBy string `json:"order_by"`
+	Query   string  `json:"query"`
+	Prove   bool    `json:"prove"`
+	Page    *StrInt `json:"page"`
+	PerPage *StrInt `json:"per_page"`
+	OrderBy *string `json:"order_by"`
 }
+
 type blockSearchArgs struct {
-	Query   string `json:"query"`
-	Page    StrInt `json:"page"`
-	PerPage StrInt `json:"per_page"`
-	OrderBy string `json:"order_by"`
+	Query   string  `json:"query"`
+	Page    *StrInt `json:"page"`
+	PerPage *StrInt `json:"per_page"`
+	OrderBy *string `json:"order_by"`
 }
+
 type validatorsArgs struct {
-	Height  StrInt64 `json:"height"`
-	Page    StrInt   `json:"page"`
-	PerPage StrInt   `json:"per_page"`
+	Height  *StrInt64 `json:"height"`
+	Page    *StrInt   `json:"page"`
+	PerPage *StrInt   `json:"per_page"`
 }
-type dumpConsensusStateArgs struct {
-}
-type getConsensusStateArgs struct {
-}
+
+type dumpConsensusStateArgs struct{}
+
+type getConsensusStateArgs struct{}
+
 type consensusParamsArgs struct {
-	Height StrInt64 `json:"height"`
+	Height *StrInt64 `json:"height"`
 }
+
 type unconfirmedTxsArgs struct {
-	Limit StrInt `json:"limit"`
+	Limit *StrInt `json:"limit"`
 }
-type numUnconfirmedTxsArgs struct {
-}
+
+type numUnconfirmedTxsArgs struct{}
 
 // tx broadcast API
 type broadcastTxCommitArgs struct {
@@ -108,8 +123,8 @@ type broadcastTxAsyncArgs struct {
 type ABCIQueryArgs struct {
 	Path   string         `json:"path"`
 	Data   bytes.HexBytes `json:"data"`
-	Height StrInt64       `json:"height"`
-	Prove  bool           `json:"prove"`
+	Height *StrInt64      `json:"height"`
+	Prove  *bool          `json:"prove"`
 }
 
 // ABCIInfoArgs defines args for ABCI Info method.


### PR DESCRIPTION
## Overview

This PR restores cometbft compat by allowing optional params for all endpoints, following `/block` in #1760 

Fixes #1761 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional pointer types in various functions, enhancing the versatility of input handling.

- **Bug Fixes**
  - Improved safety and robustness in handling query parameters across multiple functions to prevent nil value errors.

- **Tests**
  - Updated test cases to reflect changes in request paths and parameter handling for improved accuracy.

- **Refactor**
  - Converted several struct fields from non-pointer to pointer types, allowing for nullable values and more flexible data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->