### PR TITLE
fix: verify if `MaxBytes` is less than or equal to 0

### DIFF
--- a/state/executor.go
+++ b/state/executor.go
@@ -247,8 +247,8 @@ func (e *BlockExecutor) ApplyBlock(ctx context.Context, state types.State, block
 		return types.State{}, nil, err
 	}
 
-	if state.ConsensusParams.Block.MaxBytes == 0 {
-		e.logger.Error("maxBytes=0", "state.ConsensusParams.Block", state.ConsensusParams.Block, "block", block)
+	if state.ConsensusParams.Block.MaxBytes <= 0 {
+		e.logger.Error("maxBytes<=0", "state.ConsensusParams.Block", state.ConsensusParams.Block, "block", block)
 	}
 
 	return state, resp, nil


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This PR verifies if `MaxBytes` is less than or equal to 0, following #1644.

Resolves https://github.com/rollkit/rollkit/issues/1772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling for block size conditions to ensure more accurate logging and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->