### PR TITLE
test: refactor startup of RPC servers

### DIFF
--- a/da/da_test.go
+++ b/da/da_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/rollkit/rollkit/test/server"
 	"math/rand"
 	"net/url"
 	"os"
@@ -22,6 +21,7 @@ import (
 	proxyjsonrpc "github.com/rollkit/go-da/proxy/jsonrpc"
 	goDATest "github.com/rollkit/go-da/test"
 	"github.com/rollkit/rollkit/da/mock"
+	testServer "github.com/rollkit/rollkit/test/server"
 	"github.com/rollkit/rollkit/types"
 )
 
@@ -50,11 +50,11 @@ const (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	jsonrpcSrv := server.StartMockDAServJSONRPC(ctx, MockDAAddressHTTP)
+	jsonrpcSrv := testServer.StartMockDAServJSONRPC(ctx, MockDAAddressHTTP)
 	if jsonrpcSrv == nil {
 		os.Exit(1)
 	}
-	grpcSrv := server.StartMockDAServGRPC(MockDAAddress)
+	grpcSrv := testServer.StartMockDAServGRPC(MockDAAddress)
 	exitCode := m.Run()
 
 	// teardown servers

--- a/da/da_test.go
+++ b/da/da_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/rollkit/rollkit/test/server"
 	"math/rand"
-	"net"
 	"net/url"
 	"os"
 	"testing"
@@ -50,11 +50,11 @@ const (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	jsonrpcSrv := startMockDAServJSONRPC(ctx)
+	jsonrpcSrv := server.StartMockDAServJSONRPC(ctx, MockDAAddressHTTP)
 	if jsonrpcSrv == nil {
 		os.Exit(1)
 	}
-	grpcSrv := startMockDAServGRPC()
+	grpcSrv := server.StartMockDAServGRPC(MockDAAddress)
 	exitCode := m.Run()
 
 	// teardown servers
@@ -143,19 +143,6 @@ func TestSubmitRetrieve(t *testing.T) {
 	}
 }
 
-func startMockDAServGRPC() *grpc.Server {
-	server := proxygrpc.NewServer(goDATest.NewDummyDA(), grpc.Creds(insecure.NewCredentials()))
-	addr, _ := url.Parse(MockDAAddress)
-	lis, err := net.Listen("tcp", addr.Host)
-	if err != nil {
-		panic(err)
-	}
-	go func() {
-		_ = server.Serve(lis)
-	}()
-	return server
-}
-
 func startMockDAClientGRPC() *DAClient {
 	client := proxygrpc.NewClient()
 	addr, _ := url.Parse(MockDAAddress)
@@ -163,16 +150,6 @@ func startMockDAClientGRPC() *DAClient {
 		panic(err)
 	}
 	return NewDAClient(client, -1, -1, nil, log.TestingLogger())
-}
-
-func startMockDAServJSONRPC(ctx context.Context) *proxyjsonrpc.Server {
-	addr, _ := url.Parse(MockDAAddressHTTP)
-	srv := proxyjsonrpc.NewServer(addr.Hostname(), addr.Port(), goDATest.NewDummyDA())
-	err := srv.Start(ctx)
-	if err != nil {
-		panic(err)
-	}
-	return srv
 }
 
 func startMockDAClientJSONRPC(ctx context.Context) (*DAClient, error) {

--- a/test/server/server.go
+++ b/test/server/server.go
@@ -2,15 +2,21 @@ package server
 
 import (
 	"context"
+	"net"
+	"net/url"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
 	grpc2 "github.com/rollkit/go-da/proxy/grpc"
 	"github.com/rollkit/go-da/proxy/jsonrpc"
 	"github.com/rollkit/go-da/test"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
-	"net"
-	"net/url"
 )
 
+// StartMockDAServGRPC starts a mock gRPC server with the given listenAddress.
+//
+// The server uses a test.NewDummyDA() as the service implementation and  insecure credentials.
+// The function returns the created server instance.
 func StartMockDAServGRPC(listenAddress string) *grpc.Server {
 	server := grpc2.NewServer(test.NewDummyDA(), grpc.Creds(insecure.NewCredentials()))
 	addr, _ := url.Parse(listenAddress)
@@ -24,6 +30,10 @@ func StartMockDAServGRPC(listenAddress string) *grpc.Server {
 	return server
 }
 
+// StartMockDAServJSONRPC starts a mock JSON-RPC server with the given listenAddress.
+//
+// The server uses a test.NewDummyDA() as the service implementation.
+// The function returns the created server instance.
 func StartMockDAServJSONRPC(ctx context.Context, listenAddress string) *jsonrpc.Server {
 	addr, _ := url.Parse(listenAddress)
 	srv := jsonrpc.NewServer(addr.Hostname(), addr.Port(), test.NewDummyDA())

--- a/test/server/server.go
+++ b/test/server/server.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"context"
+	grpc2 "github.com/rollkit/go-da/proxy/grpc"
+	"github.com/rollkit/go-da/proxy/jsonrpc"
+	"github.com/rollkit/go-da/test"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"net"
+	"net/url"
+)
+
+func StartMockDAServGRPC(listenAddress string) *grpc.Server {
+	server := grpc2.NewServer(test.NewDummyDA(), grpc.Creds(insecure.NewCredentials()))
+	addr, _ := url.Parse(listenAddress)
+	lis, err := net.Listen("tcp", addr.Host)
+	if err != nil {
+		panic(err)
+	}
+	go func() {
+		_ = server.Serve(lis)
+	}()
+	return server
+}
+
+func StartMockDAServJSONRPC(ctx context.Context, listenAddress string) *jsonrpc.Server {
+	addr, _ := url.Parse(listenAddress)
+	srv := jsonrpc.NewServer(addr.Hostname(), addr.Port(), test.NewDummyDA())
+	err := srv.Start(ctx)
+	if err != nil {
+		panic(err)
+	}
+	return srv
+}


### PR DESCRIPTION
The test server start functions have been moved to a separate server package in tests. Mock RPC server is now started directly in rpc/json package.

Resolves #1642
