### PR TITLE
fix(ci): test.yml inherit secrets

### DIFF
--- a/.github/workflows/ci_release.yml
+++ b/.github/workflows/ci_release.yml
@@ -28,6 +28,7 @@ jobs:
 
   test:
     uses: ./.github/workflows/test.yml
+    secrets: inherit
 
   proto:
     uses: ./.github/workflows/proto.yml


### PR DESCRIPTION
## Overview

Fixed codecov action to inherit secrets, required for uploading coverage reports. CI coverage was broken after #1519 due to https://github.com/codecov/codecov-action/issues/1274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
	- Enhanced security and management of sensitive information in the CI workflow by allowing the test job to inherit secrets from the parent workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->