### PR TITLE
perf(state): remove fmt.Sprintf within for-loop

### DIFF
--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -540,7 +540,7 @@ func (idx *BlockerIndexer) indexEvents(batch ds.Txn, events []abci.Event, typ st
 			}
 
 			// index iff the event specified index:true and it's not a reserved event
-			compositeKey := event.Type + ". " + attr.Key
+			compositeKey := event.Type + "." + attr.Key
 			if compositeKey == types.BlockHeightKey {
 				return fmt.Errorf("event type and attribute key \"%s\" is reserved; please use a different key", compositeKey)
 			}

--- a/state/indexer/block/kv/kv.go
+++ b/state/indexer/block/kv/kv.go
@@ -540,7 +540,7 @@ func (idx *BlockerIndexer) indexEvents(batch ds.Txn, events []abci.Event, typ st
 			}
 
 			// index iff the event specified index:true and it's not a reserved event
-			compositeKey := fmt.Sprintf("%s.%s", event.Type, string(attr.Key))
+			compositeKey := event.Type + ". " + attr.Key
 			if compositeKey == types.BlockHeightKey {
 				return fmt.Errorf("event type and attribute key \"%s\" is reserved; please use a different key", compositeKey)
 			}

--- a/state/txindex/kv/kv.go
+++ b/state/txindex/kv/kv.go
@@ -162,7 +162,7 @@ func (txi *TxIndex) indexEvents(result *abci.TxResult, hash []byte, store ds.Txn
 			}
 
 			// index if `index: true` is set
-			compositeTag := fmt.Sprintf("%s.%s", event.Type, string(attr.Key))
+			compositeTag := event.Type + "." + attr.Key
 			if attr.GetIndex() {
 				err := store.Put(txi.ctx, ds.NewKey(keyForEvent(compositeTag, attr.Value, result)), hash)
 				if err != nil {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Bug Fixes**
	- Adjusted the method for constructing composite keys within the indexing process, which may enhance string matching.
- **Improvements**
	- Simplified string concatenation for composite key creation, potentially improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->