### PR TITLE
fix(manager): refactor lazy mode flags

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -724,13 +724,12 @@ func TestManager_getRemainingSleep(t *testing.T) {
 				conf: config.BlockManagerConfig{
 					BlockTime:      10 * time.Second,
 					LazyBlockTime:  20 * time.Second,
-					LazyBufferTime: defaultLazyBufferTime,
 					LazyAggregator: true,
 				},
 				buildingBlock: true,
 			},
 			start:         time.Now().Add(-15 * time.Second),
-			expectedSleep: defaultLazyBufferTime,
+			expectedSleep: (10 * time.Second * time.Duration(defaultLazySleepPercent) / 100),
 		},
 		{
 			name: "Lazy aggregation, not building block, elapsed < interval",

--- a/cmd/rollkit/docs/rollkit_start.md
+++ b/cmd/rollkit/docs/rollkit_start.md
@@ -41,7 +41,6 @@ rollkit start [flags]
       --rollkit.da_start_height uint                    starting DA block height (for syncing)
       --rollkit.lazy_aggregator                         wait for transactions, don't build empty blocks
       --rollkit.lazy_block_time duration                block time (for lazy mode) (default 1m0s)
-      --rollkit.lazy_buffer_time duration               additional time to wait to accumulate transactions in lazy mode (default 1s)
       --rollkit.light                                   run light client
       --rollkit.max_pending_blocks uint                 limit of blocks pending DA submission (0 for no limit)
       --rollkit.trusted_hash string                     initial trusted hash to start the header exchange service

--- a/config/config.go
+++ b/config/config.go
@@ -40,8 +40,6 @@ const (
 	FlagDAMempoolTTL = "rollkit.da_mempool_ttl"
 	// FlagLazyBlockTime is a flag for specifying the block time in lazy mode
 	FlagLazyBlockTime = "rollkit.lazy_block_time"
-	// FlagLazyBufferTime is a flag for specifying the additional time to wait to accumulate transactions in lazy mode
-	FlagLazyBufferTime = "rollkit.lazy_buffer_time"
 )
 
 // NodeConfig stores Rollkit node configuration.
@@ -89,9 +87,6 @@ type BlockManagerConfig struct {
 	// LazyBlockTime defines how often new blocks are produced in lazy mode
 	// even if there are no transactions
 	LazyBlockTime time.Duration `mapstructure:"lazy_block_time"`
-	// LazyBufferTime defines the additional time to wait to accumulate
-	// transactions in lazy mode
-	LazyBufferTime time.Duration `mapstructure:"lazy_buffer_time"`
 }
 
 // GetNodeConfig translates Tendermint's configuration into Rollkit configuration.
@@ -140,7 +135,6 @@ func (nc *NodeConfig) GetViperConfig(v *viper.Viper) error {
 	nc.MaxPendingBlocks = v.GetUint64(FlagMaxPendingBlocks)
 	nc.DAMempoolTTL = v.GetUint64(FlagDAMempoolTTL)
 	nc.LazyBlockTime = v.GetDuration(FlagLazyBlockTime)
-	nc.LazyBufferTime = v.GetDuration(FlagLazyBufferTime)
 	return nil
 }
 
@@ -164,5 +158,4 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64(FlagMaxPendingBlocks, def.MaxPendingBlocks, "limit of blocks pending DA submission (0 for no limit)")
 	cmd.Flags().Uint64(FlagDAMempoolTTL, def.DAMempoolTTL, "number of DA blocks until transaction is dropped from the mempool")
 	cmd.Flags().Duration(FlagLazyBlockTime, def.LazyBlockTime, "block time (for lazy mode)")
-	cmd.Flags().Duration(FlagLazyBufferTime, def.LazyBufferTime, "additional time to wait to accumulate transactions in lazy mode")
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -26,7 +26,6 @@ var DefaultNodeConfig = NodeConfig{
 		DABlockTime:    15 * time.Second,
 		LazyAggregator: false,
 		LazyBlockTime:  60 * time.Second,
-		LazyBufferTime: 1 * time.Second,
 	},
 	DAAddress:       "http://localhost:26658",
 	DAGasPrice:      -1,


### PR DESCRIPTION
## Overview

Following up #1779 the new flag `LazyBufferTime` has been removed to simplify lazy mode flags. We use a hardcoded value of `defaultLazySleepPercent = 10` to indicate a wait time equal to 10% of the block time. It might be possible to expose this as a flag if users request.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced configurability of transaction accumulation by shifting from a static time-based approach to a dynamic percentage-based system.
	
- **Bug Fixes**
	- Improved accuracy in sleep duration calculations related to block manager behavior.

- **Chores**
	- Simplified node configuration by removing the `LazyBufferTime` parameter, streamlining operational parameters.
	- Simplified command-line options by removing the `--rollkit.lazy_buffer_time` parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->