### PR TITLE
fix(ci): update .goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -46,7 +46,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Overview

goreleaser-action/2.2.0 deprecation:

```
snapshot:
  name_template: 'foo'
```

has been renamed to

```
snapshot:
  version_template: 'foo'

```
https://goreleaser.com/deprecations/#snapshotname_template


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated configuration to clarify the purpose of versioning templates.
  
- **Documentation**
	- Enhanced semantic clarity regarding versioning vs. naming conventions in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->