### PR TITLE
chore(manager): pending blocks err

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -807,7 +807,8 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 	}
 
 	if m.conf.MaxPendingBlocks != 0 && m.pendingBlocks.numPendingBlocks() >= m.conf.MaxPendingBlocks {
-		return fmt.Errorf("number of blocks pending DA submission (%d) reached configured limit (%d)", m.pendingBlocks.numPendingBlocks(), m.conf.MaxPendingBlocks)
+		return fmt.Errorf("refusing to create block: pending blocks [%d] reached limit [%d]",
+			m.pendingBlocks.numPendingBlocks(), m.conf.MaxPendingBlocks)
 	}
 
 	var (


### PR DESCRIPTION
## Overview

This PR improves the error message when pending blocks limit is reached to indicate that block production is being intentionally refused.

Fixes #1813 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved clarity of error messages related to block publishing limits, enhancing user understanding of refusal to create new blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->