### PR TITLE
docs: add DA included height to RPC doc

### DIFF
--- a/rpc/rpc-equivalency-coverage.md
+++ b/rpc/rpc-equivalency-coverage.md
@@ -46,9 +46,9 @@ curl http://127.0.0.1:26657/block?height=1
 curl http://127.0.0.1:26657/block?height=included
 ```
 
-#### Parameters
-- height (integer or string): height of the requested block. If no height is specified the latest block will be used. If height is set to the string "included", the latest DA included block will be returned.
+### Parameters
 
+- height (integer or string): height of the requested block. If no height is specified the latest block will be used. If height is set to the string "included", the latest DA included block will be returned.
 
 ## Implementation
 

--- a/rpc/rpc-equivalency-coverage.md
+++ b/rpc/rpc-equivalency-coverage.md
@@ -38,6 +38,18 @@ The communication format depends on the protocol used. For HTTP-based protocols,
 
 The RPC service assumes that the Rollkit node it interacts with is running and correctly configured. It also assumes that the client is authorized to perform the requested operations.
 
+The RPC provides an additional query for DA included blocks using the `height` parameter:
+
+```sh
+curl http://127.0.0.1:26657/block?height=1
+
+curl http://127.0.0.1:26657/block?height=included
+```
+
+#### Parameters
+- height (integer or string): height of the requested block. If no height is specified the latest block will be used. If height is set to the string "included", the latest DA included block will be returned.
+
+
 ## Implementation
 
 The implementation of the Rollkit RPC service can be found in the [`rpc/json/service.go`] file in the Rollkit repository.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Add DA included height to RPC doc

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new query option in the RPC service for retrieving DA included blocks by specifying the height parameter.
	- Added example curl commands to assist users in utilizing the new query functionality.
	- Included a new section in the documentation detailing the parameters for the height query, enhancing clarity on expected inputs and default behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->