### PR TITLE
fix: adjust sleep duration tolerance in tests

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -788,8 +788,8 @@ func TestManager_getRemainingSleep(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			actualSleep := tt.manager.getRemainingSleep(tt.start)
-			// Allow for a small difference, e.g., 1 millisecond
-			assert.True(t, WithinDuration(t, tt.expectedSleep, actualSleep, 1*time.Millisecond))
+			// Allow for a small difference, e.g., 5 millisecond
+			assert.True(t, WithinDuration(t, tt.expectedSleep, actualSleep, 5*time.Millisecond))
 		})
 	}
 }


### PR DESCRIPTION
Increase the sleep duration tolerance in the manager tests from 1 millisecond to 5 milliseconds. This change ensures that the tests are less sensitive to minor timing variations, potentially reducing flaky test failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Increased the tolerance for sleep duration assertions to improve accuracy in timing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->