### PR TITLE
chore(ci): split rollkit org deps out to reduce spam

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,35 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    labels:
+      - T:dependencies
+    # Group all patch updates into a single PR
+    groups:
+      patch-updates:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
       interval: daily
+    allow:
+      - dependency-name: "rollkit/*"
+    labels:
+      - T:dependencies
+    # Group all patch updates into a single PR
+    groups:
+      patch-updates:
+        applies-to: version-updates
+        update-types:
+          - "patch"
+          - "minor"
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
     open-pull-requests-limit: 10
     labels:
       - T:dependencies
@@ -17,7 +45,8 @@ updates:
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    allow:
+      - dependency-name: "github.com/rollkit/*"
     labels:
       - T:dependencies
     # Group all patch updates into a single PR
@@ -26,6 +55,7 @@ updates:
         applies-to: version-updates
         update-types:
           - "patch"
+          - "minor"
   - package-ecosystem: docker
     directory: "/docker"
     schedule:


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This PR adds updates to the dependabot config to address the PR spam. 

We want to be pulling in rollkit dependency updates ASAP so dependabot should trigger daily, however we care less about the frequency of updates from other dependencies. 

This PR splits our a daily and weekly update for the github actions and gomod triggers. For rollkit owned dependencies, the trigger will remain daily and both minor and patch updates will be grouped. 
For non-rollkit updates, the trigger is reduced to weekly. 

The wildcard dependency strings are based off of [this commit](https://github.com/rollkit/rollkit/commit/d3859461daa9fb7a51abe9d4363cf1ba08efa91d) and [this commit](https://github.com/rollkit/rollkit/commit/562c79e3b498e09811a76b0db8c2bc33b0853314).

Dependabot docs REF: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#allow

We should watch this update for a week and then apply to other repos. 