### PR TITLE
fix(rpc/json): avoid strict checks on jsonrpc code

### DIFF
--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -64,10 +64,10 @@ func TestREST(t *testing.T) {
 		bodyContains string
 	}{
 
-		{"valid/malformed request", "/block?so{}wrong!", http.StatusOK, int(json2.E_INTERNAL), ``},
+		{"valid/malformed request", "/block?so{}wrong!", http.StatusOK, -1, ``},
 		// to keep test simple, allow returning application error in following case
 		{"invalid/missing required param", "/tx", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'hash'`},
-		{"valid/missing optional param", "/block", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
+		{"valid/missing optional param", "/block", http.StatusOK, -1, ``},
 		{"valid/included block tag param", "/block?height=included", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
 		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
 		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -2,9 +2,11 @@ package json
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -64,10 +66,10 @@ func TestREST(t *testing.T) {
 		bodyContains string
 	}{
 
-		{"valid/malformed request", "/block?so{}wrong!", http.StatusOK, -1, ``},
+		{"valid/malformed request", "/block?so{}wrong!", http.StatusOK, -1, `"result":{"block_id":`},
 		// to keep test simple, allow returning application error in following case
 		{"invalid/missing required param", "/tx", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'hash'`},
-		{"valid/missing optional param", "/block", http.StatusOK, -1, ``},
+		{"valid/missing optional param", "/block", http.StatusOK, -1, `"result":{"block_id":`},
 		{"valid/included block tag param", "/block?height=included", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
 		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
 		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
@@ -85,6 +87,19 @@ func TestREST(t *testing.T) {
 	_, local := getRPC(t, "TestREST")
 	handler, err := GetHTTPHandler(local, log.TestingLogger())
 	require.NoError(err)
+
+	// wait for blocks
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	for {
+		if errors.Is(err, context.DeadlineExceeded) {
+			t.FailNow()
+		}
+		resp, err := local.Header(ctx, nil)
+		if err == nil && resp.Header.Height > 1 {
+			break
+		}
+	}
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## Overview

This PR fixes a flaky test `TestREST` which has happening due to strict checks on json rpc error codes. Fixes #1798 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated expected JSON-RPC error codes in test cases to a generic error indication for improved error handling.
	- Introduced additional logic to handle potential delays in response during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->