### PR TITLE
feat: start mockda server only if it's not running already

### DIFF
--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -258,8 +258,8 @@ func startMockDAServJSONRPC(
 	srv := newServer(addr.Hostname(), addr.Port(), goDATest.NewDummyDA())
 	if err := srv.Start(ctx); err != nil {
 		if errors.Is(err, syscall.EADDRINUSE) {
-			logger.Info("Mock DA server is already running", "address", nodeConfig.DAAddress)
-			return nil, errMockDAServerAlreadyRunning
+			logger.Info("DA server is already running", "address", nodeConfig.DAAddress)
+			return nil, errDAServerAlreadyRunning
 		}
 		return nil, err
 	}

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -133,7 +133,7 @@ func NewRunNodeCmd() *cobra.Command {
 			// use mock jsonrpc da server by default
 			if !cmd.Flags().Lookup("rollkit.da_address").Changed {
 				srv, err := startMockDAServJSONRPC(cmd.Context(), nodeConfig.DAAddress, proxy.NewServer)
-				if err != nil && !errors.Is(err, errMockDAServerAlreadyRunning) {
+				if err != nil && !errors.Is(err, errDAServerAlreadyRunning) {
 					return fmt.Errorf("failed to launch mock da server: %w", err)
 				}
 				// nolint:errcheck,gosec

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"syscall"
 	"time"
 
 	cmtcmd "github.com/cometbft/cometbft/cmd/cometbft/commands"
@@ -249,6 +250,7 @@ func startMockDAServJSONRPC(ctx context.Context) (*proxy.Server, error) {
 		return nil, err
 	}
 	// Attempt to start the server and handle the error if the port is already in use.
+	srv := proxy.NewServer(addr.Hostname(), addr.Port(), goDATest.NewDummyDA())
 	if err := srv.Start(ctx); err != nil {
 		if errors.Is(err, syscall.EADDRINUSE) {
 			logger.Info("Mock DA server is already running", "address", nodeConfig.DAAddress)
@@ -257,7 +259,6 @@ func startMockDAServJSONRPC(ctx context.Context) (*proxy.Server, error) {
 		return nil, err
 	}
 	logger.Info("Starting mock DA server", "address", nodeConfig.DAAddress)
-	srv := proxy.NewServer(addr.Hostname(), addr.Port(), goDATest.NewDummyDA())
 	if err := srv.Start(ctx); err != nil {
 		return nil, err
 	}
@@ -394,15 +395,4 @@ func parseFlags(cmd *cobra.Command) error {
 	}
 
 	return nil
-}
-
-func isPortOccupied(host, port string) bool {
-	address := net.JoinHostPort(host, port)
-	conn, err := net.DialTimeout("tcp", address, time.Second)
-	if err != nil {
-		return false
-	}
-	// nolint:errcheck
-	defer conn.Close()
-	return true
 }

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"net"
@@ -130,7 +131,7 @@ func NewRunNodeCmd() *cobra.Command {
 			// use mock jsonrpc da server by default
 			if !cmd.Flags().Lookup("rollkit.da_address").Changed {
 				srv, err := startMockDAServJSONRPC(cmd.Context())
-				if err != nil && err != errMockDAServerAlreadyRunning {
+				if err != nil && !errors.Is(err, errMockDAServerAlreadyRunning) {
 					return fmt.Errorf("failed to launch mock da server: %w", err)
 				}
 				// nolint:errcheck,gosec
@@ -397,6 +398,7 @@ func isPortOccupied(host, port string) bool {
 	if err != nil {
 		return false
 	}
+	// nolint:errcheck
 	defer conn.Close()
 	return true
 }

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -49,7 +49,7 @@ var (
 	// initialize the logger with the cometBFT defaults
 	logger = cometlog.NewTMLogger(cometlog.NewSyncWriter(os.Stdout))
 
-	errMockDAServerAlreadyRunning = fmt.Errorf("mock DA server already running")
+	errMockDAServerAlreadyRunning = errors.New("mock DA server already running")
 )
 
 // MockSequencerAddress is a sample address used by the mock sequencer

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -51,7 +51,7 @@ var (
 	// initialize the logger with the cometBFT defaults
 	logger = cometlog.NewTMLogger(cometlog.NewSyncWriter(os.Stdout))
 
-	errMockDAServerAlreadyRunning = errors.New("mock DA server already running")
+	errDAServerAlreadyRunning = errors.New("DA server already running")
 )
 
 // MockSequencerAddress is a sample address used by the mock sequencer

--- a/cmd/rollkit/commands/run_node_test.go
+++ b/cmd/rollkit/commands/run_node_test.go
@@ -187,7 +187,7 @@ func TestStartMockDAServJSONRPC(t *testing.T) {
 			name:          "Server Already Running",
 			daAddress:     "http://localhost:26657",
 			mockServerErr: syscall.EADDRINUSE,
-			expectedErr:   errMockDAServerAlreadyRunning,
+			expectedErr:   errDAServerAlreadyRunning,
 		},
 		{
 			name:          "Other Server Error",

--- a/cmd/rollkit/commands/run_node_test.go
+++ b/cmd/rollkit/commands/run_node_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/rollkit/go-da"
 	proxy "github.com/rollkit/go-da/proxy/jsonrpc"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestParseFlags(t *testing.T) {


### PR DESCRIPTION
Closes [#1818](https://github.com/rollkit/rollkit/issues/1818)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for starting the mock DA server.
	- Added mock server capabilities for improved testing.

- **Bug Fixes**
	- Improved robustness in handling scenarios where the mock DA server is already running, allowing the application to continue without crashing.
	- Expanded error handling scenarios in testing to cover various outcomes, including server start and invalid URL handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->