### PR TITLE
chore: clean up handling of nil batch on startup

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -1079,8 +1079,7 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 			return nil
 		}
 		if err != nil {
-			m.logger.Debug("waiting for transactions to include in block or empty batch", "height", newHeight, "details", err)
-			return nil
+			return fmt.Errorf("failed to get transactions from batch: %w", err)
 		}
 		// sanity check timestamp for monotonically increasing
 		if timestamp.Before(lastHeaderTime) {

--- a/block/manager.go
+++ b/block/manager.go
@@ -1075,6 +1075,10 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 		}
 
 		txs, timestamp, err := m.getTxsFromBatch()
+		if errors.Is(err, ErrNoBatch) {
+			m.logger.Info(err.Error())
+			return nil
+		}
 		if err != nil {
 			return fmt.Errorf("failed to get transactions from batch: %w", err)
 		}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

On start up, for a new rollup or restarting an existing rollup, it is common or expected for there to be no txns to process. 
Currently this triggers an error every time which is unnecessary.  Additionally, there are plenty of situations were there are no txns to process and that is ok.

This PR changes the error log to an info log.

```
I[2024-10-29|09:27:02.127] Creating and publishing block                module=BlockManager height=1
E[2024-10-29|09:27:02.127] error while publishing block                 module=BlockManager error="failed to get transactions from batch: no batch to process"
I[2024-10-29|09:27:03.127] Creating and publishing block                module=BlockManager height=1
```

```
I[2024-10-29|09:27:16.852] Started node                                 module=main 
I[2024-10-29|09:27:16.853] Creating and publishing block                module=BlockManager height=11
E[2024-10-29|09:27:16.853] error while publishing block                 module=BlockManager error="failed to get transactions from batch: no batch to process"
I[2024-10-29|09:27:17.853] Creating and publishing block                module=BlockManager height=11
```

After
```
I[2024-10-29|09:32:03.615] Creating and publishing block                module=BlockManager height=1
I[2024-10-29|09:32:03.615] no batch to process                          module=BlockManager  
I[2024-10-29|09:32:04.615] Creating and publishing block                module=BlockManager height=1
```

```
I[2024-10-29|09:35:09.721] Started node                                 module=main 
I[2024-10-29|09:35:09.721] Creating and publishing block                module=BlockManager height=6
I[2024-10-29|09:35:09.721] no batch to process                          module=BlockManager 
I[2024-10-29|09:35:10.722] Creating and publishing block                module=BlockManager height=6
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error handling for block publishing when no transactions are available, preventing unnecessary block creation attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->