### PR TITLE
feat: enable mock servers with intercept command

### DIFF
--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -72,7 +72,7 @@ readTOML:
 	if daAddress == "" {
 		daAddress = rollconf.DefaultDAAddress
 	}
-	daSrv, err := startMockDAServJSONRPC(rollkitCommand.Context(), daAddress, proxy.NewServer)
+	daSrv, err := tryStartMockDAServJSONRPC(rollkitCommand.Context(), daAddress, proxy.NewServer)
 	if err != nil && !errors.Is(err, errDAServerAlreadyRunning) {
 		return shouldExecute, fmt.Errorf("failed to launch mock da server: %w", err)
 	}

--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -38,18 +38,16 @@ func InterceptCommand(
 			return
 		case "start":
 			isStartCommand = true
-			goto readTOML
-		}
-
-		// Check if user attempted to run a rollkit command
-		for _, cmd := range rollkitCommand.Commands() {
-			if os.Args[1] == cmd.Use {
-				return
+		default:
+			// Check if user attempted to run a rollkit command
+			for _, cmd := range rollkitCommand.Commands() {
+				if os.Args[1] == cmd.Use {
+					return
+				}
 			}
 		}
 	}
 
-readTOML:
 	rollkitConfig, err = readToml()
 	if err != nil {
 		return

--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -9,7 +9,6 @@ import (
 
 	cometos "github.com/cometbft/cometbft/libs/os"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	proxy "github.com/rollkit/go-da/proxy/jsonrpc"
 	rollconf "github.com/rollkit/rollkit/config"
@@ -91,7 +90,7 @@ readTOML:
 	if rollupID == "" {
 		rollupID = rollconf.DefaultSequencerRollupID
 	}
-	seqSrv, err := tryStartMockSequencerServerGRPC(viper.GetString(sequencerAddress), rollupID)
+	seqSrv, err := tryStartMockSequencerServerGRPC(sequencerAddress, rollupID)
 	if err != nil && !errors.Is(err, errSequencerAlreadyRunning) {
 		return shouldExecute, fmt.Errorf("failed to launch mock sequencing server: %w", err)
 	}

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -130,7 +130,7 @@ func NewRunNodeCmd() *cobra.Command {
 
 			// Try and launch a mock JSON RPC DA server if there is no DA server running.
 			// NOTE: if the user supplied an address for a running DA server, and the address doesn't match, this will launch a mock DA server. This is ok because the logs will tell the user that a mock DA server is being used.
-			daSrv, err := startMockDAServJSONRPC(cmd.Context(), nodeConfig.DAAddress, proxy.NewServer)
+			daSrv, err := tryStartMockDAServJSONRPC(cmd.Context(), nodeConfig.DAAddress, proxy.NewServer)
 			if err != nil && !errors.Is(err, errDAServerAlreadyRunning) {
 				return fmt.Errorf("failed to launch mock da server: %w", err)
 			}
@@ -249,8 +249,8 @@ func addNodeFlags(cmd *cobra.Command) {
 	rollconf.AddFlags(cmd)
 }
 
-// startMockDAServJSONRPC starts a mock JSONRPC server
-func startMockDAServJSONRPC(
+// tryStartMockDAServJSONRPC will try and start a mock JSONRPC server
+func tryStartMockDAServJSONRPC(
 	ctx context.Context,
 	daAddress string,
 	newServer func(string, string, da.DA) *proxy.Server,

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -143,10 +143,12 @@ func NewRunNodeCmd() *cobra.Command {
 			}
 
 			// use mock grpc sequencer server by default
-			if !cmd.Flags().Lookup("rollkit.sequencer_address").Changed {
-				// If we are using defaults, then we also will override the default chainID from the genesis doc with the default from the node config
+			if !cmd.Flags().Lookup("rollkit.sequencer_rollup_id").Changed {
 				genDoc.ChainID = nodeConfig.SequencerRollupID
-				srv, err := startMockSequencerServerGRPC(nodeConfig.SequencerAddress, nodeConfig.SequencerRollupID)
+			}
+			sequecnerRollupID := genDoc.ChainID
+			if !cmd.Flags().Lookup("rollkit.sequencer_address").Changed {
+				srv, err := startMockSequencerServerGRPC(nodeConfig.SequencerAddress, sequecnerRollupID)
 				if err != nil && !errors.Is(err, errSequencerAlreadyRunning) {
 					return fmt.Errorf("failed to launch mock sequencing server: %w", err)
 				}

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -143,7 +143,7 @@ func NewRunNodeCmd() *cobra.Command {
 			}
 
 			// use mock grpc sequencer server by default
-			if !cmd.Flags().Lookup("rollkit.sequencer_rollup_id").Changed {
+			if cmd.Flags().Lookup("rollkit.sequencer_rollup_id").Changed {
 				genDoc.ChainID = nodeConfig.SequencerRollupID
 			}
 			sequecnerRollupID := genDoc.ChainID
@@ -286,6 +286,7 @@ func startMockSequencerServerGRPC(listenAddress string, rollupId string) (*grpc.
 	go func() {
 		_ = server.Serve(lis)
 	}()
+	logger.Info("Starting mock DA server", "address", nodeConfig.DAAddress)
 	return server, nil
 }
 

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -145,10 +145,10 @@ func NewRunNodeCmd() *cobra.Command {
 			if cmd.Flags().Lookup(rollconf.FlagSequencerRollupID).Changed {
 				genDoc.ChainID = nodeConfig.SequencerRollupID
 			}
-			sequecnerRollupID := genDoc.ChainID
+			sequencerRollupID := genDoc.ChainID
 			// Try and launch a mock gRPC sequencer if there is no sequencer running.
 			// NOTE: if the user supplied an address for a running sequencer, and the address doesn't match, this will launch a mock sequencer. This is ok because the logs will tell the user that a mock sequencer is being used.
-			seqSrv, err := tryStartMockSequencerServerGRPC(nodeConfig.SequencerAddress, sequecnerRollupID)
+			seqSrv, err := tryStartMockSequencerServerGRPC(nodeConfig.SequencerAddress, sequencerRollupID)
 			if err != nil && !errors.Is(err, errSequencerAlreadyRunning) {
 				return fmt.Errorf("failed to launch mock sequencing server: %w", err)
 			}

--- a/cmd/rollkit/commands/run_node_test.go
+++ b/cmd/rollkit/commands/run_node_test.go
@@ -209,7 +209,7 @@ func TestStartMockDAServJSONRPC(t *testing.T) {
 				return mockServer.Server
 			}
 
-			srv, err := startMockDAServJSONRPC(context.Background(), tt.daAddress, newServerFunc)
+			srv, err := tryStartMockDAServJSONRPC(context.Background(), tt.daAddress, newServerFunc)
 
 			if tt.expectedErr != nil {
 				assert.Error(t, err)

--- a/cmd/rollkit/docs/rollkit_start.md
+++ b/cmd/rollkit/docs/rollkit_start.md
@@ -45,6 +45,7 @@ rollkit start [flags]
       --rollkit.light                                   run light client
       --rollkit.max_pending_blocks uint                 limit of blocks pending DA submission (0 for no limit)
       --rollkit.sequencer_address string                sequencer middleware address (host:port) (default "localhost:50051")
+      --rollkit.sequencer_rollup_id string              sequencer middleware rollup ID (default: mock-rollup) (default "mock-rollup")
       --rollkit.trusted_hash string                     initial trusted hash to start the header exchange service
       --rpc.grpc_laddr string                           GRPC listen address (BroadcastTx only). Port required
       --rpc.laddr string                                RPC listen address. Port required (default "tcp://127.0.0.1:26657")

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,8 @@ const (
 	FlagLazyBlockTime = "rollkit.lazy_block_time"
 	// FlagSequencerAddress is a flag for specifying the sequencer middleware address
 	FlagSequencerAddress = "rollkit.sequencer_address"
+	// FlagSequencerRollupID is a flag for specifying the sequencer middleware rollup ID
+	FlagSequencerRollupID = "rollkit.sequencer_rollup_id"
 )
 
 // NodeConfig stores Rollkit node configuration.
@@ -66,8 +68,9 @@ type NodeConfig struct {
 	DASubmitOptions    string                       `mapstructure:"da_submit_options"`
 
 	// CLI flags
-	DANamespace      string `mapstructure:"da_namespace"`
-	SequencerAddress string `mapstructure:"sequencer_address"`
+	DANamespace       string `mapstructure:"da_namespace"`
+	SequencerAddress  string `mapstructure:"sequencer_address"`
+	SequencerRollupID string `mapstructure:"sequencer_rollup_id"`
 }
 
 // HeaderConfig allows node to pass the initial trusted header hash to start the header exchange service
@@ -143,6 +146,7 @@ func (nc *NodeConfig) GetViperConfig(v *viper.Viper) error {
 	nc.DAMempoolTTL = v.GetUint64(FlagDAMempoolTTL)
 	nc.LazyBlockTime = v.GetDuration(FlagLazyBlockTime)
 	nc.SequencerAddress = v.GetString(FlagSequencerAddress)
+	nc.SequencerRollupID = v.GetString(FlagSequencerRollupID)
 
 	return nil
 }
@@ -170,4 +174,5 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Uint64(FlagDAMempoolTTL, def.DAMempoolTTL, "number of DA blocks until transaction is dropped from the mempool")
 	cmd.Flags().Duration(FlagLazyBlockTime, def.LazyBlockTime, "block time (for lazy mode)")
 	cmd.Flags().String(FlagSequencerAddress, def.SequencerAddress, "sequencer middleware address (host:port)")
+	cmd.Flags().String(FlagSequencerRollupID, def.SequencerRollupID, "sequencer middleware rollup ID (default: mock-rollup)")
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -13,7 +13,7 @@ const (
 	// Please keep updated with each new release
 	Version = "0.38.5"
 	// DefaultDAAddress is the default address for the DA middleware
-	DefaultDAAddress = "localhost:26658"
+	DefaultDAAddress = "http://localhost:26658"
 	// DefaultSequencerAddress is the default address for the sequencer middleware
 	DefaultSequencerAddress = "localhost:50051"
 	// DefaultSequencerRollupID is the default rollup ID for the sequencer middleware

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -12,8 +12,12 @@ const (
 	// Version is the current rollkit version
 	// Please keep updated with each new release
 	Version = "0.38.5"
+	// DefaultDAAddress is the default address for the DA middleware
+	DefaultDAAddress = "localhost:26658"
 	// DefaultSequencerAddress is the default address for the sequencer middleware
 	DefaultSequencerAddress = "localhost:50051"
+	// DefaultSequencerRollupID is the default rollup ID for the sequencer middleware
+	DefaultSequencerRollupID = "mock-rollup"
 )
 
 // DefaultNodeConfig keeps default values of NodeConfig
@@ -29,7 +33,7 @@ var DefaultNodeConfig = NodeConfig{
 		LazyAggregator: false,
 		LazyBlockTime:  60 * time.Second,
 	},
-	DAAddress:       "http://localhost:26658",
+	DAAddress:       DefaultDAAddress,
 	DAGasPrice:      -1,
 	DAGasMultiplier: 0,
 	Light:           false,
@@ -38,5 +42,5 @@ var DefaultNodeConfig = NodeConfig{
 	},
 	Instrumentation:   config.DefaultInstrumentationConfig(),
 	SequencerAddress:  DefaultSequencerAddress,
-	SequencerRollupID: "mock-rollup",
+	SequencerRollupID: DefaultSequencerRollupID,
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -12,7 +12,7 @@ const (
 	// Version is the current rollkit version
 	// Please keep updated with each new release
 	Version = "0.38.5"
-	// DefaultSequencerAddress
+	// DefaultSequencerAddress is the default address for the sequencer middleware
 	DefaultSequencerAddress = "localhost:50051"
 )
 

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -12,6 +12,8 @@ const (
 	// Version is the current rollkit version
 	// Please keep updated with each new release
 	Version = "0.38.5"
+	// DefaultSequencerAddress
+	DefaultSequencerAddress = "localhost:50051"
 )
 
 // DefaultNodeConfig keeps default values of NodeConfig
@@ -34,6 +36,7 @@ var DefaultNodeConfig = NodeConfig{
 	HeaderConfig: HeaderConfig{
 		TrustedHash: "",
 	},
-	Instrumentation:  config.DefaultInstrumentationConfig(),
-	SequencerAddress: "localhost:50051",
+	Instrumentation:   config.DefaultInstrumentationConfig(),
+	SequencerAddress:  DefaultSequencerAddress,
+	SequencerRollupID: "mock-rollup",
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This PR does two key things:
1. Handles already running sequencer
2. Enables using mock services with the intercept command. 

1 is pretty straight forward as we did this for the DA server as well. The one thing to note though with this PR is that because we are checking for already running servers, I just remove the redundant check of if the flag was set. I add a comment to the code to explain the reasoning and to document the context for the future. 

For 2, this will help us clean up the rollkit docs. Right now, even for simple ignite apps, you have to run the local da, local sequencer, and in the future some local execution. This makes the docs and rollkit feel clunky. 

By adding the mock server commands to the intercept command, we can spin up mock da and mock sequencer for these tutorials to reduce the steps required by the users. 

Enables: https://github.com/rollkit/docs/issues/485
Closes #1910 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added command-line option `--rollkit.sequencer_rollup_id` for specifying the sequencer middleware rollup ID, defaulting to "mock-rollup."
  - Introduced functionality to start mock services for improved testing and development.

- **Bug Fixes**
  - Enhanced error handling for starting mock servers, including checks for already running services.

- **Documentation**
  - Updated documentation to reflect new command-line options and improved configurations.

- **Refactor**
  - Streamlined control flow and error handling in the `InterceptCommand` and mock server initialization processes.
  - Improved code structure and readability for mock server startup logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->