### PR TITLE
chore: replay blocks to sync app and rollup states

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -1589,13 +1589,13 @@ func (m *Manager) replayBlocks(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get block data for height %d: %w", i, err)
 		}
-		appHash, err = m.executor.ExecCommitBlock(proxyApp.Consensus(), header, data, m.logger, state, m.store)
-		if err != nil {
-			return nil, err
-		}
 		// Extra check to ensure the app was not changed in a way it shouldn't have.
 		if len(appHash) > 0 {
 			assertAppHashEqualsOneFromBlock(appHash, header)
+		}
+		appHash, err = m.executor.ExecCommitBlock(proxyApp.Consensus(), header, data, m.logger, state, m.store)
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/block/manager.go
+++ b/block/manager.go
@@ -193,7 +193,7 @@ func NewManager(
 	mempool mempool.Mempool,
 	mempoolReaper *mempool.CListMempoolReaper,
 	seqClient *grpc.Client,
-	proxyApp proxy.AppConnConsensus,
+	proxyApp proxy.AppConns,
 	dalc *da.DAClient,
 	eventBus *cmtypes.EventBus,
 	logger log.Logger,
@@ -242,7 +242,7 @@ func NewManager(
 	// allow buffer for the block header and protocol encoding
 	maxBlobSize -= blockProtocolOverhead
 
-	exec := state.NewBlockExecutor(proposerAddress, genesis.ChainID, mempool, mempoolReaper, proxyApp, eventBus, maxBlobSize, logger, execMetrics)
+	exec := state.NewBlockExecutor(proposerAddress, genesis.ChainID, mempool, mempoolReaper, proxyApp.Consensus(), eventBus, maxBlobSize, logger, execMetrics)
 	if s.LastBlockHeight+1 == uint64(genesis.InitialHeight) { //nolint:gosec
 		res, err := exec.InitChain(genesis)
 		if err != nil {
@@ -298,6 +298,14 @@ func NewManager(
 		bq:             NewBatchQueue(),
 	}
 	agg.init(context.Background())
+
+	if agg.conf.Replay {
+		// Handshake to ensure that app and rollup are in sync
+		if err := agg.Handshake(context.Background(), proxyApp); err != nil {
+			return nil, err
+		}
+	}
+
 	return agg, nil
 }
 
@@ -1491,4 +1499,128 @@ func updateState(s *types.State, res *abci.ResponseInitChain) error {
 	s.LastValidators = cmtypes.NewValidatorSet(nValSet.Validators)
 
 	return nil
+}
+
+// Handshake performs the ABCI handshake with the application.
+func (m *Manager) Handshake(ctx context.Context, proxyApp proxy.AppConns) error {
+	// Handshake is done via ABCI Info on the query conn.
+	res, err := proxyApp.Query().Info(ctx, proxy.RequestInfo)
+	if err != nil {
+		return fmt.Errorf("error calling Info: %v", err)
+	}
+
+	blockHeight := res.LastBlockHeight
+	if blockHeight < 0 {
+		return fmt.Errorf("got a negative last block height (%d) from the app", blockHeight)
+	}
+	appHash := res.LastBlockAppHash
+
+	m.logger.Info("ABCI Handshake App Info",
+		"height", blockHeight,
+		"hash", fmt.Sprintf("%X", appHash),
+		"software-version", res.Version,
+		"protocol-version", res.AppVersion,
+	)
+
+	// Replay blocks up to the latest in the blockstore.
+	appHash, err = m.ReplayBlocks(ctx, appHash, blockHeight, proxyApp)
+	if err != nil {
+		return fmt.Errorf("error on replay: %v", err)
+	}
+
+	m.logger.Info("Completed ABCI Handshake - CometBFT and App are synced",
+		"appHeight", blockHeight, "appHash", fmt.Sprintf("%X", appHash))
+
+	// TODO: (on restart) replay mempool
+
+	return nil
+}
+
+// ReplayBlocks replays blocks from the last state to the app's last block height.
+func (m *Manager) ReplayBlocks(
+	ctx context.Context,
+	appHash []byte,
+	appBlockHeight int64,
+	proxyApp proxy.AppConns,
+) ([]byte, error) {
+	state := m.lastState
+	stateBlockHeight := m.lastState.LastBlockHeight
+	m.logger.Info(
+		"ABCI Replay Blocks",
+		"appHeight",
+		appBlockHeight,
+		"stateHeight",
+		stateBlockHeight)
+
+	if appBlockHeight < int64(stateBlockHeight) {
+		// the app is behind, so replay blocks
+		return m.replayBlocks(ctx, state, proxyApp, uint64(appBlockHeight), stateBlockHeight)
+	} else if appBlockHeight == int64(stateBlockHeight) {
+		// We're good!
+		assertAppHashEqualsOneFromState(appHash, state)
+		return appHash, nil
+	}
+
+	panic(fmt.Sprintf("uncovered case! app height higher than state height, possibly need app rollback; appHeight: %d, stateHeight: %d", appBlockHeight, stateBlockHeight))
+}
+
+func (m *Manager) replayBlocks(
+	ctx context.Context,
+	state types.State,
+	proxyApp proxy.AppConns,
+	appBlockHeight,
+	stateBlockHeight uint64,
+) ([]byte, error) {
+	var appHash []byte
+	finalBlock := stateBlockHeight
+	firstBlock := appBlockHeight + 1
+	if firstBlock == 1 {
+		firstBlock = state.InitialHeight
+	}
+	for i := firstBlock; i <= finalBlock; i++ {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		m.logger.Info("Applying block", "height", i)
+		header, data, err := m.store.GetBlockData(ctx, i)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get block data for height %d: %w", i, err)
+		}
+		appHash, err = m.executor.ExecCommitBlock(proxyApp.Consensus(), header, data, m.logger, state, m.store)
+		if err != nil {
+			return nil, err
+		}
+		// Extra check to ensure the app was not changed in a way it shouldn't have.
+		if len(appHash) > 0 {
+			assertAppHashEqualsOneFromBlock(appHash, header)
+		}
+	}
+
+	assertAppHashEqualsOneFromState(appHash, state)
+	return appHash, nil
+}
+
+func assertAppHashEqualsOneFromBlock(appHash []byte, header *types.SignedHeader) {
+	if !bytes.Equal(appHash, header.AppHash) {
+		panic(fmt.Sprintf(`block.AppHash does not match AppHash after replay. Got %X, expected %X.
+
+Block: %v
+`,
+			appHash, header.AppHash, header))
+	}
+}
+
+func assertAppHashEqualsOneFromState(appHash []byte, state types.State) {
+	if !bytes.Equal(appHash, state.AppHash) {
+		panic(fmt.Sprintf(`state.AppHash does not match AppHash after replay. Got
+%X, expected %X.
+
+State: %v
+
+Did you reset CometBFT without resetting your application's data?`,
+			appHash, state.AppHash, state))
+	}
 }

--- a/cmd/rollkit/docs/rollkit_start.md
+++ b/cmd/rollkit/docs/rollkit_start.md
@@ -44,7 +44,7 @@ rollkit start [flags]
       --rollkit.lazy_block_time duration                block time (for lazy mode) (default 1m0s)
       --rollkit.light                                   run light client
       --rollkit.max_pending_blocks uint                 limit of blocks pending DA submission (0 for no limit)
-      --rollkit.replay                                  replay blocks
+      --rollkit.replay                                  enable block replay to synchronize application and rollup states
       --rollkit.sequencer_address string                sequencer middleware address (host:port) (default "localhost:50051")
       --rollkit.sequencer_rollup_id string              sequencer middleware rollup ID (default: mock-rollup) (default "mock-rollup")
       --rollkit.trusted_hash string                     initial trusted hash to start the header exchange service

--- a/cmd/rollkit/docs/rollkit_start.md
+++ b/cmd/rollkit/docs/rollkit_start.md
@@ -44,6 +44,7 @@ rollkit start [flags]
       --rollkit.lazy_block_time duration                block time (for lazy mode) (default 1m0s)
       --rollkit.light                                   run light client
       --rollkit.max_pending_blocks uint                 limit of blocks pending DA submission (0 for no limit)
+      --rollkit.replay                                  replay blocks
       --rollkit.sequencer_address string                sequencer middleware address (host:port) (default "localhost:50051")
       --rollkit.sequencer_rollup_id string              sequencer middleware rollup ID (default: mock-rollup) (default "mock-rollup")
       --rollkit.trusted_hash string                     initial trusted hash to start the header exchange service

--- a/config/config.go
+++ b/config/config.go
@@ -180,5 +180,5 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Duration(FlagLazyBlockTime, def.LazyBlockTime, "block time (for lazy mode)")
 	cmd.Flags().String(FlagSequencerAddress, def.SequencerAddress, "sequencer middleware address (host:port)")
 	cmd.Flags().String(FlagSequencerRollupID, def.SequencerRollupID, "sequencer middleware rollup ID (default: mock-rollup)")
-	cmd.Flags().Bool(FlagReplay, def.Replay, "replay blocks")
+	cmd.Flags().Bool(FlagReplay, def.Replay, "enable block replay to synchronize application and rollup states")
 }

--- a/config/config.go
+++ b/config/config.go
@@ -46,6 +46,8 @@ const (
 	FlagSequencerAddress = "rollkit.sequencer_address"
 	// FlagSequencerRollupID is a flag for specifying the sequencer middleware rollup ID
 	FlagSequencerRollupID = "rollkit.sequencer_rollup_id"
+	// FlagReplay is a flag for replaying blocks
+	FlagReplay = "rollkit.replay"
 )
 
 // NodeConfig stores Rollkit node configuration.
@@ -96,6 +98,8 @@ type BlockManagerConfig struct {
 	// LazyBlockTime defines how often new blocks are produced in lazy mode
 	// even if there are no transactions
 	LazyBlockTime time.Duration `mapstructure:"lazy_block_time"`
+	// Replay defines whether to replay blocks
+	Replay bool `mapstructure:"replay"`
 }
 
 // GetNodeConfig translates Tendermint's configuration into Rollkit configuration.
@@ -147,6 +151,7 @@ func (nc *NodeConfig) GetViperConfig(v *viper.Viper) error {
 	nc.LazyBlockTime = v.GetDuration(FlagLazyBlockTime)
 	nc.SequencerAddress = v.GetString(FlagSequencerAddress)
 	nc.SequencerRollupID = v.GetString(FlagSequencerRollupID)
+	nc.Replay = v.GetBool(FlagReplay)
 
 	return nil
 }
@@ -175,4 +180,5 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().Duration(FlagLazyBlockTime, def.LazyBlockTime, "block time (for lazy mode)")
 	cmd.Flags().String(FlagSequencerAddress, def.SequencerAddress, "sequencer middleware address (host:port)")
 	cmd.Flags().String(FlagSequencerRollupID, def.SequencerRollupID, "sequencer middleware rollup ID (default: mock-rollup)")
+	cmd.Flags().Bool(FlagReplay, def.Replay, "replay blocks")
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -32,6 +32,7 @@ var DefaultNodeConfig = NodeConfig{
 		DABlockTime:    15 * time.Second,
 		LazyAggregator: false,
 		LazyBlockTime:  60 * time.Second,
+		Replay:         false,
 	},
 	DAAddress:       DefaultDAAddress,
 	DAGasPrice:      -1,

--- a/node/full.go
+++ b/node/full.go
@@ -280,7 +280,7 @@ func initDataSyncService(mainKV ds.TxnDatastore, nodeConfig config.NodeConfig, g
 }
 
 func initBlockManager(signingKey crypto.PrivKey, nodeConfig config.NodeConfig, genesis *cmtypes.GenesisDoc, store store.Store, mempool mempool.Mempool, mempoolReaper *mempool.CListMempoolReaper, seqClient *seqGRPC.Client, proxyApp proxy.AppConns, dalc *da.DAClient, eventBus *cmtypes.EventBus, logger log.Logger, headerSyncService *block.HeaderSyncService, dataSyncService *block.DataSyncService, seqMetrics *block.Metrics, execMetrics *state.Metrics) (*block.Manager, error) {
-	blockManager, err := block.NewManager(signingKey, nodeConfig.BlockManagerConfig, genesis, store, mempool, mempoolReaper, seqClient, proxyApp.Consensus(), dalc, eventBus, logger.With("module", "BlockManager"), headerSyncService.Store(), dataSyncService.Store(), seqMetrics, execMetrics)
+	blockManager, err := block.NewManager(signingKey, nodeConfig.BlockManagerConfig, genesis, store, mempool, mempoolReaper, seqClient, proxyApp, dalc, eventBus, logger.With("module", "BlockManager"), headerSyncService.Store(), dataSyncService.Store(), seqMetrics, execMetrics)
 	if err != nil {
 		return nil, fmt.Errorf("error while initializing BlockManager: %w", err)
 	}

--- a/state/executor.go
+++ b/state/executor.go
@@ -335,7 +335,7 @@ func (e *BlockExecutor) ExecCommitBlock(
 		return nil, fmt.Errorf("expected tx results length to match size of transactions in block. Expected %d, got %d", len(data.Txs), len(resp.TxResults))
 	}
 
-	logger.Info("Executed block", "height", header.Height, "app_hash", fmt.Sprintf("%X", resp.AppHash))
+	logger.Info("Executed block", "height", header.Height(), "app_hash", fmt.Sprintf("%X", resp.AppHash))
 
 	// Commit block
 	_, err = e.proxyApp.Commit(context.TODO())

--- a/state/executor.go
+++ b/state/executor.go
@@ -14,7 +14,6 @@ import (
 	cmtypes "github.com/cometbft/cometbft/types"
 
 	"github.com/rollkit/rollkit/mempool"
-	"github.com/rollkit/rollkit/store"
 	"github.com/rollkit/rollkit/third_party/log"
 	"github.com/rollkit/rollkit/types"
 	abciconv "github.com/rollkit/rollkit/types/abci"
@@ -296,12 +295,10 @@ func (e *BlockExecutor) Commit(ctx context.Context, state types.State, header *t
 // ExecCommitBlock executes and commits a block on the proxyApp without validating or mutating the state.
 // It returns the application root hash (result of abci.Commit).
 func (e *BlockExecutor) ExecCommitBlock(
-	appConnConsensus proxy.AppConnConsensus,
 	header *types.SignedHeader,
 	data *types.Data,
 	logger log.Logger,
 	state types.State,
-	store store.Store,
 ) ([]byte, error) {
 	abciHeader, err := abciconv.ToABCIHeaderPB(&header.Header)
 	if err != nil {


### PR DESCRIPTION
Partially addresses: https://github.com/rollkit/rollkit/issues/1881

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced new methods for block management: `Handshake`, `ReplayBlocks`, and `ExecCommitBlock`, enhancing synchronization and execution capabilities.
  - Added a configuration flag `--rollkit.replay` to allow users to specify block replay settings.

- **Bug Fixes**
  - Improved error handling during block manager initialization to ensure consistent setup.

- **Documentation**
  - Updated documentation to include new command-line option for block replay functionality.

These updates enhance the application's interaction with the blockchain, providing users with more control and improved performance in block processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->