### PR TITLE
Correct typos and grammatical issues in documentation files

### DIFF
--- a/block/block-manager.md
+++ b/block/block-manager.md
@@ -71,7 +71,7 @@ When the full node is operating as a sequencer (aka aggregator), the block manag
 
 In `normal` mode, the block manager runs a timer, which is set to the `BlockTime` configuration parameter, and continuously produces blocks at `BlockTime` intervals.
 
-In `lazy` mode, the block manager starts building a block when any transaction becomes available in the mempool. After the first notification of the transaction availability, the manager will wait for a 1 second timer to finish, in order to collect as many transactions from the mempool as possible. The 1 second delay is chosen in accordance with the default block time of 1s. The block manager also notifies the full node after every lazy block building.
+In `lazy` mode, the block manager starts building a block when any transaction becomes available in the mempool. After the first notification of the transaction availability, the manager will wait for a 1 second timer to finish, in order to collect as many transactions from the mempool as possible. The 1-second delay is chosen in accordance with the default block time of 1s. The block manager also notifies the full node after every lazy block building.
 
 #### Building the Block
 

--- a/specs/lazy-adr/adr-006-da-interface.md
+++ b/specs/lazy-adr/adr-006-da-interface.md
@@ -14,7 +14,7 @@ Rollkit requires data availability layer. Different implementations are expected
 
 ## Alternative Approaches
 
-> This section contains information around alternative options that are considered before making a decision. It should contain a explanation on why the alternative approach(es) were not chosen.
+> This section contains information around alternative options that are considered before making a decision. It should contain an explanation on why the alternative approach(es) were not chosen.
 
 ## Decision
 

--- a/specs/lazy-adr/adr-template.md
+++ b/specs/lazy-adr/adr-template.md
@@ -10,7 +10,7 @@
 
 ## Alternative Approaches
 
-> This section contains information around alternative options that are considered before making a decision. It should contain a explanation on why the alternative approach(es) were not chosen.
+> This section contains information around alternative options that are considered before making a decision. It should contain an explanation on why the alternative approach(es) were not chosen.
 
 ## Decision
 


### PR DESCRIPTION
This pull request fixes several typos and grammatical errors in the following documentation files:  

1. **block-manager.md**:  
   - Added a hyphen to "1 second delay" to correctly form the adjectival compound "1-second delay."  

2. **adr-006-da-interface.md**:  
   - Replaced "a explanation" with "an explanation" for grammatical correctness.  

3. **adr-template.md**:  
   - Replaced "a explanation" with "an explanation" for grammatical correctness.  

### Rationale  
These changes improve the grammatical accuracy and readability of the documentation, ensuring consistency and clarity for contributors and users.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Improved clarity and consistency in the block manager documentation regarding lazy block production mode.
	- Corrected typographical errors in the ADR documents, enhancing grammatical accuracy.
	- Maintained the structure and content of the ADR template, ensuring effective guidance for documenting architectural decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->