### PR TITLE
fix: typos in documentation files

### DIFF
--- a/specs/lazy-adr/adr-001-node-interface.md
+++ b/specs/lazy-adr/adr-001-node-interface.md
@@ -7,7 +7,7 @@
 - 22.01.2023: Rename rollmint to Rollkit
 
 Replacing on the `Node` level gives much flexibility. Still, significant amount of code can be reused, and there is no need to refactor lazyledger-core.
-Cosmos SDK is tigtly coupled with Tendermint with regards to node creation, RPC, app initialization, etc. De-coupling requires big refactoring of cosmos-sdk.
+Cosmos SDK is tightly coupled with Tendermint with regards to node creation, RPC, app initialization, etc. De-coupling requires big refactoring of cosmos-sdk.
 
 There are known issues related to Tendermint RPC communication.
 

--- a/specs/lazy-adr/adr-001-node-interface.md
+++ b/specs/lazy-adr/adr-001-node-interface.md
@@ -14,7 +14,7 @@ There are known issues related to Tendermint RPC communication.
 ## Replacing Tendermint `Node`
 
 Tendermint `Node` is a struct. It's used directly in cosmos-sdk (not via interface).
-We don't need to introduce common interface `Node`s, because the plan is to use scafolding tool in the feature, so we can make any required changes in cosmos-sdk.
+We don't need to introduce common interface `Node`s, because the plan is to use scaffolding tool in the feature, so we can make any required changes in cosmos-sdk.
 
 ### Interface required by cosmos-sdk
 

--- a/specs/lazy-adr/adr-001-node-interface.md
+++ b/specs/lazy-adr/adr-001-node-interface.md
@@ -14,7 +14,7 @@ There are known issues related to Tendermint RPC communication.
 ## Replacing Tendermint `Node`
 
 Tendermint `Node` is a struct. It's used directly in cosmos-sdk (not via interface).
-We don't need to introduce common interface `Node`s, because the plan is to use scaffolding tool in the feature, so we can make any required changes in cosmos-sdk.
+We don't need to introduce common interface `Node`s, because the plan is to use scaffolding tool in the future, so we can make any required changes in cosmos-sdk.
 
 ### Interface required by cosmos-sdk
 

--- a/specs/lazy-adr/adr-001-node-interface.md
+++ b/specs/lazy-adr/adr-001-node-interface.md
@@ -44,7 +44,7 @@ We don't need to introduce common interface `Node`s, because the plan is to use 
 ## `tendermint` vs `lazyledger-core`
 
 Right now, either `tendermint` or `lazyledger-core` can be used for base types (including interfaces).
-Similarly, vanilla `cosomos-sdk` (not a fork under lazyledger organization) can be used as a base for ORU client.
+Similarly, vanilla `cosmos-sdk` (not a fork under lazyledger organization) can be used as a base for ORU client.
 `lazyledger-core` is a repository created because of needs related to lazyledger client, not optimistic rollups client.
 On the other hand, some of the functionality will be shared between both clients. This will have to be resolved later in time.
 Using 'vanilla' repositories (not forks) probably will make easier to upstream changes if required, and will make scaffolding


### PR DESCRIPTION
Corrected `tigtly` to `tightly`
Corrected `scafolding` to `scaffolding`
Corrected `feature` to `future`
Corrected `cosomos` to `cosmos`




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated terminology and clarified relationships between Cosmos SDK and Tendermint.
	- Renamed "Optimint" to "Rollkit."
	- Corrected spelling errors and discussed implications of tight coupling between systems.
	- Outlined interface requirements for Cosmos SDK and alternative RPC approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->