### PR TITLE
docs: Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rollkit
 
-Rollkit is the first soveriegn rollup framework. For more in-depth information about Rollkit, please visit our [website][docs].
+Rollkit is the first sovereign rollup framework. For more in-depth information about Rollkit, please visit our [website][docs].
 
 <!-- markdownlint-disable MD013 -->
 [![build-and-test](https://github.com/rollkit/rollkit/actions/workflows/test.yml/badge.svg)](https://github.com/rollkit/rollkit/actions/workflows/test.yml)


### PR DESCRIPTION
## Overview

I noticed a typo in the README file.

The word "soveriegn" was misspelled and should be corrected to "sovereign." 

The corrected sentence now reads:  
> Rollkit is the first **sovereign** rollup framework.  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Improved text clarity by correcting a typographical error in the framework’s description, ensuring consistency and accuracy in the product documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->