### PR TITLE
refactor: access data in store by height, not hash

### DIFF
--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -48,9 +47,6 @@ func TestHandlerMapping(t *testing.T) {
 }
 
 func TestREST(t *testing.T) {
-	assert := assert.New(t)
-	require := require.New(t)
-
 	txSearchParams := url.Values{}
 	txSearchParams.Set("query", "message.sender='cosmos1njr26e02fjcq3schxstv458a3w5szp678h23dh'")
 	txSearchParams.Set("prove", "true")
@@ -86,7 +82,7 @@ func TestREST(t *testing.T) {
 
 	_, local := getRPC(t, "TestREST")
 	handler, err := GetHTTPHandler(local, log.TestingLogger())
-	require.NoError(err)
+	require.NoError(t, err)
 
 	// wait for blocks
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
@@ -107,18 +103,16 @@ func TestREST(t *testing.T) {
 			resp := httptest.NewRecorder()
 			handler.ServeHTTP(resp, req)
 
-			assert.Equal(c.httpCode, resp.Code)
+			assert.Equal(t, c.httpCode, resp.Code)
 			s := resp.Body.String()
-			assert.NotEmpty(s)
-			fmt.Print(s)
-			assert.Contains(s, c.bodyContains)
+			assert.NotEmpty(t, s)
+			assert.Contains(t, s, c.bodyContains)
 			var jsonResp response
-			assert.NoError(json.Unmarshal([]byte(s), &jsonResp))
+			assert.NoError(t, json.Unmarshal([]byte(s), &jsonResp))
 			if c.jsonrpcCode != -1 {
-				require.NotNil(jsonResp.Error)
-				assert.EqualValues(c.jsonrpcCode, jsonResp.Error.Code)
+				require.NotNil(t, jsonResp.Error)
+				assert.EqualValues(t, c.jsonrpcCode, jsonResp.Error.Code)
 			}
-			t.Log(s)
 		})
 	}
 

--- a/rpc/json/service_test.go
+++ b/rpc/json/service_test.go
@@ -66,9 +66,9 @@ func TestREST(t *testing.T) {
 		// to keep test simple, allow returning application error in following case
 		{"invalid/missing required param", "/tx", http.StatusOK, int(json2.E_INVALID_REQ), `missing param 'hash'`},
 		{"valid/missing optional param", "/block", http.StatusOK, -1, `"result":{"block_id":`},
-		{"valid/included block tag param", "/block?height=included", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
+		{"valid/included block tag param", "/block?height=included", http.StatusOK, int(json2.E_INTERNAL), "failed to load block header"},
 		{"valid/no params", "/abci_info", http.StatusOK, -1, `"last_block_height":"345"`},
-		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), "failed to load hash from index"},
+		{"valid/int param", "/block?height=321", http.StatusOK, int(json2.E_INTERNAL), "failed to load block header"},
 		{"invalid/int param", "/block?height=foo", http.StatusOK, int(json2.E_PARSE), "failed to parse param 'height'"},
 		{"valid/bool int string params",
 			"/tx_search?" + txSearchParams.Encode(),

--- a/store/store.go
+++ b/store/store.go
@@ -96,7 +96,7 @@ func (s *DefaultStore) SaveBlockData(ctx context.Context, header *types.SignedHe
 	if err != nil {
 		return fmt.Errorf("failed to create a new key for Commit Blob: %w", err)
 	}
-	err = bb.Put(ctx, ds.NewKey(getIndexKey(hash)), hash[:])
+	err = bb.Put(ctx, ds.NewKey(getIndexKey(hash)), encodeHeight(height))
 	if err != nil {
 		return fmt.Errorf("failed to create a new key using height of the block: %w", err)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -105,7 +105,6 @@ func (s *DefaultStore) SaveBlockData(ctx context.Context, header *types.SignedHe
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}
 
-	s.SetHeight(ctx, height)
 	return nil
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -174,7 +174,7 @@ func (s *DefaultStore) GetBlockResponses(ctx context.Context, height uint64) (*a
 	return &responses, nil
 }
 
-// GetSignature returns signature for a block at given height, or error if it's not found in Store.
+// GetSignatureByHash returns signature for a block at given height, or error if it's not found in Store.
 func (s *DefaultStore) GetSignatureByHash(ctx context.Context, hash types.Hash) (*types.Signature, error) {
 	height, err := s.loadHeightFromIndex(ctx, hash)
 	if err != nil {
@@ -183,7 +183,7 @@ func (s *DefaultStore) GetSignatureByHash(ctx context.Context, hash types.Hash) 
 	return s.GetSignature(ctx, height)
 }
 
-// GetSignatureByHash returns signature for a block with given block header hash, or error if it's not found in Store.
+// GetSignature returns signature for a block with given block header hash, or error if it's not found in Store.
 func (s *DefaultStore) GetSignature(ctx context.Context, height uint64) (*types.Signature, error) {
 	signatureData, err := s.db.Get(ctx, ds.NewKey(getSignatureKey(height)))
 	if err != nil {

--- a/store/store.go
+++ b/store/store.go
@@ -26,6 +26,7 @@ var (
 	statePrefix          = "s"
 	responsesPrefix      = "r"
 	metaPrefix           = "m"
+	heightIndexPrefix    = "h"
 )
 
 // DefaultStore is a default store implmementation.
@@ -102,7 +103,11 @@ func (s *DefaultStore) SaveBlockData(ctx context.Context, header *types.SignedHe
 	if err != nil {
 		return fmt.Errorf("failed to create a new key using height of the block: %w", err)
 	}
-
+	// Store height indexed by hash
+	err = s.storeHeightForHash(ctx, block.Hash(), block.Height())
+	if err != nil {
+		return fmt.Errorf("failed to create a new key using hash of the block: %w", err)
+	}
 	if err = bb.Commit(ctx); err != nil {
 		return fmt.Errorf("failed to commit transaction: %w", err)
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -135,15 +135,15 @@ func (s *DefaultStore) GetBlockData(ctx context.Context, height uint64) (*types.
 
 // GetBlockByHash returns block with given block header hash, or error if it's not found in Store.
 func (s *DefaultStore) GetBlockByHash(ctx context.Context, hash types.Hash) (*types.SignedHeader, *types.Data, error) {
-	height, err := s.GetHeightByHash(ctx, hash)
+	height, err := s.getHeightByHash(ctx, hash)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to load height from index %w", err)
 	}
 	return s.GetBlockData(ctx, height)
 }
 
-// GetHeightByHash returns height for a block with given block header hash.
-func (s *DefaultStore) GetHeightByHash(ctx context.Context, hash types.Hash) (uint64, error) {
+// getHeightByHash returns height for a block with given block header hash.
+func (s *DefaultStore) getHeightByHash(ctx context.Context, hash types.Hash) (uint64, error) {
 	heightBytes, err := s.db.Get(ctx, ds.NewKey(getIndexKey(hash)))
 	if err != nil {
 		return 0, fmt.Errorf("failed to get height for hash %v: %w", hash, err)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Closes #1494
Replaces #1791

This is a rebase of previous work from @TropicalDog17, with small fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the internal block data storage mechanism to use block heights for indexing, improving data retrieval reliability.
- **Bug Fixes**
  - Refined error messaging during block data loading to provide clearer and more consistent feedback.
- **Tests**
  - Enhanced error reporting in test cases by improving assertion clarity and updating expected error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->