### PR TITLE
fix: tryStartMockSequencerServerGRPC would start a server anyway in some cases

### DIFF
--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -280,7 +280,7 @@ func tryStartMockSequencerServerGRPC(listenAddress string, rollupId string) (*gr
 	server := seqGRPC.NewServer(dummySeq, dummySeq, dummySeq)
 	lis, err := net.Listen("tcp", listenAddress)
 	if err != nil {
-		if errors.Is(err, syscall.EADDRINUSE) {
+		if errors.Is(err, syscall.EADDRINUSE) || errors.Is(err, syscall.EADDRNOTAVAIL) {
 			logger.Info(errSequencerAlreadyRunning.Error(), "address", listenAddress)
 			logger.Info("make sure your rollupID matches your sequencer", "rollupID", rollupId)
 			return nil, errSequencerAlreadyRunning


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

On my Mac, when providing the DA address, rollkit would start a mock DA anyway, ignoring my passed in address. This seems to be because I was trying to use a remote URL, thus returning a different error.


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced network error handling during service startup. The system now more effectively detects when a network resource is either occupied or unavailable, providing clear notifications to help you quickly troubleshoot configuration issues and ensure a smoother startup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->