### PR TITLE
feat: add configurable max gRPC message size

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -48,6 +48,8 @@ const (
 	FlagSequencerRollupID = "rollkit.sequencer_rollup_id"
 	// FlagExecutorAddress is a flag for specifying the sequencer middleware address
 	FlagExecutorAddress = "rollkit.executor_address"
+	// FlagMaxMsgSize is a flag for specifying the maximum gRPC message size (in bytes)
+	FlagMaxMsgSize = "rollkit.max_msg_size"
 )
 
 // NodeConfig stores Rollkit node configuration.
@@ -74,6 +76,8 @@ type NodeConfig struct {
 	SequencerRollupID string `mapstructure:"sequencer_rollup_id"`
 
 	ExecutorAddress string `mapstructure:"executor_address"`
+
+	MaxMsgSize int `mapstructure:"max_msg_size"`
 }
 
 // HeaderConfig allows node to pass the initial trusted header hash to start the header exchange service
@@ -171,4 +175,5 @@ func AddFlags(cmd *cobra.Command) {
 	cmd.Flags().String(FlagSequencerAddress, def.SequencerAddress, "sequencer middleware address (host:port)")
 	cmd.Flags().String(FlagSequencerRollupID, def.SequencerRollupID, "sequencer middleware rollup ID (default: mock-rollup)")
 	cmd.Flags().String(FlagExecutorAddress, def.ExecutorAddress, "executor middleware address (host:port)")
+	cmd.Flags().Int(FlagMaxMsgSize, def.MaxMsgSize, "maximum gRPC message size (in bytes)")
 }

--- a/config/defaults.go
+++ b/config/defaults.go
@@ -43,4 +43,5 @@ var DefaultNodeConfig = NodeConfig{
 	SequencerAddress:  DefaultSequencerAddress,
 	SequencerRollupID: DefaultSequencerRollupID,
 	ExecutorAddress:   DefaultExecutorAddress,
+	MaxMsgSize:        4 * 1024 * 1024,
 }

--- a/node/full.go
+++ b/node/full.go
@@ -269,6 +269,10 @@ func initExecutor(cfg config.NodeConfig) (execution.Executor, error) {
 	client := execproxy.NewClient()
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(cfg.MaxMsgSize),
+			grpc.MaxCallSendMsgSize(cfg.MaxMsgSize),
+		),
 	}
 
 	err := client.Start(cfg.ExecutorAddress, opts...)
@@ -386,6 +390,10 @@ func (n *FullNode) OnStart() error {
 	if err := n.seqClient.Start(
 		n.nodeConfig.SequencerAddress,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		grpc.WithDefaultCallOptions(
+			grpc.MaxCallRecvMsgSize(n.nodeConfig.MaxMsgSize),
+			grpc.MaxCallSendMsgSize(n.nodeConfig.MaxMsgSize),
+		),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Introduce a `MaxMsgSize` parameter to configure the maximum gRPC message size for sending and receiving. This update ensures more flexibility in handling larger gRPC messages and prevents message size-related issues. New configuration flag and default value have been added accordingly.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
