### PR TITLE
test: Fix inconsistent test case name in params_test.go

### DIFF
--- a/types/params_test.go
+++ b/types/params_test.go
@@ -116,9 +116,9 @@ func TestConsensusParamsValidateBasic(t *testing.T) {
 			},
 			err: ErrPubKeyTypesEmpty,
 		},
-		// 8. Test PubKeyType unknown
+		// 8. Test PubKeyTypes unknown
 		{
-			name: "PubKeyType unknown",
+			name: "PubKeyTypes unknown",
 			prepare: func() cmtypes.ConsensusParams {
 				return cmtypes.ConsensusParams{
 					Block: cmtypes.BlockParams{


### PR DESCRIPTION
Changed test case name from "PubKeyType unknown" to "PubKeyTypes unknown" to maintain consistency with other test names and match the actual parameter name PubKeyTypes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test naming for improved consistency and clarity in validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->