### PR TITLE
refactor: use t.TempDir() instead of os.MkdirTemp

### DIFF
--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
-	"os"
 	"strconv"
 	"testing"
 	"time"
@@ -204,16 +203,12 @@ func TestPendingBlocks(t *testing.T) {
 	mockDA.On("Submit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("DA not available"))
 
 	dac := da.NewDAClient(mockDA, 1234, -1, goDA.Namespace(MockDAAddress), nil, nil)
-	dbPath, err := os.MkdirTemp("", "testdb")
-	require.NoError(t, err)
-	defer func() {
-		_ = os.RemoveAll(dbPath)
-	}()
+	dbPath := t.TempDir()
 
 	genesis, genesisValidatorKey := types.GetGenesisWithPrivkey(types.DefaultSigningKeyType, "TestPendingBlocks")
 
 	node, _ := createAggregatorWithPersistence(ctx, dbPath, dac, genesis, genesisValidatorKey, t)
-	err = node.Start()
+	err := node.Start()
 	assert.NoError(t, err)
 
 	const (

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -3,7 +3,6 @@ package store
 import (
 	"context"
 	"fmt"
-	"os"
 	"testing"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
@@ -83,14 +82,7 @@ func TestStoreLoad(t *testing.T) {
 		//}},
 	}
 
-	tmpDir, err := os.MkdirTemp("", "rollkit_test")
-	require.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(tmpDir)
-		if err != nil {
-			t.Log("failed to remove temporary directory", err)
-		}
-	}()
+	tmpDir := t.TempDir()
 
 	mKV, _ := NewDefaultInMemoryKVStore()
 	dKV, _ := NewDefaultKVStore(tmpDir, "db", "test")
@@ -139,11 +131,7 @@ func TestRestart(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	tmpDir, err := os.MkdirTemp("", t.Name())
-	require.NoError(err)
-	defer func() {
-		_ = os.RemoveAll(tmpDir)
-	}()
+	tmpDir := t.TempDir()
 
 	kv, err := NewDefaultKVStore(tmpDir, "test", "test")
 	require.NoError(err)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

 TempDir returns a temporary directory for the test to use.The directory is automatically removed when the test and
all its subtests complete. More info  https://pkg.go.dev/testing#B.TempDir


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test setup by switching to automated temporary directory management, reducing manual error handling and cleanup.
	- Streamlined test initialization processes for improved reliability and robustness, indirectly supporting overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->