### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/node/full.go
+++ b/node/full.go
@@ -438,7 +438,7 @@ func (n *FullNode) GetGenesisChunks() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return n.genChunks, err
+	return n.genChunks, nil
 }
 
 // OnStop is a part of Service interface.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted the logic for fetching initial data segments so that successful operations consistently indicate no error, preventing potential confusion during normal use.
- **New Features**
	- Help messages are now displayed in alphabetical order for improved readability.
- **Refactor**
	- Simplified temporary directory creation in tests, enhancing code clarity and reducing error handling complexity.
	- Updated integer presence check functionality for conciseness and efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->