### PR TITLE
refactor: use `errors.New` to replace `fmt.Errorf` with no parameters

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -1502,7 +1502,7 @@ func updateState(s *types.State, res *abci.ResponseInitChain) error {
 		return err
 	}
 	if len(nValSet.Validators) != 1 {
-		return fmt.Errorf("expected exactly one validator")
+		return errors.New("expected exactly one validator")
 	}
 
 	s.Validators = cmtypes.NewValidatorSet(nValSet.Validators)

--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -346,7 +346,7 @@ func TestVoteExtension(t *testing.T) {
 
 		invalidVoteExtension := func(_ context.Context, req *abci.RequestExtendVote) (*abci.ResponseExtendVote, error) {
 			extendVoteFailureChan <- struct{}{}
-			return nil, fmt.Errorf("ExtendVote failed")
+			return nil, errors.New("ExtendVote failed")
 		}
 		app.On("ExtendVote", mock.Anything, mock.Anything).Return(invalidVoteExtension)
 


### PR DESCRIPTION
Similar to #2023 

I have checked across whole repository, there is no more `fmt.Errorf` with no parameters now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined error handling to ensure consistent, straightforward error messages without changing overall functionality.
- **Tests**
	- Adjusted internal test validations to align with the updated error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->