### PR TITLE
refactor(test): using `t.TempDir` to auto-manage test temp dir

### DIFF
--- a/state/txindex/kv/kv_bench_test.go
+++ b/state/txindex/kv/kv_bench_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"io/ioutil"
 	"testing"
 
 	abci "github.com/cometbft/cometbft/abci/types"
@@ -15,12 +14,9 @@ import (
 )
 
 func BenchmarkTxSearch(b *testing.B) {
-	dbDir, err := ioutil.TempDir("", "benchmark_tx_search_test")
-	if err != nil {
-		b.Errorf("failed to create temporary directory: %s", err)
-	}
+	dbDir := b.TempDir()
 
-	db, _ := store.NewDefaultKVStore(dbDir, "db", "benchmark_tx_search_test")
+	db, err := store.NewDefaultKVStore(dbDir, "db", "benchmark_tx_search_test")
 	if err != nil {
 		b.Errorf("failed to create database: %s", err)
 	}

--- a/state/txindex/kv/kv_test.go
+++ b/state/txindex/kv/kv_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
-	"os"
 	"testing"
 
 	"github.com/gogo/protobuf/proto"
@@ -340,9 +338,7 @@ func txResultWithEvents(events []abci.Event) *abci.TxResult {
 }
 
 func benchmarkTxIndex(txsCount int64, b *testing.B) {
-	dir, err := ioutil.TempDir("", "tx_index_db")
-	require.NoError(b, err)
-	defer os.RemoveAll(dir)
+	dir := b.TempDir()
 
 	store, err := store.NewDefaultKVStore(dir, "db", "tx_index")
 	require.NoError(b, err)


### PR DESCRIPTION
`ioutil.TempDir` could be replaced by `t.TempDir` in tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Simplified the setup process for temporary resources in performance testing.
  - Enhanced error handling during test initialization to improve overall test reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->