### PR TITLE
fix(ci): nolint should be written without leading space

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -182,7 +182,7 @@ func getInitialState(store store.Store, genesis *cmtypes.GenesisDoc) (types.Stat
 		// Perform a sanity-check to stop the user from
 		// using a higher genesis than the last stored state.
 		// if they meant to hard-fork, they should have cleared the stored State
-		if uint64(genesis.InitialHeight) > s.LastBlockHeight { //nolint:gosec
+		if uint64(genesis.InitialHeight) > s.LastBlockHeight {
 			return types.State{}, fmt.Errorf("genesis.InitialHeight (%d) is greater than last stored state's LastBlockHeight (%d)", genesis.InitialHeight, s.LastBlockHeight)
 		}
 	}
@@ -249,7 +249,7 @@ func NewManager(
 	maxBlobSize -= blockProtocolOverhead
 
 	exec := state.NewBlockExecutor(proposerAddress, genesis.ChainID, mempool, mempoolReaper, proxyApp, eventBus, maxBlobSize, logger, execMetrics)
-	if s.LastBlockHeight+1 == uint64(genesis.InitialHeight) { //nolint:gosec
+	if s.LastBlockHeight+1 == uint64(genesis.InitialHeight) {
 		res, err := exec.InitChain(genesis)
 		if err != nil {
 			return nil, err
@@ -477,7 +477,7 @@ func (m *Manager) BatchRetrieveLoop(ctx context.Context) {
 
 // AggregationLoop is responsible for aggregating transactions into rollup-blocks.
 func (m *Manager) AggregationLoop(ctx context.Context) {
-	initialHeight := uint64(m.genesis.InitialHeight) //nolint:gosec
+	initialHeight := uint64(m.genesis.InitialHeight)
 	height := m.store.Height()
 	var delay time.Duration
 
@@ -1057,7 +1057,7 @@ func (m *Manager) publishBlock(ctx context.Context) error {
 	height := m.store.Height()
 	newHeight := height + 1
 	// this is a special case, when first block is produced - there is no previous commit
-	if newHeight == uint64(m.genesis.InitialHeight) { //nolint:gosec
+	if newHeight == uint64(m.genesis.InitialHeight) {
 		lastSignature = &types.Signature{}
 	} else {
 		lastSignature, err = m.store.GetSignature(ctx, height)
@@ -1255,7 +1255,7 @@ func (m *Manager) processVoteExtension(ctx context.Context, header *types.Signed
 	}
 
 	vote := &cmproto.Vote{
-		Height:    int64(newHeight), //nolint:gosec
+		Height:    int64(newHeight),
 		Round:     0,
 		Extension: extension,
 	}
@@ -1275,12 +1275,12 @@ func (m *Manager) processVoteExtension(ctx context.Context, header *types.Signed
 
 func (m *Manager) voteExtensionEnabled(newHeight uint64) bool {
 	enableHeight := m.lastState.ConsensusParams.Abci.VoteExtensionsEnableHeight
-	return m.lastState.ConsensusParams.Abci != nil && enableHeight != 0 && uint64(enableHeight) <= newHeight //nolint:gosec
+	return m.lastState.ConsensusParams.Abci != nil && enableHeight != 0 && uint64(enableHeight) <= newHeight
 }
 
 func (m *Manager) getExtendedCommit(ctx context.Context, height uint64) (abci.ExtendedCommitInfo, error) {
 	emptyExtendedCommit := abci.ExtendedCommitInfo{}
-	if !m.voteExtensionEnabled(height) || height <= uint64(m.genesis.InitialHeight) { //nolint:gosec
+	if !m.voteExtensionEnabled(height) || height <= uint64(m.genesis.InitialHeight) {
 		return emptyExtendedCommit, nil
 	}
 	extendedCommit, err := m.store.GetExtendedCommit(ctx, height)
@@ -1382,7 +1382,7 @@ daSubmitRetryLoop:
 			m.logger.Debug("resetting DA layer submission options", "backoff", backoff, "gasPrice", gasPrice, "maxBlobSize", maxBlobSize)
 		case da.StatusNotIncludedInBlock, da.StatusAlreadyInMempool:
 			m.logger.Error("DA layer submission failed", "error", res.Message, "attempt", attempt)
-			backoff = m.conf.DABlockTime * time.Duration(m.conf.DAMempoolTTL) //nolint:gosec
+			backoff = m.conf.DABlockTime * time.Duration(m.conf.DAMempoolTTL)
 			if m.dalc.GasMultiplier > 0 && gasPrice != -1 {
 				gasPrice = gasPrice * m.dalc.GasMultiplier
 			}

--- a/cmd/rollkit/commands/intercept.go
+++ b/cmd/rollkit/commands/intercept.go
@@ -95,7 +95,6 @@ func InterceptCommand(
 		if err != nil && !errors.Is(err, errSequencerAlreadyRunning) {
 			return shouldExecute, fmt.Errorf("failed to launch mock sequencing server: %w", err)
 		}
-		// nolint:errcheck,gosec
 		defer func() {
 			if seqSrv != nil {
 				seqSrv.Stop()

--- a/cmd/rollkit/commands/run_node.go
+++ b/cmd/rollkit/commands/run_node.go
@@ -152,7 +152,6 @@ func NewRunNodeCmd() *cobra.Command {
 			if err != nil && !errors.Is(err, errSequencerAlreadyRunning) {
 				return fmt.Errorf("failed to launch mock sequencing server: %w", err)
 			}
-			// nolint:errcheck,gosec
 			defer func() {
 				if seqSrv != nil {
 					seqSrv.Stop()

--- a/node/full_client.go
+++ b/node/full_client.go
@@ -294,13 +294,13 @@ func (c *FullClient) GenesisChunked(context context.Context, id uint) (*ctypes.R
 		return nil, errors.New("service configuration error, there are no chunks")
 	}
 
-	if int(id) > chunkLen-1 { //nolint:gosec
+	if int(id) > chunkLen-1 {
 		return nil, fmt.Errorf("there are %d chunks, %d is invalid", chunkLen-1, id)
 	}
 
 	return &ctypes.ResultGenesisChunk{
 		TotalChunks: chunkLen,
-		ChunkNumber: int(id), //nolint:gosec
+		ChunkNumber: int(id),
 		Data:        genChunks[id],
 	}, nil
 }
@@ -312,7 +312,7 @@ func (c *FullClient) BlockchainInfo(ctx context.Context, minHeight, maxHeight in
 	// Currently blocks are not pruned and are synced linearly so the base height is 0
 	minHeight, maxHeight, err := filterMinMax(
 		0,
-		int64(c.node.Store.Height()), //nolint:gosec
+		int64(c.node.Store.Height()),
 		minHeight,
 		maxHeight,
 		limit)
@@ -337,7 +337,7 @@ func (c *FullClient) BlockchainInfo(ctx context.Context, minHeight, maxHeight in
 	}
 
 	return &ctypes.ResultBlockchainInfo{
-		LastHeight: int64(c.node.Store.Height()), //nolint:gosec
+		LastHeight: int64(c.node.Store.Height()),
 		BlockMetas: blocks,
 	}, nil
 
@@ -383,7 +383,7 @@ func (c *FullClient) ConsensusParams(ctx context.Context, height *int64) (*ctype
 	}
 	params := state.ConsensusParams
 	return &ctypes.ResultConsensusParams{
-		BlockHeight: int64(c.normalizeHeight(height)), //nolint:gosec
+		BlockHeight: int64(c.normalizeHeight(height)),
 		ConsensusParams: cmtypes.ConsensusParams{
 			Block: cmtypes.BlockParams{
 				MaxBytes: params.Block.MaxBytes,
@@ -487,7 +487,7 @@ func (c *FullClient) BlockResults(ctx context.Context, height *int64) (*ctypes.R
 	}
 
 	return &ctypes.ResultBlockResults{
-		Height:                int64(h), //nolint:gosec
+		Height:                int64(h),
 		TxsResults:            resp.TxResults,
 		FinalizeBlockEvents:   resp.Events,
 		ValidatorUpdates:      resp.ValidatorUpdates,
@@ -539,7 +539,7 @@ func (c *FullClient) Validators(ctx context.Context, heightPtr *int64, pagePtr, 
 	}
 
 	return &ctypes.ResultValidators{
-		BlockHeight: int64(height), //nolint:gosec
+		BlockHeight: int64(height),
 		Validators: []*cmtypes.Validator{
 			&validator,
 		},

--- a/node/full_client_test.go
+++ b/node/full_client_test.go
@@ -188,7 +188,7 @@ func TestGenesisChunked(t *testing.T) {
 	gotID := gc2.ChunkNumber
 	assert.NoError(err)
 	assert.NotNil(gc2)
-	assert.Equal(int(expectedID), gotID) //nolint:gosec
+	assert.Equal(int(expectedID), gotID)
 
 	gc3, err := rpc.GenesisChunked(context.Background(), 5)
 	assert.Error(err)

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -691,7 +691,7 @@ func doTestMaxPending(maxPending uint64, t *testing.T) {
 		require.NoError(waitForAtLeastNBlocks(seq, 3, Store))
 		return
 	} else { // if there is a limit, sequencer should produce exactly maxPending blocks and pause
-		require.NoError(waitForAtLeastNBlocks(seq, int(maxPending), Store)) //nolint:gosec
+		require.NoError(waitForAtLeastNBlocks(seq, int(maxPending), Store))
 		// wait few block times and ensure that new blocks are not produced
 		time.Sleep(3 * seq.nodeConfig.BlockTime)
 		require.EqualValues(maxPending, seq.Store.Height())
@@ -710,7 +710,7 @@ func doTestMaxPending(maxPending uint64, t *testing.T) {
 		})
 
 	// wait for next block to ensure that sequencer is producing blocks again
-	require.NoError(waitForAtLeastNBlocks(seq, int(maxPending+1), Store)) //nolint:gosec
+	require.NoError(waitForAtLeastNBlocks(seq, int(maxPending+1), Store))
 }
 
 // TODO: https://github.com/rollkit/rollkit/issues/1811

--- a/rpc/json/helpers_test.go
+++ b/rpc/json/helpers_test.go
@@ -49,7 +49,6 @@ func TestMain(m *testing.M) {
 	exitCode := m.Run()
 
 	// teardown servers
-	// nolint:errcheck,gosec
 	grpcSrv.Stop()
 
 	os.Exit(exitCode)

--- a/state/executor.go
+++ b/state/executor.go
@@ -101,9 +101,9 @@ func (e *BlockExecutor) CreateBlock(height uint64, lastSignature *types.Signatur
 	if emptyMaxBytes {
 		maxBytes = int64(cmtypes.MaxBlockSizeBytes)
 	}
-	if maxBytes > int64(e.maxBytes) { //nolint:gosec
+	if maxBytes > int64(e.maxBytes) {
 		e.logger.Debug("limiting maxBytes to", "e.maxBytes=%d", e.maxBytes)
-		maxBytes = int64(e.maxBytes) //nolint:gosec
+		maxBytes = int64(e.maxBytes)
 	}
 
 	header := &types.SignedHeader{
@@ -115,7 +115,7 @@ func (e *BlockExecutor) CreateBlock(height uint64, lastSignature *types.Signatur
 			BaseHeader: types.BaseHeader{
 				ChainID: e.chainID,
 				Height:  height,
-				Time:    uint64(timestamp.UnixNano()), //nolint:gosec
+				Time:    uint64(timestamp.UnixNano()),
 			},
 			DataHash:        make(types.Hash, 32),
 			ConsensusHash:   make(types.Hash, 32),
@@ -139,8 +139,8 @@ func (e *BlockExecutor) CreateBlock(height uint64, lastSignature *types.Signatur
 			Txs:                txs.ToSliceOfBytes(),
 			LocalLastCommit:    lastExtendedCommit,
 			Misbehavior:        []abci.Misbehavior{},
-			Height:             int64(header.Height()), //nolint:gosec
-			Time:               header.Time(),          //TODO: replace with sequencer timestamp
+			Height:             int64(header.Height()),
+			Time:               header.Time(), //TODO: replace with sequencer timestamp
 			NextValidatorsHash: state.Validators.Hash(),
 			ProposerAddress:    e.proposerAddress,
 		},
@@ -178,7 +178,7 @@ func (e *BlockExecutor) ProcessProposal(
 ) (bool, error) {
 	resp, err := e.proxyApp.ProcessProposal(context.TODO(), &abci.RequestProcessProposal{
 		Hash:   header.Hash(),
-		Height: int64(header.Height()), //nolint:gosec
+		Height: int64(header.Height()),
 		Time:   header.Time(),
 		Txs:    data.Txs.ToSliceOfBytes(),
 		ProposedLastCommit: abci.CommitInfo{
@@ -253,7 +253,7 @@ func (e *BlockExecutor) ApplyBlock(ctx context.Context, state types.State, heade
 func (e *BlockExecutor) ExtendVote(ctx context.Context, header *types.SignedHeader, data *types.Data) ([]byte, error) {
 	resp, err := e.proxyApp.ExtendVote(ctx, &abci.RequestExtendVote{
 		Hash:   header.Hash(),
-		Height: int64(header.Height()), //nolint:gosec
+		Height: int64(header.Height()),
 		Time:   header.Time(),
 		Txs:    data.Txs.ToSliceOfBytes(),
 		ProposedLastCommit: abci.CommitInfo{
@@ -295,7 +295,7 @@ func (e *BlockExecutor) updateConsensusParams(height uint64, params cmtypes.Cons
 	if err := types.ConsensusParamsValidateBasic(nextParams); err != nil {
 		return cmproto.ConsensusParams{}, 0, fmt.Errorf("validating new consensus params: %w", err)
 	}
-	if err := nextParams.ValidateUpdate(consensusParamUpdates, int64(height)); err != nil { //nolint:gosec
+	if err := nextParams.ValidateUpdate(consensusParamUpdates, int64(height)); err != nil {
 		return cmproto.ConsensusParams{}, 0, fmt.Errorf("updating consensus params: %w", err)
 	}
 	return nextParams.ToProto(), nextParams.Version.App, nil
@@ -329,7 +329,7 @@ func (e *BlockExecutor) updateState(state types.State, header *types.SignedHeade
 			}
 		}
 		// Change results from this height but only applies to the next next height.
-		lastHeightValSetChanged = int64(header.Header.Height() + 1 + 1) //nolint:gosec
+		lastHeightValSetChanged = int64(header.Header.Height() + 1 + 1)
 
 		if len(nValSet.Validators) > 0 {
 			nValSet.IncrementProposerPriority(1)
@@ -382,7 +382,7 @@ func (e *BlockExecutor) commit(ctx context.Context, state types.State, header *t
 		return nil, 0, err
 	}
 
-	return resp.AppHash, uint64(commitResp.RetainHeight), err //nolint:gosec
+	return resp.AppHash, uint64(commitResp.RetainHeight), err
 }
 
 // Validate validates the state and the block for the executor
@@ -512,7 +512,7 @@ func (e *BlockExecutor) publishEvents(resp *abci.ResponseFinalizeBlock, header *
 		for _, ev := range abciBlock.Evidence.Evidence {
 			if err := e.eventBus.PublishEventNewEvidence(cmtypes.EventDataNewEvidence{
 				Evidence: ev,
-				Height:   int64(header.Header.Height()), //nolint:gosec
+				Height:   int64(header.Header.Height()),
 			}); err != nil {
 				e.logger.Error("failed publishing new evidence", "err", err)
 			}
@@ -523,7 +523,7 @@ func (e *BlockExecutor) publishEvents(resp *abci.ResponseFinalizeBlock, header *
 		err := e.eventBus.PublishEventTx(cmtypes.EventDataTx{
 			TxResult: abci.TxResult{
 				Height: abciBlock.Height,
-				Index:  uint32(i), //nolint:gosec
+				Index:  uint32(i),
 				Tx:     tx,
 				Result: *(resp.TxResults[i]),
 			},

--- a/types/abci/block.go
+++ b/types/abci/block.go
@@ -19,7 +19,7 @@ func ToABCIHeaderPB(header *types.Header) (cmproto.Header, error) {
 			Block: header.Version.Block,
 			App:   header.Version.App,
 		},
-		Height: int64(header.Height()), //nolint:gosec
+		Height: int64(header.Height()),
 		Time:   header.Time(),
 		LastBlockId: cmproto.BlockID{
 			Hash: header.LastHeaderHash[:],
@@ -49,7 +49,7 @@ func ToABCIHeader(header *types.Header) (cmtypes.Header, error) {
 			Block: header.Version.Block,
 			App:   header.Version.App,
 		},
-		Height: int64(header.Height()), //nolint:gosec
+		Height: int64(header.Height()),
 		Time:   header.Time(),
 		LastBlockID: cmtypes.BlockID{
 			Hash: cmbytes.HexBytes(header.LastHeaderHash[:]),

--- a/types/abci/block_test.go
+++ b/types/abci/block_test.go
@@ -22,7 +22,7 @@ func TestToABCIHeaderPB(t *testing.T) {
 			Block: header.Version.Block,
 			App:   header.Version.App,
 		},
-		Height: int64(header.Height()), //nolint:gosec
+		Height: int64(header.Height()),
 		Time:   header.Time(),
 		LastBlockId: cmproto.BlockID{
 			Hash: header.LastHeaderHash[:],
@@ -58,7 +58,7 @@ func TestToABCIHeader(t *testing.T) {
 			Block: header.Version.Block,
 			App:   header.Version.App,
 		},
-		Height: int64(header.Height()), //nolint:gosec
+		Height: int64(header.Height()),
 		Time:   header.Time(),
 		LastBlockID: cmtypes.BlockID{
 			Hash: cmbytes.HexBytes(header.LastHeaderHash[:]),

--- a/types/hashing.go
+++ b/types/hashing.go
@@ -19,7 +19,7 @@ func (h *Header) Hash() Hash {
 			Block: h.Version.Block,
 			App:   h.Version.App,
 		},
-		Height: int64(h.Height()), //nolint:gosec
+		Height: int64(h.Height()),
 		Time:   h.Time(),
 		LastBlockID: cmtypes.BlockID{
 			Hash: cmbytes.HexBytes(h.LastHeaderHash),

--- a/types/header.go
+++ b/types/header.go
@@ -92,7 +92,7 @@ func (h *Header) LastHeader() Hash {
 
 // Time returns timestamp as unix time with nanosecond precision
 func (h *Header) Time() time.Time {
-	return time.Unix(0, int64(h.BaseHeader.Time)) //nolint:gosec
+	return time.Unix(0, int64(h.BaseHeader.Time))
 }
 
 // Verify verifies the header.
@@ -128,7 +128,7 @@ func (h *Header) ValidateBasic() error {
 func (h *Header) MakeCometBFTVote() []byte {
 	vote := cmtproto.Vote{
 		Type:   cmtproto.PrecommitType,
-		Height: int64(h.Height()), //nolint:gosec
+		Height: int64(h.Height()),
 		Round:  0,
 		// Header hash = block hash in rollkit
 		BlockID: cmtproto.BlockID{

--- a/types/utils.go
+++ b/types/utils.go
@@ -403,7 +403,7 @@ func getBlockDataWith(nTxs int) *Data {
 // Other fields (especially ValidatorAddress and Timestamp of Signature) have to be filled by caller.
 func GetABCICommit(height uint64, hash Hash, val cmtypes.Address, time time.Time, signature Signature) *cmtypes.Commit {
 	tmCommit := cmtypes.Commit{
-		Height: int64(height), //nolint:gosec
+		Height: int64(height),
 		Round:  0,
 		BlockID: cmtypes.BlockID{
 			Hash:          cmbytes.HexBytes(hash),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Performed internal code cleanup by removing obsolete lint suppression comments. These changes enhance code clarity and adherence to current linting standards without affecting functionality or the end-user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->