### PR TITLE
fix(block): fix err handling in `prepareSyncer`

### DIFF
--- a/block/sync_service.go
+++ b/block/sync_service.go
@@ -236,16 +236,15 @@ func (syncService *SyncService[H]) prepareSyncer(ctx context.Context) error {
 		syncService.sub,
 		[]goheadersync.Option{goheadersync.WithBlockTime(syncService.conf.BlockTime)},
 	); err != nil {
-		return nil
+		return err
 	}
 
 	if syncService.isInitialized() {
 		if err := syncService.StartSyncer(ctx); err != nil {
-			return nil
+			return err
 		}
-		return nil
 	}
-	return err
+	return nil
 }
 
 // setFirstAndStart looks up for the trusted hash or the genesis header/block.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Based on the comment of `func prepareSyncer`, we should return error instead of nil when initialization or starting of syncer fails


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error reporting by ensuring that issues during process initialization are now properly flagged, preventing errors from being silently suppressed and enhancing overall system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->