### PR TITLE
refactor(da): preallocate `blobs` when submit block headers to DA

### DIFF
--- a/da/da.go
+++ b/da/da.go
@@ -98,7 +98,7 @@ func NewDAClient(da goDA.DA, gasPrice, gasMultiplier float64, ns goDA.Namespace,
 // SubmitHeaders submits block headers to DA.
 func (dac *DAClient) SubmitHeaders(ctx context.Context, headers []*types.SignedHeader, maxBlobSize uint64, gasPrice float64) ResultSubmit {
 	var (
-		blobs    [][]byte
+		blobs    [][]byte = make([][]byte, 0, len(headers))
 		blobSize uint64
 		message  string
 	)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Preallocate `var blobs [][byte` in `SubmitHeaders` to improve blobs allocating


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved internal processing efficiency through optimized data handling, enhancing overall performance without impacting public functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->