### PR TITLE
fix: add test case for zero out of priv key

### DIFF
--- a/pkg/signer/file/file_signer_test.go
+++ b/pkg/signer/file/file_signer_test.go
@@ -237,6 +237,9 @@ func TestKeyPersistence(t *testing.T) {
 	signer1, err := CreateFileSystemSigner(keyPath, passphrase)
 	require.NoError(t, err)
 
+	privateKey1 := signer1.(*FileSystemSigner).privateKey
+	require.NotNil(t, privateKey1)
+
 	// Get public key for later comparison
 	pubKey1, err := signer1.GetPublic()
 	require.NoError(t, err)
@@ -258,6 +261,10 @@ func TestKeyPersistence(t *testing.T) {
 	newPassphrase := []byte("secure-test-passphrase")
 	signer2, err := LoadFileSystemSigner(keyPath, newPassphrase)
 	require.NoError(t, err)
+
+	privateKey3 := signer2.(*FileSystemSigner).privateKey
+	require.NotNil(t, privateKey3)
+	require.Equal(t, privateKey1, privateKey3)
 
 	// Get public key from loaded signer
 	pubKey2, err := signer2.GetPublic()

--- a/pkg/signer/file/local.go
+++ b/pkg/signer/file/local.go
@@ -244,7 +244,6 @@ func (s *FileSystemSigner) loadKeys(passphrase []byte) error {
 
 	// Zero out sensitive data
 	zeroBytes(derivedKey)
-	zeroBytes(privKeyBytes)
 
 	return nil
 }


### PR DESCRIPTION
this pr adds a test case and a fix that was zeroing out the internal decoding of ed25519 keys 