### PR TITLE
refactor: move init to testapp

### DIFF
--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -7,8 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/spf13/cobra"
-
 	rollconf "github.com/rollkit/rollkit/pkg/config"
 	genesispkg "github.com/rollkit/rollkit/pkg/genesis"
 	"github.com/rollkit/rollkit/pkg/hash"
@@ -103,62 +101,4 @@ func InitializeGenesis(homePath string, chainID string, initialHeight uint64, pr
 
 	fmt.Printf("Initialized new genesis file: %s\n", genesisPath)
 	return nil
-}
-
-// InitCmd initializes a new rollkit.yaml file in the current directory
-var InitCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Initialize rollkit config",
-	Long:  fmt.Sprintf("This command initializes a new %s file in the specified directory (or current directory if not specified).", rollconf.ConfigName),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		homePath, err := cmd.Flags().GetString(rollconf.FlagRootDir)
-		if err != nil {
-			return fmt.Errorf("error reading home flag: %w", err)
-		}
-
-		aggregator, err := cmd.Flags().GetBool(rollconf.FlagAggregator)
-		if err != nil {
-			return fmt.Errorf("error reading aggregator flag: %w", err)
-		}
-
-		// ignore error, as we are creating a new config
-		// we use load in order to parse all the flags
-		cfg, _ := rollconf.Load(cmd)
-		cfg.Node.Aggregator = aggregator
-		if err := cfg.Validate(); err != nil {
-			return fmt.Errorf("error validating config: %w", err)
-		}
-
-		passphrase, err := cmd.Flags().GetString(rollconf.FlagSignerPassphrase)
-		if err != nil {
-			return fmt.Errorf("error reading passphrase flag: %w", err)
-		}
-
-		proposerAddress, err := InitializeSigner(&cfg, homePath, passphrase)
-		if err != nil {
-			return err
-		}
-
-		if err := cfg.SaveAsYaml(); err != nil {
-			return fmt.Errorf("error writing rollkit.yaml file: %w", err)
-		}
-
-		if err := InitializeNodeKey(homePath); err != nil {
-			return err
-		}
-
-		// get chain ID or use default
-		chainID, _ := cmd.Flags().GetString(rollconf.FlagChainID)
-		if chainID == "" {
-			chainID = "rollkit-test"
-		}
-
-		// Initialize genesis with empty app state
-		if err := InitializeGenesis(homePath, chainID, 1, proposerAddress, []byte("{}")); err != nil {
-			return fmt.Errorf("error initializing genesis file: %w", err)
-		}
-
-		cmd.Printf("Successfully initialized config file at %s\n", cfg.ConfigPath())
-		return nil
-	},
 }

--- a/rollups/testapp/cmd/init.go
+++ b/rollups/testapp/cmd/init.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	rollcmd "github.com/rollkit/rollkit/pkg/cmd"
+	rollconf "github.com/rollkit/rollkit/pkg/config"
+)
+
+// InitCmd initializes a new rollkit.yaml file in the current directory
+func InitCmd() *cobra.Command {
+	initCmd := &cobra.Command{
+		Use:   "init",
+		Short: "Initialize rollkit config",
+		Long:  fmt.Sprintf("This command initializes a new %s file in the specified directory (or current directory if not specified).", rollconf.ConfigName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			homePath, err := cmd.Flags().GetString(rollconf.FlagRootDir)
+			if err != nil {
+				return fmt.Errorf("error reading home flag: %w", err)
+			}
+
+			aggregator, err := cmd.Flags().GetBool(rollconf.FlagAggregator)
+			if err != nil {
+				return fmt.Errorf("error reading aggregator flag: %w", err)
+			}
+
+			// ignore error, as we are creating a new config
+			// we use load in order to parse all the flags
+			cfg, _ := rollconf.Load(cmd)
+			cfg.Node.Aggregator = aggregator
+			if err := cfg.Validate(); err != nil {
+				return fmt.Errorf("error validating config: %w", err)
+			}
+
+			passphrase, err := cmd.Flags().GetString(rollconf.FlagSignerPassphrase)
+			if err != nil {
+				return fmt.Errorf("error reading passphrase flag: %w", err)
+			}
+
+			proposerAddress, err := rollcmd.InitializeSigner(&cfg, homePath, passphrase)
+			if err != nil {
+				return err
+			}
+
+			if err := cfg.SaveAsYaml(); err != nil {
+				return fmt.Errorf("error writing rollkit.yaml file: %w", err)
+			}
+
+			if err := rollcmd.InitializeNodeKey(homePath); err != nil {
+				return err
+			}
+
+			// get chain ID or use default
+			chainID, _ := cmd.Flags().GetString(rollconf.FlagChainID)
+			if chainID == "" {
+				chainID = "rollkit-test"
+			}
+
+			// Initialize genesis with empty app state
+			if err := rollcmd.InitializeGenesis(homePath, chainID, 1, proposerAddress, []byte("{}")); err != nil {
+				return fmt.Errorf("error initializing genesis file: %w", err)
+			}
+
+			cmd.Printf("Successfully initialized config file at %s\n", cfg.ConfigPath())
+			return nil
+		},
+	}
+
+	// Add flags to the command
+	rollconf.AddFlags(initCmd)
+
+	return initCmd
+}

--- a/rollups/testapp/cmd/init_test.go
+++ b/rollups/testapp/cmd/init_test.go
@@ -36,8 +36,7 @@ func TestInitCommand(t *testing.T) {
 	}
 
 	// Add init command as subcommand
-	initCmd := InitCmd // Create a copy to avoid affecting other tests
-	rollconf.AddFlags(initCmd)
+	initCmd := InitCmd() // Create a copy to avoid affecting other tests
 	cmd.AddCommand(initCmd)
 
 	// Register all persistent flags from root command

--- a/rollups/testapp/main.go
+++ b/rollups/testapp/main.go
@@ -5,17 +5,13 @@ import (
 	"os"
 
 	rollcmd "github.com/rollkit/rollkit/pkg/cmd"
-	rollkitconfig "github.com/rollkit/rollkit/pkg/config"
 	cmds "github.com/rollkit/rollkit/rollups/testapp/cmd"
 )
 
 func main() {
 	// Initiate the root command
 	rootCmd := cmds.RootCmd
-
-	initCmd := rollcmd.InitCmd
-
-	rollkitconfig.AddFlags(initCmd)
+	initCmd := cmds.InitCmd()
 
 	// Add subcommands to the root command
 	rootCmd.AddCommand(


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Move init command to `testapp`. Users should use the helpers when creating their init command.
For instance go-abci-execution will have its own init command supporting the SDK genesis.
This was confusing because it wouldn't generate an app state.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
