### PR TITLE
refactor(genesis): simplify genesis apis

### DIFF
--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -184,7 +184,6 @@ func TestInitialStateUnexpectedHigherGenesis(t *testing.T) {
 		uint64(2), // Set initial height to 2
 		genesisData.GenesisDAStartHeight,
 		genesisData.ProposerAddress,
-		nil, // No raw bytes for now
 	)
 	sampleState := types.State{
 		ChainID:         "TestInitialStateUnexpectedHigherGenesis",
@@ -620,7 +619,6 @@ func TestAggregationLoop(t *testing.T) {
 			1,
 			time.Now(),
 			[]byte{}, // Empty extra data
-			nil,      // No raw bytes for now
 		),
 		config: config.Config{
 			Node: config.NodeConfig{

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"time"
 
 	rollconf "github.com/rollkit/rollkit/pkg/config"
-	genesispkg "github.com/rollkit/rollkit/pkg/genesis"
 	"github.com/rollkit/rollkit/pkg/hash"
 	"github.com/rollkit/rollkit/pkg/p2p/key"
 	"github.com/rollkit/rollkit/pkg/signer/file"
@@ -58,41 +56,6 @@ func LoadOrGenNodeKey(homePath string) error {
 	_, err := key.LoadOrGenNodeKey(nodeKeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to create node key: %w", err)
-	}
-
-	return nil
-}
-
-var ErrGenesisExists = fmt.Errorf("genesis file already exists")
-
-// CreateGenesis creates and saves a genesis file with the given app state.
-// If the genesis file already exists, it skips the creation and returns ErrGenesisExists.
-// The genesis file is saved in the config directory of the specified home path.
-func CreateGenesis(homePath string, chainID string, initialHeight uint64, proposerAddress, appState []byte) error {
-	configDir := filepath.Join(homePath, "config")
-	genesisPath := filepath.Join(configDir, "genesis.json")
-
-	// Check if the genesis file already exists
-	if _, err := os.Stat(genesisPath); err == nil {
-		return ErrGenesisExists
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("failed to check for existing genesis file at %s: %w", genesisPath, err)
-	}
-
-	// If the directory doesn't exist, create it
-	if err := os.MkdirAll(configDir, 0o750); err != nil {
-		return fmt.Errorf("error creating config directory: %w", err)
-	}
-
-	genesisData := genesispkg.NewGenesis(
-		chainID,
-		initialHeight,
-		time.Now(),      // Current time as genesis DA start height
-		proposerAddress, // Proposer address
-	)
-
-	if err := genesisData.Save(genesisPath); err != nil {
-		return fmt.Errorf("error writing genesis file: %w", err)
 	}
 
 	return nil

--- a/pkg/cmd/init.go
+++ b/pkg/cmd/init.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -14,8 +13,8 @@ import (
 	"github.com/rollkit/rollkit/pkg/signer/file"
 )
 
-// InitializeSigner sets up the signer configuration and creates necessary files
-func InitializeSigner(config *rollconf.Config, homePath string, passphrase string) ([]byte, error) {
+// CreateSigner sets up the signer configuration and creates necessary files
+func CreateSigner(config *rollconf.Config, homePath string, passphrase string) ([]byte, error) {
 	if config.Signer.SignerType == "file" && config.Node.Aggregator {
 		if passphrase == "" {
 			return nil, fmt.Errorf("passphrase is required when using local file signer")
@@ -44,61 +43,57 @@ func InitializeSigner(config *rollconf.Config, homePath string, passphrase strin
 		}
 
 		proposerAddress := hash.SumTruncated(bz)
-
 		return proposerAddress, nil
 	} else if config.Signer.SignerType != "file" && config.Node.Aggregator {
 		return nil, fmt.Errorf("remote signer not implemented for aggregator nodes, use local signer instead")
 	}
+
 	return nil, nil
 }
 
-// InitializeNodeKey creates the node key file
-func InitializeNodeKey(homePath string) error {
+// LoadOrGenNodeKey creates the node key file.
+func LoadOrGenNodeKey(homePath string) error {
 	nodeKeyFile := filepath.Join(homePath, "config")
+
 	_, err := key.LoadOrGenNodeKey(nodeKeyFile)
 	if err != nil {
 		return fmt.Errorf("failed to create node key: %w", err)
 	}
+
 	return nil
 }
 
-// InitializeGenesis creates and saves a genesis file with the given app state
-func InitializeGenesis(homePath string, chainID string, initialHeight uint64, proposerAddress, appState []byte) error {
-	// Create the config directory path first
+var ErrGenesisExists = fmt.Errorf("genesis file already exists")
+
+// CreateGenesis creates and saves a genesis file with the given app state.
+// If the genesis file already exists, it skips the creation and returns ErrGenesisExists.
+// The genesis file is saved in the config directory of the specified home path.
+func CreateGenesis(homePath string, chainID string, initialHeight uint64, proposerAddress, appState []byte) error {
 	configDir := filepath.Join(homePath, "config")
-	// Determine the genesis file path
 	genesisPath := filepath.Join(configDir, "genesis.json")
 
 	// Check if the genesis file already exists
 	if _, err := os.Stat(genesisPath); err == nil {
-		// File exists, return successfully without overwriting
-		fmt.Printf("Genesis file already exists at %s: skipping...\n", genesisPath)
-		return nil
+		return ErrGenesisExists
 	} else if !os.IsNotExist(err) {
-		// An error other than "not exist" occurred (e.g., permissions)
 		return fmt.Errorf("failed to check for existing genesis file at %s: %w", genesisPath, err)
 	}
-	// If os.IsNotExist(err) is true, the file doesn't exist, so we proceed.
 
-	// Create the config directory if it doesn't exist (needed before saving genesis)
+	// If the directory doesn't exist, create it
 	if err := os.MkdirAll(configDir, 0o750); err != nil {
 		return fmt.Errorf("error creating config directory: %w", err)
 	}
 
-	// Create the genesis data struct since the file doesn't exist
 	genesisData := genesispkg.NewGenesis(
 		chainID,
 		initialHeight,
-		time.Now(),                // Current time as genesis DA start height
-		proposerAddress,           // Proposer address
-		json.RawMessage(appState), // App state from parameters
+		time.Now(),      // Current time as genesis DA start height
+		proposerAddress, // Proposer address
 	)
 
-	// Save the new genesis file
-	if err := genesispkg.SaveGenesis(genesisData, genesisPath); err != nil {
+	if err := genesisData.Save(genesisPath); err != nil {
 		return fmt.Errorf("error writing genesis file: %w", err)
 	}
 
-	fmt.Printf("Initialized new genesis file: %s\n", genesisPath)
 	return nil
 }

--- a/pkg/genesis/genesis.go
+++ b/pkg/genesis/genesis.go
@@ -1,40 +1,38 @@
 package genesis
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 )
 
-// Genesis represents the genesis state of the blockchain
+// Genesis represents the genesis state of the blockchain.
+// This genesis struct only contains the fields required by rollkit.
+// The app state or other fields are not included here.
 type Genesis struct {
-	ChainID              string          `json:"chain_id"`
-	GenesisDAStartHeight time.Time       `json:"genesis_da_start_height"` // TODO: change to uint64 and remove time.Time, basically we need a mechanism to convert DAHeight to time.Time
-	InitialHeight        uint64          `json:"initial_height"`
-	ProposerAddress      []byte          `json:"proposer_address"`
-	AppState             json.RawMessage `json:"app_state,omitempty"`
+	ChainID              string    `json:"chain_id"`
+	GenesisDAStartHeight time.Time `json:"genesis_da_start_height"` // TODO: change to uint64 and remove time.Time, basically we need a mechanism to convert DAHeight to time.Time
+	InitialHeight        uint64    `json:"initial_height"`
+	ProposerAddress      []byte    `json:"proposer_address"`
 }
 
-// NewGenesis creates a new Genesis instance
+// NewGenesis creates a new Genesis instance.
 func NewGenesis(
 	chainID string,
 	initialHeight uint64,
 	genesisDAStartHeight time.Time,
 	proposerAddress []byte,
-	appState json.RawMessage,
 ) Genesis {
 	genesis := Genesis{
 		ChainID:              chainID,
 		GenesisDAStartHeight: genesisDAStartHeight,
 		InitialHeight:        initialHeight,
 		ProposerAddress:      proposerAddress,
-		AppState:             appState,
 	}
 
 	return genesis
 }
 
-// Validate checks if the Genesis object is valid
+// Validate checks if the Genesis object is valid.
 func (g Genesis) Validate() error {
 	if g.ChainID == "" {
 		return fmt.Errorf("invalid or missing chain_id in genesis file")

--- a/pkg/genesis/genesis_test.go
+++ b/pkg/genesis/genesis_test.go
@@ -1,7 +1,6 @@
 package genesis
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -11,7 +10,6 @@ import (
 func TestNewGenesis(t *testing.T) {
 	// Test valid genesis creation
 	validTime := time.Now()
-	appState := json.RawMessage(`{"key": "value"}`)
 	proposerAddress := []byte("proposer")
 
 	genesis := NewGenesis(
@@ -19,14 +17,12 @@ func TestNewGenesis(t *testing.T) {
 		1,
 		validTime,
 		proposerAddress,
-		appState,
 	)
 
 	assert.Equal(t, "test-chain", genesis.ChainID)
 	assert.Equal(t, uint64(1), genesis.InitialHeight)
 	assert.Equal(t, validTime, genesis.GenesisDAStartHeight)
 	assert.Equal(t, proposerAddress, genesis.ProposerAddress)
-	assert.Equal(t, appState, genesis.AppState)
 
 	// Test that NewGenesis validates and panics on invalid input
 	genesis = NewGenesis(
@@ -34,7 +30,6 @@ func TestNewGenesis(t *testing.T) {
 		1,
 		validTime,
 		proposerAddress,
-		appState,
 	)
 	err := genesis.Validate()
 	assert.Error(t, err)
@@ -44,7 +39,6 @@ func TestNewGenesis(t *testing.T) {
 		0, // Zero initial height should cause panic
 		validTime,
 		proposerAddress,
-		appState,
 	)
 	err = genesis.Validate()
 	assert.Error(t, err)
@@ -54,7 +48,6 @@ func TestNewGenesis(t *testing.T) {
 		1,
 		time.Time{}, // Zero time should cause panic
 		proposerAddress,
-		appState,
 	)
 	err = genesis.Validate()
 	assert.Error(t, err)
@@ -64,7 +57,6 @@ func TestNewGenesis(t *testing.T) {
 		1,
 		validTime,
 		nil, // Nil proposer address should cause panic
-		appState,
 	)
 	err = genesis.Validate()
 	assert.Error(t, err)
@@ -84,7 +76,6 @@ func TestGenesis_Validate(t *testing.T) {
 				GenesisDAStartHeight: validTime,
 				InitialHeight:        1,
 				ProposerAddress:      []byte("proposer"),
-				AppState:             json.RawMessage(`{}`),
 			},
 			wantErr: false,
 		},

--- a/pkg/genesis/io.go
+++ b/pkg/genesis/io.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 )
 
-// LoadGenesis loads the genesis state from the specified file path
+// LoadGenesis loads the genesis state from the specified file path.
 func LoadGenesis(genesisPath string) (Genesis, error) {
 	// Validate and clean the file path
 	cleanPath := filepath.Clean(genesisPath)
@@ -21,8 +21,7 @@ func LoadGenesis(genesisPath string) (Genesis, error) {
 	}
 
 	var genesis Genesis
-	err = json.Unmarshal(genesisJSON, &genesis)
-	if err != nil {
+	if err := json.Unmarshal(genesisJSON, &genesis); err != nil {
 		return Genesis{}, fmt.Errorf("invalid genesis file: %w", err)
 	}
 
@@ -33,17 +32,15 @@ func LoadGenesis(genesisPath string) (Genesis, error) {
 	return genesis, nil
 }
 
-// SaveGenesis saves the genesis state to the specified file path
-func SaveGenesis(genesis Genesis, genesisPath string) error {
-	// Validate and clean the file path
-	cleanPath := filepath.Clean(genesisPath)
-
-	genesisJSON, err := json.MarshalIndent(genesis, "", "  ")
+// Save saves the genesis state to the specified file path.
+// It should only be used when the application is NOT handling the genesis creation.
+func (g Genesis) Save(genesisPath string) error {
+	genesisJSON, err := json.MarshalIndent(g, "", "  ")
 	if err != nil {
 		return fmt.Errorf("failed to marshal genesis state: %w", err)
 	}
 
-	err = os.WriteFile(cleanPath, genesisJSON, 0600)
+	err = os.WriteFile(filepath.Clean(genesisPath), genesisJSON, 0o600)
 	if err != nil {
 		return fmt.Errorf("failed to write genesis file: %w", err)
 	}

--- a/rollups/testapp/cmd/init.go
+++ b/rollups/testapp/cmd/init.go
@@ -39,7 +39,7 @@ func InitCmd() *cobra.Command {
 				return fmt.Errorf("error reading passphrase flag: %w", err)
 			}
 
-			proposerAddress, err := rollcmd.InitializeSigner(&cfg, homePath, passphrase)
+			proposerAddress, err := rollcmd.CreateSigner(&cfg, homePath, passphrase)
 			if err != nil {
 				return err
 			}
@@ -48,7 +48,7 @@ func InitCmd() *cobra.Command {
 				return fmt.Errorf("error writing rollkit.yaml file: %w", err)
 			}
 
-			if err := rollcmd.InitializeNodeKey(homePath); err != nil {
+			if err := rollcmd.LoadOrGenNodeKey(homePath); err != nil {
 				return err
 			}
 

--- a/rollups/testapp/cmd/init.go
+++ b/rollups/testapp/cmd/init.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
 	rollcmd "github.com/rollkit/rollkit/pkg/cmd"
 	rollconf "github.com/rollkit/rollkit/pkg/config"
+	rollgenesis "github.com/rollkit/rollkit/pkg/genesis"
 )
 
 // InitCmd initializes a new rollkit.yaml file in the current directory
@@ -58,8 +60,20 @@ func InitCmd() *cobra.Command {
 				chainID = "rollkit-test"
 			}
 
-			// Initialize genesis with empty app state
-			if err := rollcmd.InitializeGenesis(homePath, chainID, 1, proposerAddress, []byte("{}")); err != nil {
+			// Initialize genesis without app state
+			err = rollgenesis.CreateGenesis(homePath, chainID, 1, proposerAddress)
+			if errors.Is(err, rollgenesis.ErrGenesisExists) {
+				// check if existing genesis file is valid
+				if genesis, err := rollgenesis.LoadGenesis(homePath); err == nil {
+					if err := genesis.Validate(); err != nil {
+						return fmt.Errorf("existing genesis file is invalid: %w", err)
+					}
+				} else {
+					return fmt.Errorf("error loading existing genesis file: %w", err)
+				}
+
+				cmd.Printf("Genesis file already exists at %s, skipping creation.\n", homePath)
+			} else if err != nil {
 				return fmt.Errorf("error initializing genesis file: %w", err)
 			}
 

--- a/types/utils.go
+++ b/types/utils.go
@@ -228,7 +228,6 @@ func GetGenesisWithPrivkey(chainID string) (genesis.Genesis, crypto.PrivKey, cry
 		1,
 		time.Now().UTC(),
 		signer.Address,
-		nil,
 	), privKey, pubKey
 }
 


### PR DESCRIPTION
Ref: https://github.com/rollkit/go-execution-abci/issues/49

The genesis apis do not need to handle app state.
The rollkit side should never need to marshal the app side. If an application has some app state, that side should handle the genesis creation.

Additionally it simplifies and makes some api naming consistent.