### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/node/full.go
+++ b/node/full.go
@@ -233,11 +233,7 @@ func (n *FullNode) initGenesisChunks() error {
 	}
 
 	for i := 0; i < len(data); i += genesisChunkSize {
-		end := i + genesisChunkSize
-
-		if end > len(data) {
-			end = len(data)
-		}
+		end := min(i+genesisChunkSize, len(data))
 
 		n.genChunks = append(n.genChunks, base64.StdEncoding.EncodeToString(data[i:end]))
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the logic for dividing genesis data into chunks, resulting in cleaner and more maintainable code. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->