### PR TITLE
chore(local-da): add flag to change maxblob size

### DIFF
--- a/da/cmd/local-da/local.go
+++ b/da/cmd/local-da/local.go
@@ -228,3 +228,11 @@ func (d *LocalDA) getProof(id, blob []byte) []byte {
 	sign, _ := d.privKey.Sign(rand.Reader, d.getHash(blob), &ed25519.Options{})
 	return sign
 }
+
+// WithMaxBlobSize returns a function that sets the max blob size of LocalDA
+func WithMaxBlobSize(maxBlobSize uint64) func(*LocalDA) *LocalDA {
+	return func(da *LocalDA) *LocalDA {
+		da.maxBlobSize = maxBlobSize
+		return da
+	}
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a command-line flag to configure the maximum blob size for the local DA server.
  - Server startup logs now display the configured maximum blob size.

- **Improvements**
  - Enhanced error logging for server startup failures to provide clearer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->