### PR TITLE
fix: Remove transaction reaping logic from Manager

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -16,8 +16,6 @@ import (
 	ds "github.com/ipfs/go-datastore"
 	"github.com/libp2p/go-libp2p/core/crypto"
 
-	"github.com/rollkit/go-sequencing"
-
 	coreda "github.com/rollkit/rollkit/core/da"
 	coreexecutor "github.com/rollkit/rollkit/core/execution"
 	coresequencer "github.com/rollkit/rollkit/core/sequencer"
@@ -540,29 +538,6 @@ func (m *Manager) publishBlockInternal(ctx context.Context) error {
 		header = pendingHeader
 		data = pendingData
 	} else {
-		execTxs, err := m.exec.GetTxs(ctx)
-		if err != nil {
-			m.logger.Error("failed to get txs from executor", "err", err)
-			// Continue but log the state
-			m.logger.Info("Current state",
-				"height", height,
-				"pendingHeaders", m.pendingHeaders.numPendingHeaders())
-		}
-
-		m.logger.Debug("Submitting transaction to sequencer",
-			"txCount", len(execTxs))
-		_, err = m.sequencer.SubmitRollupBatchTxs(ctx, coresequencer.SubmitRollupBatchTxsRequest{
-			RollupId: sequencing.RollupId(m.genesis.ChainID),
-			Batch:    &coresequencer.Batch{Transactions: execTxs},
-		})
-		if err != nil {
-			m.logger.Error("failed to submit rollup transaction to sequencer",
-				"err", err,
-				"chainID", m.genesis.ChainID)
-			// Add retry logic or proper error handling
-		}
-		m.logger.Debug("Successfully submitted transaction to sequencer")
-
 		batchData, err := m.retrieveBatch(ctx)
 		if errors.Is(err, ErrNoBatch) {
 			m.logger.Info("No batch retrieved from sequencer, skipping block production")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

The file `reaper.go` already has transaction reaping logic, we can remove it from the manager.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the block publishing process by removing the step that fetched and submitted executor transactions to the sequencer. The system now retrieves batches directly from the sequencer, simplifying the workflow. No user-facing functionality has changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->