### PR TITLE
chore: move based flags 

### DIFF
--- a/rollups/evm/based/cmd/run.go
+++ b/rollups/evm/based/cmd/run.go
@@ -63,33 +63,33 @@ func NewExtendedRunNodeCmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("failed to get 'evm.fee-recipient' flag: %w", err)
 			}
 
-			basedURL, err = cmd.Flags().GetString("based.url")
+			basedURL, err = cmd.Flags().GetString(based.FlagBasedURL)
 			if err != nil {
-				return fmt.Errorf("failed to get 'based.url' flag: %w", err)
+				return fmt.Errorf("failed to get '%s' flag: %w", based.FlagBasedURL, err)
 			}
-			basedAuth, err = cmd.Flags().GetString("based.auth")
+			basedAuth, err = cmd.Flags().GetString(based.FlagBasedAuth)
 			if err != nil {
-				return fmt.Errorf("failed to get 'based.auth' flag: %w", err)
+				return fmt.Errorf("failed to get '%s' flag: %w", based.FlagBasedAuth, err)
 			}
-			basedNamespace, err = cmd.Flags().GetString("based.namespace")
+			basedNamespace, err = cmd.Flags().GetString(based.FlagBasedNamespace)
 			if err != nil {
-				return fmt.Errorf("failed to get 'based.namespace' flag: %w", err)
+				return fmt.Errorf("failed to get '%s' flag: %w", based.FlagBasedNamespace, err)
 			}
-			basedStartHeight, err = cmd.Flags().GetUint64("based.start-height")
+			basedStartHeight, err = cmd.Flags().GetUint64(based.FlagBasedStartHeight)
 			if err != nil {
-				return fmt.Errorf("failed to get 'based.start-height' flag: %w", err)
+				return fmt.Errorf("failed to get '%s' flag: %w", based.FlagBasedStartHeight, err)
 			}
-			basedMaxHeightDrift, err = cmd.Flags().GetUint64("based.max-height-drift")
+			basedMaxHeightDrift, err = cmd.Flags().GetUint64(based.FlagBasedMaxHeightDrift)
 			if err != nil {
-				return fmt.Errorf("failed to get 'based.max-height-drift' flag: %w", err)
+				return fmt.Errorf("failed to get '%s' flag: %w", based.FlagBasedMaxHeightDrift, err)
 			}
-			basedGasMultiplier, err = cmd.Flags().GetFloat64("based.gas-multiplier")
+			basedGasMultiplier, err = cmd.Flags().GetFloat64(based.FlagBasedGasMultiplier)
 			if err != nil {
-				return fmt.Errorf("failed to get 'based.gas-multiplier' flag: %w", err)
+				return fmt.Errorf("failed to get '%s' flag: %w", based.FlagBasedGasMultiplier, err)
 			}
-			basedGasPrice, err = cmd.Flags().GetFloat64("based.gas-price")
+			basedGasPrice, err = cmd.Flags().GetFloat64(based.FlagBasedGasPrice)
 			if err != nil {
-				return fmt.Errorf("failed to get 'based.gas-price' flag: %w", err)
+				return fmt.Errorf("failed to get '%s' flag: %w", based.FlagBasedGasPrice, err)
 			}
 			return nil
 		},
@@ -140,7 +140,7 @@ func NewExtendedRunNodeCmd(ctx context.Context) *cobra.Command {
 			sequencer, err := based.NewSequencer(
 				logger,
 				basedDA,
-				[]byte("rollkit-test"),
+				[]byte(basedNamespace), // Use the namespace from the flag
 				basedStartHeight,
 				basedMaxHeightDrift,
 				datastore,
@@ -181,13 +181,13 @@ func NewExtendedRunNodeCmd(ctx context.Context) *cobra.Command {
 	cmd.Flags().StringVar(&jwtSecret, "evm.jwt-secret", "", "JWT secret for Engine API")
 	cmd.Flags().StringVar(&genesisHash, "evm.genesis-hash", "", "Genesis block hash")
 	cmd.Flags().StringVar(&feeRecipient, "evm.fee-recipient", "", "Fee recipient address")
-	cmd.Flags().StringVar(&basedURL, "based.url", "http://localhost:26658", "Based API URL")
-	cmd.Flags().StringVar(&basedAuth, "based.auth", "", "Authentication token for Based API")
-	cmd.Flags().StringVar(&basedNamespace, "based.namespace", "", "Namespace for Based API")
-	cmd.Flags().Uint64Var(&basedStartHeight, "based.start-height", 0, "Starting height for Based API")
-	cmd.Flags().Uint64Var(&basedMaxHeightDrift, "based.max-height-drift", 1, "Maximum L1 block height drift")
-	cmd.Flags().Float64Var(&basedGasMultiplier, "based.gas-multiplier", 1.0, "Gas multiplier for Based API")
-	cmd.Flags().Float64Var(&basedGasPrice, "based.gas-price", -1.0, "Gas price for Based API")
+	cmd.Flags().StringVar(&basedURL, based.FlagBasedURL, "http://localhost:26658", "Based API URL")
+	cmd.Flags().StringVar(&basedAuth, based.FlagBasedAuth, "", "Authentication token for Based API")
+	cmd.Flags().StringVar(&basedNamespace, based.FlagBasedNamespace, "", "Namespace for Based API")
+	cmd.Flags().Uint64Var(&basedStartHeight, based.FlagBasedStartHeight, 0, "Starting height for Based API")
+	cmd.Flags().Uint64Var(&basedMaxHeightDrift, based.FlagBasedMaxHeightDrift, 1, "Maximum L1 block height drift")
+	cmd.Flags().Float64Var(&basedGasMultiplier, based.FlagBasedGasMultiplier, 1.0, "Gas multiplier for Based API")
+	cmd.Flags().Float64Var(&basedGasPrice, based.FlagBasedGasPrice, -1.0, "Gas price for Based API")
 
 	return cmd
 }

--- a/sequencers/based/flags.go
+++ b/sequencers/based/flags.go
@@ -1,0 +1,11 @@
+package based
+
+const (
+	FlagBasedURL            = "based.url"
+	FlagBasedAuth           = "based.auth"
+	FlagBasedNamespace      = "based.namespace"
+	FlagBasedStartHeight    = "based.start-height"
+	FlagBasedMaxHeightDrift = "based.max-height-drift"
+	FlagBasedGasMultiplier  = "based.gas-multiplier"
+	FlagBasedGasPrice       = "based.gas-price"
+)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

This pr moves based flags from strings to constants in order to be able to reuse htem 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved maintainability by standardizing the use of flag name constants for configuration options in the "based" subsystem.
  - Error messages and namespace handling now dynamically reference flag names, enhancing consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->