### PR TITLE
fix: fix store prefixing

### DIFF
--- a/node/full.go
+++ b/node/full.go
@@ -95,7 +95,7 @@ func newFullNode(
 		return nil, err
 	}
 
-	store := store.New(mainKV)
+	store := store.New(database)
 
 	blockManager, err := initBlockManager(
 		ctx,

--- a/node/full.go
+++ b/node/full.go
@@ -31,8 +31,8 @@ import (
 	"github.com/rollkit/rollkit/pkg/sync"
 )
 
-// prefixes used in KV store to separate main node data from DALC data
-var mainPrefix = "0"
+// prefixes used in KV store to separate rollkit data from execution environment data (if the same data base is reused)
+var RollkitPrefix = "0"
 
 const (
 	// genesisChunkSize is the maximum size, in bytes, of each
@@ -84,7 +84,7 @@ func newFullNode(
 ) (fn *FullNode, err error) {
 	seqMetrics, _ := metricsProvider(genesis.ChainID)
 
-	mainKV := newPrefixKV(database, mainPrefix)
+	mainKV := newPrefixKV(database, RollkitPrefix)
 	headerSyncService, err := initHeaderSyncService(mainKV, nodeConfig, genesis, p2pClient, logger)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func newFullNode(
 		return nil, err
 	}
 
-	store := store.New(database)
+	store := store.New(mainKV)
 
 	blockManager, err := initBlockManager(
 		ctx,

--- a/node/full.go
+++ b/node/full.go
@@ -536,5 +536,5 @@ func (n *FullNode) GetLogger() log.Logger {
 }
 
 func newPrefixKV(kvStore ds.Batching, prefix string) ds.Batching {
-	return (ktds.Wrap(kvStore, ktds.PrefixTransform{Prefix: ds.NewKey(prefix)}).Children()[0]).(ds.Batching)
+	return ktds.Wrap(kvStore, ktds.PrefixTransform{Prefix: ds.NewKey(prefix)})
 }

--- a/pkg/store/prefix_test.go
+++ b/pkg/store/prefix_test.go
@@ -106,5 +106,4 @@ func TestPrefixKVBatch(t *testing.T) {
 	prefixbatchkv2, _ := badgerPrefixkv.NewTransaction(t.Context(), false)
 	err = prefixbatchkv2.Delete(t.Context(), ds.NewKey("key1"))
 	require.NoError(err)
-
 }

--- a/sequencers/single/queue.go
+++ b/sequencers/single/queue.go
@@ -21,18 +21,16 @@ func newPrefixKV(kvStore ds.Batching, prefix string) ds.Batching {
 
 // BatchQueue implements a persistent queue for transaction batches
 type BatchQueue struct {
-	queue  []coresequencer.Batch
-	mu     sync.Mutex
-	db     ds.Batching
-	prefix string
+	queue []coresequencer.Batch
+	mu    sync.Mutex
+	db    ds.Batching
 }
 
 // NewBatchQueue creates a new TransactionQueue
 func NewBatchQueue(db ds.Batching, prefix string) *BatchQueue {
 	return &BatchQueue{
-		queue:  make([]coresequencer.Batch, 0),
-		db:     newPrefixKV(db, prefix),
-		prefix: prefix,
+		queue: make([]coresequencer.Batch, 0),
+		db:    newPrefixKV(db, prefix),
 	}
 }
 

--- a/sequencers/single/queue.go
+++ b/sequencers/single/queue.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newPrefixKV(kvStore ds.Batching, prefix string) ds.Batching {
-	return (ktds.Wrap(kvStore, ktds.PrefixTransform{Prefix: ds.NewKey(prefix)}).Children()[0]).(ds.Batching)
+	return ktds.Wrap(kvStore, ktds.PrefixTransform{Prefix: ds.NewKey(prefix)})
 }
 
 // BatchQueue implements a persistent queue for transaction batches


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

We found this was not properly prefixing the store in abci. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of batch loading by skipping over invalid entries instead of halting the process.
  - Simplified error messages during batch loading for clearer feedback.

- **Refactor**
  - Streamlined internal handling of prefixed datastores for improved maintainability.
  - Enhanced concurrency testing with coordinated completion and timeout for better test robustness.

- **Style**
  - Removed unnecessary blank line in test code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->