### PR TITLE
fix: update DA implementation link path

### DIFF
--- a/specs/src/specs/da.md
+++ b/specs/src/specs/da.md
@@ -35,7 +35,7 @@ See [da implementation]
 
 [3] [proxy/jsonrpc][proxy/jsonrpc]
 
-[da implementation]: https://github.com/rollkit/rollkit/blob/main/core/da/da.go
+[da implementation]: https://github.com/rollkit/rollkit/blob/main/da/jsonrpc/client.go
 [go-da]: https://github.com/rollkit/go-da
 [proxy/grpc]: https://github.com/rollkit/go-da/tree/main/proxy/grpc
 [proxy/jsonrpc]: https://github.com/rollkit/go-da/tree/main/proxy/jsonrpc

--- a/specs/src/specs/da.md
+++ b/specs/src/specs/da.md
@@ -35,7 +35,7 @@ See [da implementation]
 
 [3] [proxy/jsonrpc][proxy/jsonrpc]
 
-[da implementation]: https://github.com/rollkit/rollkit/blob/main/da/da.go
+[da implementation]: https://github.com/rollkit/rollkit/blob/main/core/da/da.go
 [go-da]: https://github.com/rollkit/go-da
 [proxy/grpc]: https://github.com/rollkit/go-da/tree/main/proxy/grpc
 [proxy/jsonrpc]: https://github.com/rollkit/go-da/tree/main/proxy/jsonrpc


### PR DESCRIPTION
Update the broken link to DA implementation from da/da.go to core/da/da.go to reflect the current repository structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the URL link for the "da implementation" reference to point to the correct location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->