### PR TITLE
refactor: replace HasPrefix+TrimPrefix with CutPrefix

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -352,9 +352,9 @@ func LoadFromViper(inputViper *viper.Viper) (Config, error) {
 	// then override with settings from input viper (higher precedence)
 	for _, key := range inputViper.AllKeys() {
 		// Handle special case for prefixed keys
-		if strings.HasPrefix(key, "rollkit.") {
+		if after, ok := strings.CutPrefix(key, "rollkit."); ok {
 			// Strip the prefix for the merged viper
-			strippedKey := strings.TrimPrefix(key, "rollkit.")
+			strippedKey := after
 			mergedViper.Set(strippedKey, inputViper.Get(key))
 		} else {
 			mergedViper.Set(key, inputViper.Get(key))


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview


Optimize code using a more modern writing style. Official support from Go, for more details visit https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the internal logic for handling configuration keys with the "rollkit." prefix. No changes to user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->