### PR TITLE
refactor(cache): save caches to disk

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -278,8 +278,7 @@ func NewManager(
 	}
 
 	// set block height in store
-	err = store.SetHeight(ctx, s.LastBlockHeight)
-	if err != nil {
+	if err = store.SetHeight(ctx, s.LastBlockHeight); err != nil {
 		return nil, err
 	}
 
@@ -288,22 +287,22 @@ func NewManager(
 	}
 
 	if config.DA.BlockTime.Duration == 0 {
-		logger.Info("Using default DA block time", "DABlockTime", defaultDABlockTime)
+		logger.Info("using default DA block time", "DABlockTime", defaultDABlockTime)
 		config.DA.BlockTime.Duration = defaultDABlockTime
 	}
 
 	if config.Node.BlockTime.Duration == 0 {
-		logger.Info("Using default block time", "BlockTime", defaultBlockTime)
+		logger.Info("using default block time", "BlockTime", defaultBlockTime)
 		config.Node.BlockTime.Duration = defaultBlockTime
 	}
 
 	if config.Node.LazyBlockInterval.Duration == 0 {
-		logger.Info("Using default lazy block time", "LazyBlockTime", defaultLazyBlockTime)
+		logger.Info("using default lazy block time", "LazyBlockTime", defaultLazyBlockTime)
 		config.Node.LazyBlockInterval.Duration = defaultLazyBlockTime
 	}
 
 	if config.DA.MempoolTTL == 0 {
-		logger.Info("Using default mempool ttl", "MempoolTTL", defaultMempoolTTL)
+		logger.Info("using default mempool ttl", "MempoolTTL", defaultMempoolTTL)
 		config.DA.MempoolTTL = defaultMempoolTTL
 	}
 
@@ -314,7 +313,7 @@ func NewManager(
 
 	// If lastBatchHash is not set, retrieve the last batch hash from store
 	lastBatchDataBytes, err := store.GetMetadata(ctx, LastBatchDataKey)
-	if err != nil {
+	if err != nil && s.LastBlockHeight > 0 {
 		logger.Error("error while retrieving last batch hash", "error", err)
 	}
 

--- a/block/manager.go
+++ b/block/manager.go
@@ -954,11 +954,13 @@ func (m *Manager) LoadCache() error {
 	gob.Register(&types.SignedHeader{})
 	gob.Register(&types.Data{})
 
-	if err := m.headerCache.LoadFromDisk(filepath.Join(filepath.Dir(m.config.ConfigPath()), headerCacheDir)); err != nil {
+	cfgDir := filepath.Dir(m.config.ConfigPath())
+
+	if err := m.headerCache.LoadFromDisk(filepath.Join(cfgDir, headerCacheDir)); err != nil {
 		return fmt.Errorf("failed to load header cache from disk: %w", err)
 	}
 
-	if err := m.dataCache.LoadFromDisk(filepath.Join(filepath.Dir(m.config.ConfigPath()), dataCacheDir)); err != nil {
+	if err := m.dataCache.LoadFromDisk(filepath.Join(cfgDir, dataCacheDir)); err != nil {
 		return fmt.Errorf("failed to load data cache from disk: %w", err)
 	}
 

--- a/da/jsonrpc/client.go
+++ b/da/jsonrpc/client.go
@@ -239,7 +239,7 @@ func newClient(ctx context.Context, logger log.Logger, addr string, authHeader h
 		return nil, fmt.Errorf("failed to decode namespace: %w", err)
 	}
 	client.DA.Namespace = namespaceBytes
-	logger.Info("Creating new client", "namespace", namespace)
+	logger.Info("creating new client", "namespace", namespace)
 	errs := getKnownErrorsMapping()
 	for name, module := range moduleMap(&client) {
 		closer, err := jsonrpc.NewMergeClient(ctx, addr, name, []interface{}{module}, authHeader, jsonrpc.WithErrors(errs))

--- a/node/full.go
+++ b/node/full.go
@@ -501,11 +501,17 @@ func (n *FullNode) Run(ctx context.Context) error {
 		n.Logger.Info("full node halted successfully")
 	}
 
+	// Save caches if needed
+	if err := n.blockManager.SaveCache(); err != nil {
+		n.Logger.Error("error saving caches", "error", err)
+	}
+
 	// Return the original context error if it exists (e.g., context cancelled)
 	// or the combined shutdown error if the context cancellation was clean.
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+
 	return multiErr // Return shutdown errors if context was okay
 }
 

--- a/node/full.go
+++ b/node/full.go
@@ -377,12 +377,12 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 	}
 
 	go func() {
-		if err := n.rpcServer.ListenAndServe(); err != http.ErrServerClosed {
+		err := n.rpcServer.ListenAndServe()
+		if err != nil && err != http.ErrServerClosed {
 			n.Logger.Error("RPC server error", "err", err)
 		}
+		n.Logger.Info("started RPC server", "addr", n.nodeConfig.RPC.Address)
 	}()
-
-	n.Logger.Info("Started RPC server", "addr", n.nodeConfig.RPC.Address)
 
 	n.Logger.Info("starting P2P client")
 	err = n.p2pClient.Start(ctx)
@@ -432,8 +432,7 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 	}
 
 	// Perform cleanup
-	n.Logger.Info("halting full node...")
-	n.Logger.Info("shutting down full node sub services...")
+	n.Logger.Info("halting full node and its sub services...")
 
 	// Use a timeout context to ensure shutdown doesn't hang
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
@@ -444,7 +443,6 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 	// Stop P2P Client
 	err = n.p2pClient.Close()
 	if err != nil {
-		n.Logger.Error("error closing P2P client", "error", err)
 		multiErr = errors.Join(multiErr, fmt.Errorf("closing P2P client: %w", err))
 	}
 
@@ -479,7 +477,6 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 		err = n.prometheusSrv.Shutdown(shutdownCtx)
 		// http.ErrServerClosed is expected on graceful shutdown
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			n.Logger.Error("error shutting down Prometheus server", "error", err)
 			multiErr = errors.Join(multiErr, fmt.Errorf("shutting down Prometheus server: %w", err))
 		}
 	}
@@ -488,7 +485,6 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 	if n.pprofSrv != nil {
 		err = n.pprofSrv.Shutdown(shutdownCtx)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			n.Logger.Error("error shutting down pprof server", "error", err)
 			multiErr = errors.Join(multiErr, fmt.Errorf("shutting down pprof server: %w", err))
 		}
 	}
@@ -497,16 +493,12 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 	if n.rpcServer != nil {
 		err = n.rpcServer.Shutdown(shutdownCtx)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
-			n.Logger.Error("error shutting down RPC server", "error", err)
 			multiErr = errors.Join(multiErr, fmt.Errorf("shutting down RPC server: %w", err))
 		}
 	}
 
 	// Ensure Store.Close is called last to maximize chance of data flushing
-	err = n.Store.Close()
-	if err != nil {
-		// Store.Close() might log internally, but log here too for context
-		n.Logger.Error("error closing store", "error", err)
+	if err = n.Store.Close(); err != nil {
 		multiErr = errors.Join(multiErr, fmt.Errorf("closing store: %w", err))
 	}
 
@@ -517,7 +509,9 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 
 	// Log final status
 	if multiErr != nil {
-		n.Logger.Error("errors encountered while stopping node", "errors", multiErr)
+		for _, err := range multiErr.(interface{ Unwrap() []error }).Unwrap() {
+			n.Logger.Error("error during shutdown", "error", err)
+		}
 	} else {
 		n.Logger.Info("full node halted successfully")
 	}

--- a/node/full.go
+++ b/node/full.go
@@ -504,6 +504,7 @@ func (n *FullNode) Run(ctx context.Context) error {
 	// Save caches if needed
 	if err := n.blockManager.SaveCache(); err != nil {
 		n.Logger.Error("error saving caches", "error", err)
+		multiErr = errors.Join(multiErr, fmt.Errorf("saving caches: %w", err))
 	}
 
 	// Return the original context error if it exists (e.g., context cancelled)

--- a/node/full.go
+++ b/node/full.go
@@ -494,17 +494,16 @@ func (n *FullNode) Run(ctx context.Context) error {
 		multiErr = errors.Join(multiErr, fmt.Errorf("closing store: %w", err))
 	}
 
+	// Save caches if needed
+	if err := n.blockManager.SaveCache(); err != nil {
+		multiErr = errors.Join(multiErr, fmt.Errorf("saving caches: %w", err))
+	}
+
 	// Log final status
 	if multiErr != nil {
 		n.Logger.Error("errors encountered while stopping node", "errors", multiErr)
 	} else {
 		n.Logger.Info("full node halted successfully")
-	}
-
-	// Save caches if needed
-	if err := n.blockManager.SaveCache(); err != nil {
-		n.Logger.Error("error saving caches", "error", err)
-		multiErr = errors.Join(multiErr, fmt.Errorf("saving caches: %w", err))
 	}
 
 	// Return the original context error if it exists (e.g., context cancelled)

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -1,6 +1,10 @@
 package cache
 
 import (
+	"encoding/gob"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -85,4 +89,149 @@ func (c *Cache[T]) IsDAIncluded(hash string) bool {
 // SetDAIncluded sets the hash as DA-included
 func (c *Cache[T]) SetDAIncluded(hash string) {
 	c.daIncluded.Store(hash, true)
+}
+
+const (
+	itemsByHeightFilename = "items_by_height.gob"
+	itemsByHashFilename   = "items_by_hash.gob"
+	hashesFilename        = "hashes.gob"
+	daIncludedFilename    = "da_included.gob"
+)
+
+// saveMapGob saves a map to a file using gob encoding.
+func saveMapGob[K comparable, V any](filePath string, data map[K]V) error {
+	file, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	encoder := gob.NewEncoder(file)
+	if err := encoder.Encode(data); err != nil {
+		return fmt.Errorf("failed to encode to file %s: %w", filePath, err)
+	}
+	return nil
+}
+
+// loadMapGob loads a map from a file using gob encoding.
+// if the file does not exist, it returns an empty map and no error.
+func loadMapGob[K comparable, V any](filePath string) (map[K]V, error) {
+	m := make(map[K]V)
+	file, err := os.Open(filePath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return m, nil // return empty map if file not found
+		}
+		return nil, fmt.Errorf("failed to open file %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	decoder := gob.NewDecoder(file)
+	if err := decoder.Decode(&m); err != nil {
+		return nil, fmt.Errorf("failed to decode file %s: %w", filePath, err)
+	}
+	return m, nil
+}
+
+// SaveToDisk saves the cache contents to disk in the specified folder.
+// It's the caller's responsibility to ensure that type T (and any types it contains)
+// are registered with the gob package if necessary (e.g., using gob.Register).
+func (c *Cache[T]) SaveToDisk(folderPath string) error {
+	if err := os.MkdirAll(folderPath, 0o755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", folderPath, err)
+	}
+
+	// prepare items maps
+	itemsByHeightMap := make(map[uint64]*T)
+	itemsByHashMap := make(map[string]*T)
+	c.items.Range(func(k, v interface{}) bool {
+		itemVal, ok := v.(*T)
+		if !ok {
+			return true // continue iteration
+		}
+		switch key := k.(type) {
+		case uint64:
+			itemsByHeightMap[key] = itemVal
+		case string:
+			itemsByHashMap[key] = itemVal
+		}
+		return true
+	})
+
+	if err := saveMapGob(filepath.Join(folderPath, itemsByHeightFilename), itemsByHeightMap); err != nil {
+		return err
+	}
+	if err := saveMapGob(filepath.Join(folderPath, itemsByHashFilename), itemsByHashMap); err != nil {
+		return err
+	}
+
+	// prepare hashes map
+	hashesToSave := make(map[string]bool)
+	c.hashes.Range(func(k, v interface{}) bool {
+		keyStr, okKey := k.(string)
+		valBool, okVal := v.(bool)
+		if okKey && okVal {
+			hashesToSave[keyStr] = valBool
+		}
+		return true
+	})
+	if err := saveMapGob(filepath.Join(folderPath, hashesFilename), hashesToSave); err != nil {
+		return err
+	}
+
+	// prepare daIncluded map
+	daIncludedToSave := make(map[string]bool)
+	c.daIncluded.Range(func(k, v interface{}) bool {
+		keyStr, okKey := k.(string)
+		valBool, okVal := v.(bool)
+		if okKey && okVal {
+			daIncludedToSave[keyStr] = valBool
+		}
+		return true
+	})
+	return saveMapGob(filepath.Join(folderPath, daIncludedFilename), daIncludedToSave)
+}
+
+// LoadFromDisk loads the cache contents from disk from the specified folder.
+// It populates the current cache instance. If files are missing, corresponding parts of the cache will be empty.
+// It's the caller's responsibility to ensure that type T (and any types it contains)
+// are registered with the gob package if necessary (e.g., using gob.Register).
+func (c *Cache[T]) LoadFromDisk(folderPath string) error {
+	// load items by height
+	itemsByHeightMap, err := loadMapGob[uint64, *T](filepath.Join(folderPath, itemsByHeightFilename))
+	if err != nil {
+		return fmt.Errorf("failed to load items by height: %w", err)
+	}
+	for k, v := range itemsByHeightMap {
+		c.items.Store(k, v)
+	}
+
+	// load items by hash
+	itemsByHashMap, err := loadMapGob[string, *T](filepath.Join(folderPath, itemsByHashFilename))
+	if err != nil {
+		return fmt.Errorf("failed to load items by hash: %w", err)
+	}
+	for k, v := range itemsByHashMap {
+		c.items.Store(k, v)
+	}
+
+	// load hashes
+	hashesMap, err := loadMapGob[string, bool](filepath.Join(folderPath, hashesFilename))
+	if err != nil {
+		return fmt.Errorf("failed to load hashes: %w", err)
+	}
+	for k, v := range hashesMap {
+		c.hashes.Store(k, v)
+	}
+
+	// load daIncluded
+	daIncludedMap, err := loadMapGob[string, bool](filepath.Join(folderPath, daIncludedFilename))
+	if err != nil {
+		return fmt.Errorf("failed to load daIncluded: %w", err)
+	}
+	for k, v := range daIncludedMap {
+		c.daIncluded.Store(k, v)
+	}
+
+	return nil
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -132,10 +132,7 @@ func TestCacheConcurrency(t *testing.T) {
 
 // TestCachePersistence tests saving and loading the cache to/from disk.
 func TestCachePersistence(t *testing.T) {
-	// define a temporary folder for cache files
-	tempDir, err := os.MkdirTemp("", "cache_test")
-	require.NoError(t, err, "Failed to create temp dir")
-	defer os.RemoveAll(tempDir) // clean up
+	tempDir := t.TempDir()
 
 	// register the type for gob encoding if it's a custom struct
 	// for basic types like string, int, this is not strictly necessary
@@ -161,7 +158,7 @@ func TestCachePersistence(t *testing.T) {
 	cache1.SetDAIncluded(hash2)
 
 	// save cache1 to disk
-	err = cache1.SaveToDisk(tempDir)
+	err := cache1.SaveToDisk(tempDir)
 	require.NoError(t, err, "Failed to save cache to disk")
 
 	// create a new cache and load from disk
@@ -213,15 +210,13 @@ func TestCachePersistence(t *testing.T) {
 
 // TestCachePersistence_EmptyCache tests saving and loading an empty cache.
 func TestCachePersistence_EmptyCache(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "empty_cache_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	gob.Register(&struct{}{}) // register dummy struct for generic type T
 
 	cache1 := NewCache[struct{}]()
 
-	err = cache1.SaveToDisk(tempDir)
+	err := cache1.SaveToDisk(tempDir)
 	require.NoError(t, err, "Failed to save empty cache")
 
 	cache2 := NewCache[struct{}]()
@@ -236,9 +231,7 @@ func TestCachePersistence_EmptyCache(t *testing.T) {
 
 // TestCachePersistence_Overwrite tests overwriting existing cache files.
 func TestCachePersistence_Overwrite(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "overwrite_cache_test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	gob.Register(0) // register int for generic type T
 
@@ -247,7 +240,7 @@ func TestCachePersistence_Overwrite(t *testing.T) {
 	val1 := 123
 	cache1.SetItem(1, &val1)
 	cache1.SetSeen("hash1")
-	err = cache1.SaveToDisk(tempDir)
+	err := cache1.SaveToDisk(tempDir)
 	require.NoError(t, err)
 
 	// second save (overwrite)


### PR DESCRIPTION
This adds saving the header and data caches. Not doing so would lead to issue tracking da included height for `SetFinal` execution in case of node crash. Same for data sync due to data cache being empty.

https://github.com/rollkit/rollkit/pull/2268 needs to be merged first so that we have a clean way to stop the app.

TODO: An improvement eventually to clean-up the cache instead of letting it grow forever.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added persistent caching for headers and data, enabling cache state to be saved to and loaded from disk.
- **Bug Fixes**
  - Improved cache initialization and shutdown procedures for more reliable startup and shutdown.
- **Tests**
  - Introduced comprehensive tests verifying cache persistence, including saving, loading, empty caches, and overwriting scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->