### PR TITLE
refactor: Make behavior consistent for empty tx round trip serialization

### DIFF
--- a/types/serialization.go
+++ b/types/serialization.go
@@ -280,7 +280,7 @@ func txsToByteSlices(txs Txs) [][]byte {
 
 func byteSlicesToTxs(bytes [][]byte) Txs {
 	if len(bytes) == 0 {
-		return nil
+		return Txs{}
 	}
 	txs := make(Txs, len(bytes))
 	for i := range txs {

--- a/types/serialization_test.go
+++ b/types/serialization_test.go
@@ -63,7 +63,7 @@ func TestBlockSerializationRoundTrip(t *testing.T) {
 			Signer:    signer1,
 		}, &Data{
 			Metadata: &Metadata{},
-			Txs:      nil,
+			Txs:      Txs{},
 		},
 		},
 	}
@@ -86,6 +86,10 @@ func TestBlockSerializationRoundTrip(t *testing.T) {
 			err = deserializedData.UnmarshalBinary(blob)
 			assert.NoError(err)
 
+			// unserialized txs=nil are converted to empty slices to be for-loop safe
+			if c.data.Txs == nil {
+				c.data.Txs = Txs{}
+			}
 			assert.Equal(c.data, deserializedData)
 		})
 	}
@@ -150,7 +154,7 @@ func TestTxsRoundtrip(t *testing.T) {
 	var txs Txs
 	byteSlices := txsToByteSlices(txs)
 	newTxs := byteSlicesToTxs(byteSlices)
-	assert.Nil(t, newTxs)
+	assert.Equal(t, Txs{}, newTxs)
 
 	// Generate 100 random transactions and convert them to byte slices
 	txs = make(Txs, 100)

--- a/types/serialization_test.go
+++ b/types/serialization_test.go
@@ -86,7 +86,7 @@ func TestBlockSerializationRoundTrip(t *testing.T) {
 			err = deserializedData.UnmarshalBinary(blob)
 			assert.NoError(err)
 
-			// unserialized txs=nil are converted to empty slices to be for-loop safe
+			// When deserialized, nil Txs are converted to empty slices to prevent for-loop panics.
 			if c.data.Txs == nil {
 				c.data.Txs = Txs{}
 			}


### PR DESCRIPTION
## Overview

Closes #143 

Make the behaviour for serialization/deserialization of empty Txs consistent.
Protobuff skips empty slices and encode the field data as nil. There is no way to change Protobuff behavior so the best we can do is make the behaviour as consistent as possible by always returning empty slices even if was the value of the field before the round-trip. The main argument for returning empty slices instead of nil is for for-loop safety concerns. 

Before:
```go
nil becomes nil
{} becomes nil
```

Now:
```go
nil becomes {}
{} becomes {}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized handling of empty transaction lists to always use empty slices instead of nil, ensuring safer iteration and consistent behavior.
- **Tests**
  - Updated tests to expect and assert empty slices rather than nil for empty transaction lists, improving test reliability and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->