### PR TITLE
test: (e2e) persistence test

### DIFF
--- a/test/e2e/base_test.go
+++ b/test/e2e/base_test.go
@@ -210,7 +210,6 @@ func TestNodeRestartPersistence(t *testing.T) {
 	defer cancel2()
 	state2, err := c.GetState(ctx2)
 	defer cancel()
-	state2, err := c.GetState(ctx)
 	require.NoError(t, err)
 	require.Greater(t, state2.LastBlockHeight, state.LastBlockHeight)
 }

--- a/test/e2e/base_test.go
+++ b/test/e2e/base_test.go
@@ -206,6 +206,8 @@ func TestNodeRestartPersistence(t *testing.T) {
 	// Wait for a block to be produced after restart
 	time.Sleep(1 * time.Second)
 
+	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 	state2, err := c.GetState(ctx)
 	require.NoError(t, err)
 	require.Greater(t, state2.LastBlockHeight, state.LastBlockHeight)

--- a/test/e2e/base_test.go
+++ b/test/e2e/base_test.go
@@ -209,7 +209,6 @@ func TestNodeRestartPersistence(t *testing.T) {
 	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second)
 	defer cancel2()
 	state2, err := c.GetState(ctx2)
-	defer cancel()
 	require.NoError(t, err)
 	require.Greater(t, state2.LastBlockHeight, state.LastBlockHeight)
 }

--- a/test/e2e/base_test.go
+++ b/test/e2e/base_test.go
@@ -206,7 +206,9 @@ func TestNodeRestartPersistence(t *testing.T) {
 	// Wait for a block to be produced after restart
 	time.Sleep(1 * time.Second)
 
-	ctx, cancel = context.WithTimeout(context.Background(), time.Second)
+	ctx2, cancel2 := context.WithTimeout(context.Background(), time.Second)
+	defer cancel2()
+	state2, err := c.GetState(ctx2)
 	defer cancel()
 	state2, err := c.GetState(ctx)
 	require.NoError(t, err)

--- a/test/e2e/base_test.go
+++ b/test/e2e/base_test.go
@@ -133,3 +133,77 @@ func TestBasic(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, state.LastBlockHeight, uint64(1))
 }
+
+func TestNodeRestartPersistence(t *testing.T) {
+	flag.Parse()
+	var (
+		workDir  = t.TempDir()
+		nodeHome = filepath.Join(workDir, "node1")
+	)
+
+	sut := NewSystemUnderTest(t)
+
+	// Start local DA if needed
+	localDABinary := filepath.Join(filepath.Dir(binaryPath), "local-da")
+	sut.StartNode(localDABinary)
+	time.Sleep(500 * time.Millisecond)
+
+	// Init node
+	output, err := sut.RunCmd(binaryPath,
+		"init",
+		"--home="+nodeHome,
+		"--chain_id=testing",
+		"--rollkit.node.aggregator",
+		"--rollkit.signer.passphrase=12345678",
+	)
+	require.NoError(t, err, "failed to init node", output)
+
+	// Start node
+	sut.StartNode(binaryPath,
+		"start",
+		"--home="+nodeHome,
+		"--chain_id=testing",
+		"--rollkit.node.aggregator",
+		"--rollkit.signer.passphrase=12345678",
+		"--rollkit.node.block_time=5ms",
+		"--rollkit.da.block_time=15ms",
+		"--kv-endpoint=127.0.0.1:9090",
+	)
+	sut.AwaitNodeUp(t, "http://127.0.0.1:7331", 2*time.Second)
+	t.Log("Node started and is up.")
+
+	// Wait for a block to be produced
+	time.Sleep(1 * time.Second)
+
+	// Shutdown node
+	sut.Shutdown()
+	t.Log("Node stopped.")
+
+	// Wait a moment to ensure shutdown
+	time.Sleep(500 * time.Millisecond)
+
+	// Restart node
+	sut.StartNode(binaryPath,
+		"start",
+		"--home="+nodeHome,
+		"--chain_id=testing",
+		"--rollkit.node.aggregator",
+		"--rollkit.signer.passphrase=12345678",
+		"--rollkit.node.block_time=5ms",
+		"--rollkit.da.block_time=15ms",
+		"--kv-endpoint=127.0.0.1:9090",
+	)
+	sut.AwaitNodeUp(t, "http://127.0.0.1:7331", 2*time.Second)
+	t.Log("Node restarted and is up.")
+
+	// Wait for a block to be produced after restart
+	time.Sleep(1 * time.Second)
+
+	// Query state to verify node is operational
+	c := nodeclient.NewClient("http://127.0.0.1:7331")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	state, err := c.GetState(ctx)
+	require.NoError(t, err)
+	require.Greater(t, state.LastBlockHeight, uint64(3))
+}

--- a/test/e2e/base_test.go
+++ b/test/e2e/base_test.go
@@ -172,6 +172,13 @@ func TestNodeRestartPersistence(t *testing.T) {
 	sut.AwaitNodeUp(t, "http://127.0.0.1:7331", 2*time.Second)
 	t.Log("Node started and is up.")
 
+	c := nodeclient.NewClient("http://127.0.0.1:7331")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	state, err := c.GetState(ctx)
+	require.NoError(t, err)
+	require.Greater(t, state.LastBlockHeight, uint64(1))
+
 	// Wait for a block to be produced
 	time.Sleep(1 * time.Second)
 
@@ -199,11 +206,7 @@ func TestNodeRestartPersistence(t *testing.T) {
 	// Wait for a block to be produced after restart
 	time.Sleep(1 * time.Second)
 
-	// Query state to verify node is operational
-	c := nodeclient.NewClient("http://127.0.0.1:7331")
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-	state, err := c.GetState(ctx)
+	state2, err := c.GetState(ctx)
 	require.NoError(t, err)
-	require.Greater(t, state.LastBlockHeight, uint64(3))
+	require.Greater(t, state2.LastBlockHeight, state.LastBlockHeight)
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

add a test case for persistence on restarts 

ref https://github.com/rollkit/rollkit/issues/2256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added a new end-to-end test to verify that node state persists correctly across restarts, ensuring continued block production after a restart.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->