### PR TITLE
Add execution RPC service

### DIFF
--- a/node/full.go
+++ b/node/full.go
@@ -363,7 +363,7 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 	}
 
 	// Start RPC server
-	handler, err := rpcserver.NewServiceHandler(n.Store, n.p2pClient)
+	handler, err := rpcserver.NewServiceHandler(n.Store, n.p2pClient, n.blockManager.GetExecutor())
 	if err != nil {
 		return fmt.Errorf("error creating RPC handler: %w", err)
 	}

--- a/node/light.go
+++ b/node/light.go
@@ -64,7 +64,7 @@ func newLightNode(
 // OnStart starts the P2P and HeaderSync services
 func (ln *LightNode) OnStart(ctx context.Context) error {
 	// Start RPC server
-	handler, err := rpcserver.NewServiceHandler(ln.Store, ln.P2P)
+	handler, err := rpcserver.NewServiceHandler(ln.Store, ln.P2P, nil)
 	if err != nil {
 		return fmt.Errorf("error creating RPC handler: %w", err)
 	}

--- a/pkg/execution/server.go
+++ b/pkg/execution/server.go
@@ -1,0 +1,58 @@
+package execution
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	coreexec "github.com/rollkit/rollkit/core/execution"
+	pb "github.com/rollkit/rollkit/types/pb/rollkit/v1"
+)
+
+// Server implements the ExecutionService defined in the protobuf file.
+type Server struct {
+	exec coreexec.Executor
+}
+
+// NewServer creates a new Execution RPC server wrapping the given executor.
+func NewServer(exec coreexec.Executor) *Server {
+	return &Server{exec: exec}
+}
+
+// InitChain delegates to the wrapped executor.
+func (s *Server) InitChain(ctx context.Context, req *connect.Request[pb.InitChainRequest]) (*connect.Response[pb.InitChainResponse], error) {
+	genesisTime := req.Msg.GenesisTime.AsTime()
+	stateRoot, maxBytes, err := s.exec.InitChain(ctx, genesisTime, req.Msg.InitialHeight, req.Msg.ChainId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&pb.InitChainResponse{StateRoot: stateRoot, MaxBytes: maxBytes}), nil
+}
+
+// GetTxs returns available transactions from the executor.
+func (s *Server) GetTxs(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[pb.GetTxsResponse], error) {
+	txs, err := s.exec.GetTxs(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&pb.GetTxsResponse{Txs: txs}), nil
+}
+
+// ExecuteTxs runs a batch of transactions via the executor.
+func (s *Server) ExecuteTxs(ctx context.Context, req *connect.Request[pb.ExecuteTxsRequest]) (*connect.Response[pb.ExecuteTxsResponse], error) {
+	ts := req.Msg.Timestamp.AsTime()
+	updated, maxBytes, err := s.exec.ExecuteTxs(ctx, req.Msg.Txs, req.Msg.BlockHeight, ts, req.Msg.PrevStateRoot)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&pb.ExecuteTxsResponse{UpdatedStateRoot: updated, MaxBytes: maxBytes}), nil
+}
+
+// SetFinal marks a block as finalized using the executor.
+func (s *Server) SetFinal(ctx context.Context, req *connect.Request[pb.SetFinalRequest]) (*connect.Response[emptypb.Empty], error) {
+	if err := s.exec.SetFinal(ctx, req.Msg.BlockHeight); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}

--- a/pkg/rpc/README.md
+++ b/pkg/rpc/README.md
@@ -12,8 +12,11 @@ The RPC implementation uses [Connect-Go](https://connectrpc.com/docs/go/getting-
 pkg/rpc/
   ├── client/       # Client implementation
   │   └── client.go
-  └── server/       # Server implementation
+  └── server/       # Core RPC handlers
       └── server.go
+
+pkg/execution/
+  └── server.go     # ExecutionService implementation
 ```
 
 ## Usage
@@ -77,13 +80,19 @@ func main() {
 
 ## Features
 
-The RPC service provides the following methods:
+The RPC services provide the following methods:
 
 - `GetHeight`: Returns the current height of the store
 - `GetBlock`: Returns a block by height or hash
 - `GetState`: Returns the current state
 - `GetMetadata`: Returns metadata for a specific key
 - `SetMetadata`: Sets metadata for a specific key
+
+ExecutionService:
+- `InitChain`: Initialize the execution environment
+- `GetTxs`: Retrieve pending transactions
+- `ExecuteTxs`: Execute a batch of transactions
+- `SetFinal`: Mark a block as finalized
 
 ## Protocol Buffers
 

--- a/pkg/rpc/example/example.go
+++ b/pkg/rpc/example/example.go
@@ -17,7 +17,7 @@ func StartStoreServer(s store.Store, address string) {
 	// Create and start the server
 	// Start RPC server
 	rpcAddr := fmt.Sprintf("%s:%d", "localhost", 8080)
-	handler, err := server.NewServiceHandler(s, nil)
+	handler, err := server.NewServiceHandler(s, nil, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -74,7 +74,7 @@ func ExampleServer(s store.Store) {
 
 	// Start RPC server
 	rpcAddr := fmt.Sprintf("%s:%d", "localhost", 8080)
-	handler, err := server.NewServiceHandler(s, nil)
+	handler, err := server.NewServiceHandler(s, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/proto/rollkit/v1/execution.proto
+++ b/proto/rollkit/v1/execution.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+package rollkit.v1;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/rollkit/rollkit/types/pb/rollkit/v1";
+
+// ExecutionService defines RPCs exposing the execution layer
+service ExecutionService {
+  // InitChain initializes a new chain
+  rpc InitChain(InitChainRequest) returns (InitChainResponse) {}
+  // GetTxs returns available transactions
+  rpc GetTxs(google.protobuf.Empty) returns (GetTxsResponse) {}
+  // ExecuteTxs executes a batch of transactions
+  rpc ExecuteTxs(ExecuteTxsRequest) returns (ExecuteTxsResponse) {}
+  // SetFinal marks a block as finalized
+  rpc SetFinal(SetFinalRequest) returns (google.protobuf.Empty) {}
+}
+
+message InitChainRequest {
+  google.protobuf.Timestamp genesis_time = 1;
+  uint64 initial_height = 2;
+  string chain_id = 3;
+}
+
+message InitChainResponse {
+  bytes state_root = 1;
+  uint64 max_bytes = 2;
+}
+
+message GetTxsResponse {
+  repeated bytes txs = 1;
+}
+
+message ExecuteTxsRequest {
+  repeated bytes txs = 1;
+  uint64 block_height = 2;
+  google.protobuf.Timestamp timestamp = 3;
+  bytes prev_state_root = 4;
+}
+
+message ExecuteTxsResponse {
+  bytes updated_state_root = 1;
+  uint64 max_bytes = 2;
+}
+
+message SetFinalRequest {
+  uint64 block_height = 1;
+}


### PR DESCRIPTION
## Summary
- implement `ExecutionService` proto and RPC server
- host the server in `pkg/execution` and wire into RPC mux
- register the service when an executor is provided
- document new service in RPC README

## Testing
- `make test` *(fails: proxy connect no route to host)*