### PR TITLE
Add standalone execution RPC server

### DIFF
--- a/pkg/execution/server.go
+++ b/pkg/execution/server.go
@@ -1,0 +1,58 @@
+package execution
+
+import (
+	"context"
+
+	"connectrpc.com/connect"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	coreexec "github.com/rollkit/rollkit/core/execution"
+	pb "github.com/rollkit/rollkit/types/pb/rollkit/v1"
+)
+
+// Server implements the ExecutionService defined in the protobuf file.
+type Server struct {
+	exec coreexec.Executor
+}
+
+// NewServer creates a new Execution RPC server wrapping the given executor.
+func NewServer(exec coreexec.Executor) *Server {
+	return &Server{exec: exec}
+}
+
+// InitChain delegates to the wrapped executor.
+func (s *Server) InitChain(ctx context.Context, req *connect.Request[pb.InitChainRequest]) (*connect.Response[pb.InitChainResponse], error) {
+	genesisTime := req.Msg.GenesisTime.AsTime()
+	stateRoot, maxBytes, err := s.exec.InitChain(ctx, genesisTime, req.Msg.InitialHeight, req.Msg.ChainId)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&pb.InitChainResponse{StateRoot: stateRoot, MaxBytes: maxBytes}), nil
+}
+
+// GetTxs returns available transactions from the executor.
+func (s *Server) GetTxs(ctx context.Context, _ *connect.Request[emptypb.Empty]) (*connect.Response[pb.GetTxsResponse], error) {
+	txs, err := s.exec.GetTxs(ctx)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&pb.GetTxsResponse{Txs: txs}), nil
+}
+
+// ExecuteTxs runs a batch of transactions via the executor.
+func (s *Server) ExecuteTxs(ctx context.Context, req *connect.Request[pb.ExecuteTxsRequest]) (*connect.Response[pb.ExecuteTxsResponse], error) {
+	ts := req.Msg.Timestamp.AsTime()
+	updated, maxBytes, err := s.exec.ExecuteTxs(ctx, req.Msg.Txs, req.Msg.BlockHeight, ts, req.Msg.PrevStateRoot)
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&pb.ExecuteTxsResponse{UpdatedStateRoot: updated, MaxBytes: maxBytes}), nil
+}
+
+// SetFinal marks a block as finalized using the executor.
+func (s *Server) SetFinal(ctx context.Context, req *connect.Request[pb.SetFinalRequest]) (*connect.Response[emptypb.Empty], error) {
+	if err := s.exec.SetFinal(ctx, req.Msg.BlockHeight); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	return connect.NewResponse(&emptypb.Empty{}), nil
+}

--- a/proto/rollkit/v1/execution.proto
+++ b/proto/rollkit/v1/execution.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+package rollkit.v1;
+
+import "google/protobuf/empty.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/rollkit/rollkit/types/pb/rollkit/v1";
+
+// ExecutionService defines RPCs exposing the execution layer
+service ExecutionService {
+  // InitChain initializes a new chain
+  rpc InitChain(InitChainRequest) returns (InitChainResponse) {}
+  // GetTxs returns available transactions
+  rpc GetTxs(google.protobuf.Empty) returns (GetTxsResponse) {}
+  // ExecuteTxs executes a batch of transactions
+  rpc ExecuteTxs(ExecuteTxsRequest) returns (ExecuteTxsResponse) {}
+  // SetFinal marks a block as finalized
+  rpc SetFinal(SetFinalRequest) returns (google.protobuf.Empty) {}
+}
+
+message InitChainRequest {
+  google.protobuf.Timestamp genesis_time = 1;
+  uint64 initial_height = 2;
+  string chain_id = 3;
+}
+
+message InitChainResponse {
+  bytes state_root = 1;
+  uint64 max_bytes = 2;
+}
+
+message GetTxsResponse {
+  repeated bytes txs = 1;
+}
+
+message ExecuteTxsRequest {
+  repeated bytes txs = 1;
+  uint64 block_height = 2;
+  google.protobuf.Timestamp timestamp = 3;
+  bytes prev_state_root = 4;
+}
+
+message ExecuteTxsResponse {
+  bytes updated_state_root = 1;
+  uint64 max_bytes = 2;
+}
+
+message SetFinalRequest {
+  uint64 block_height = 1;
+}


### PR DESCRIPTION
## Summary
- keep ExecutionService server code but remove integration with RPC and node packages
- revert README and example to show only default RPC services

## Testing
- `make test` *(fails: no route to host)*