### PR TITLE
refactor: clean-up logs + save cache under data

### DIFF
--- a/block/aggregation.go
+++ b/block/aggregation.go
@@ -24,7 +24,7 @@ func (m *Manager) AggregationLoop(ctx context.Context, errCh chan<- error) {
 	}
 
 	if delay > 0 {
-		m.logger.Info("Waiting to produce block", "delay", delay)
+		m.logger.Info("waiting to produce block", "delay", delay)
 		time.Sleep(delay)
 	}
 

--- a/block/manager.go
+++ b/block/manager.go
@@ -950,7 +950,7 @@ func (m *Manager) LoadCache() error {
 	gob.Register(&types.SignedHeader{})
 	gob.Register(&types.Data{})
 
-	cfgDir := filepath.Dir(m.config.ConfigPath())
+	cfgDir := filepath.Join(m.config.RootDir, "data")
 
 	if err := m.headerCache.LoadFromDisk(filepath.Join(cfgDir, headerCacheDir)); err != nil {
 		return fmt.Errorf("failed to load header cache from disk: %w", err)
@@ -965,11 +965,13 @@ func (m *Manager) LoadCache() error {
 
 // SaveCache saves the header and data caches to disk.
 func (m *Manager) SaveCache() error {
-	if err := m.headerCache.SaveToDisk(filepath.Join(filepath.Dir(m.config.ConfigPath()), headerCacheDir)); err != nil {
+	cfgDir := filepath.Join(m.config.RootDir, "data")
+
+	if err := m.headerCache.SaveToDisk(filepath.Join(cfgDir, headerCacheDir)); err != nil {
 		return fmt.Errorf("failed to save header cache to disk: %w", err)
 	}
 
-	if err := m.dataCache.SaveToDisk(filepath.Join(filepath.Dir(m.config.ConfigPath()), dataCacheDir)); err != nil {
+	if err := m.dataCache.SaveToDisk(filepath.Join(cfgDir, dataCacheDir)); err != nil {
 		return fmt.Errorf("failed to save data cache to disk: %w", err)
 	}
 	return nil

--- a/block/manager.go
+++ b/block/manager.go
@@ -558,7 +558,7 @@ func (m *Manager) publishBlockInternal(ctx context.Context) error {
 	// If there is use that instead of creating a new block
 	pendingHeader, pendingData, err := m.store.GetBlockData(ctx, newHeight)
 	if err == nil {
-		m.logger.Info("Using pending block", "height", newHeight)
+		m.logger.Info("using pending block", "height", newHeight)
 		header = pendingHeader
 		data = pendingData
 	} else {
@@ -566,10 +566,10 @@ func (m *Manager) publishBlockInternal(ctx context.Context) error {
 		if err != nil {
 			if errors.Is(err, ErrNoBatch) {
 				if batchData == nil {
-					m.logger.Info("No batch retrieved from sequencer, skipping block production")
+					m.logger.Info("no batch retrieved from sequencer, skipping block production")
 					return nil
 				}
-				m.logger.Info("Creating empty block", "height", newHeight)
+				m.logger.Info("creating empty block", "height", newHeight)
 			} else {
 				m.logger.Warn("failed to get transactions from batch", "error", err)
 				return nil
@@ -578,7 +578,7 @@ func (m *Manager) publishBlockInternal(ctx context.Context) error {
 			if batchData.Before(lastHeaderTime) {
 				return fmt.Errorf("timestamp is not monotonically increasing: %s < %s", batchData.Time, m.getLastBlockTime())
 			}
-			m.logger.Info("Creating and publishing block", "height", newHeight)
+			m.logger.Info("creating and publishing block", "height", newHeight)
 			m.logger.Debug("block info", "num_tx", len(batchData.Transactions))
 		}
 

--- a/block/submitter.go
+++ b/block/submitter.go
@@ -139,7 +139,7 @@ func (m *Manager) BatchSubmissionLoop(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			m.logger.Info("Batch submission loop stopped")
+			m.logger.Info("batch submission loop stopped")
 			return
 		case batch := <-m.batchSubmissionChan:
 			err := m.submitBatchToDA(ctx, batch)

--- a/block/sync.go
+++ b/block/sync.go
@@ -153,7 +153,7 @@ func (m *Manager) trySyncNextBlock(ctx context.Context, daHeight uint64) error {
 		}
 
 		hHeight := h.Height()
-		m.logger.Info("Syncing header and data", "height", hHeight)
+		m.logger.Info("syncing header and data", "height", hHeight)
 		// Validate the received block before applying
 		if err := m.Validate(ctx, h, d); err != nil {
 			return fmt.Errorf("failed to validate block: %w", err)

--- a/node/full.go
+++ b/node/full.go
@@ -487,7 +487,7 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 		}
 	}
 
-	// Shutdown RPC Serverr
+	// Shutdown RPC Server
 	if n.rpcServer != nil {
 		err = n.rpcServer.Shutdown(shutdownCtx)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/node/full.go
+++ b/node/full.go
@@ -452,11 +452,10 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 		// Log context canceled errors at a lower level if desired, or handle specific non-cancel errors
 		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			n.Logger.Error("error stopping header sync service", "error", err)
+			multiErr = errors.Join(multiErr, fmt.Errorf("stopping header sync service: %w", err))
 		} else {
 			n.Logger.Debug("header sync service stop context ended", "reason", err) // Log cancellation as debug
 		}
-		// Still include the error in multiErr for completeness if needed
-		multiErr = errors.Join(multiErr, fmt.Errorf("stopping header sync service: %w", err))
 	}
 
 	// Stop Data Sync Service
@@ -465,11 +464,10 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 		// Log context canceled errors at a lower level if desired, or handle specific non-cancel errors
 		if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 			n.Logger.Error("error stopping data sync service", "error", err)
+			multiErr = errors.Join(multiErr, fmt.Errorf("stopping data sync service: %w", err))
 		} else {
 			n.Logger.Debug("data sync service stop context ended", "reason", err) // Log cancellation as debug
 		}
-		// Still include the error in multiErr for completeness if needed
-		multiErr = errors.Join(multiErr, fmt.Errorf("stopping data sync service: %w", err))
 	}
 
 	// Shutdown Prometheus Server
@@ -489,7 +487,7 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 		}
 	}
 
-	// Shutdown RPC Server
+	// Shutdown RPC Serverrllk
 	if n.rpcServer != nil {
 		err = n.rpcServer.Shutdown(shutdownCtx)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {

--- a/node/full.go
+++ b/node/full.go
@@ -487,7 +487,7 @@ func (n *FullNode) Run(parentCtx context.Context) error {
 		}
 	}
 
-	// Shutdown RPC Serverrllk
+	// Shutdown RPC Serverr
 	if n.rpcServer != nil {
 		err = n.rpcServer.Shutdown(shutdownCtx)
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {


### PR DESCRIPTION
## Overview

1. Context cancelled isn't an error, it should be added to multiErr
2. Move cache under `data` instead of `config`

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
