### PR TITLE
refactor: remove issue found by copilot

### DIFF
--- a/block/pending_headers.go
+++ b/block/pending_headers.go
@@ -112,11 +112,6 @@ func (pb *PendingHeaders) setLastSubmittedHeight(ctx context.Context, newLastSub
 		binary.LittleEndian.PutUint64(bz, newLastSubmittedHeight)
 		err := pb.store.SetMetadata(ctx, LastSubmittedHeightKey, bz)
 		if err != nil {
-			pb.logger.Error("failed to convert last submitted height to bytes", "err", err)
-			return
-		}
-		err = pb.store.SetMetadata(ctx, LastSubmittedHeightKey, bz)
-		if err != nil {
 			// This indicates IO error in KV store. We can't do much about this.
 			// After next successful DA submission, update will be re-attempted (with new value).
 			// If store is not updated, after node restart some headers will be re-submitted to DA.


### PR DESCRIPTION
I am testing https://github.com/copilot/spaces and Copilot found some issues in the code:

1. The pb.store.SetMetadata call is duplicated. This is likely a bug and the second call is redundant or intended for a different purpose/key.