### PR TITLE
refactor: Remove redundant nil check for slice length in dummy_test.go

### DIFF
--- a/core/execution/dummy_test.go
+++ b/core/execution/dummy_test.go
@@ -27,7 +27,7 @@ func TestNewDummyExecutor(t *testing.T) {
 		t.Error("pendingRoots map was not initialized")
 	}
 
-	if executor.injectedTxs != nil && len(executor.injectedTxs) > 0 {
+	if len(executor.injectedTxs) > 0 {
 		t.Errorf("Expected injectedTxs to be empty, got %v", executor.injectedTxs)
 	}
 }


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

I forked this project and added lint checks in the CI, using staticcheck to identify this issue.

```shell
rollkit/core/execution/dummy_test.go:30:5: should omit nil check; len() for nil slices is defined as zero (S1009)
```


In Go, `len()` on a nil slice returns 0. Therefore, explicitly checking if a slice is `nil` before checking its length (e.g., `if s != nil && len(s) > 0`) is redundant. This commit removes the unnecessary `nil` check for `executor.injectedTxs` in the `TestNewDummyExecutor` function in <mcfile name="dummy_test.go" path="core/execution/dummy_test.go"></mcfile>, simplifying the condition to `if len(executor.injectedTxs) > 0`. This change adheres to common Go idioms and improves code readability without altering behavior.



<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified logic for checking if injected transactions are present in tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->