### PR TITLE
Update PoS FAQ link to direct "Nothing at Stake" section

### DIFF
--- a/specs/lazy-adr/adr-004-core-types.md
+++ b/specs/lazy-adr/adr-004-core-types.md
@@ -171,7 +171,7 @@ type EvidenceParams struct {
     //
     // It should correspond with an app's "unbonding period" or other similar
     // mechanism for handling [Nothing-At-Stake
-    // attacks](https://github.com/ethereum/wiki/wiki/Proof-of-Stake-FAQ#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
+    // attacks](https://vitalik.eth.limo/general/2017/12/31/pos_faq.html#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed).
     MaxAgeDuration time.Duration
     // This sets the maximum size of total evidence in bytes that can be committed in a single block.
     // and should fall comfortably under the max block bytes.


### PR DESCRIPTION


## Overview

Replaced the outdated Ethereum Proof-of-Stake FAQ link with the current, direct link to the "What is the 'nothing at stake' problem and how can it be fixed?" section in Vitalik Buterin's Proof of Stake FAQ. This ensures readers are directed to the most relevant and up-to-date explanation of the concept.
Reference: https://vitalik.eth.limo/general/2017/12/31/pos_faq.html#what-is-the-nothing-at-stake-problem-and-how-can-it-be-fixed




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the reference link for the "Nothing-At-Stake" problem to a more current source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->