### PR TITLE
feat: Expose Rollkit height to DA Height mapping

### DIFF
--- a/block/da_includer.go
+++ b/block/da_includer.go
@@ -28,6 +28,11 @@ func (m *Manager) DAIncluderLoop(ctx context.Context, errCh chan<- error) {
 				break
 			}
 			if daIncluded {
+				m.logger.Debug("both header and data are DA-included, advancing height", "height", nextHeight)
+				if err := m.SetRollkitHeightToDAHeight(ctx, nextHeight); err != nil {
+					errCh <- fmt.Errorf("failed to set rollkit height to DA height: %w", err)
+					return
+				}
 				// Both header and data are DA-included, so we can advance the height
 				if err := m.incrementDAIncludedHeight(ctx); err != nil {
 					errCh <- fmt.Errorf("error while incrementing DA included height: %w", err)

--- a/block/manager.go
+++ b/block/manager.go
@@ -55,6 +55,9 @@ const (
 
 	// LastBatchDataKey is the key used for persisting the last batch data in store.
 	LastBatchDataKey = "l"
+
+	// RollkitHeightToDAHeightKey is the key used for persisting the mapping rollkit height to da height in store.
+	RollkitHeightToDAHeightKey = "rhb"
 )
 
 var (
@@ -484,6 +487,45 @@ func (m *Manager) IsDAIncluded(ctx context.Context, height uint64) (bool, error)
 	headerHash, dataHash := header.Hash(), data.DACommitment()
 	isIncluded := m.headerCache.IsDAIncluded(headerHash.String()) && (bytes.Equal(dataHash, dataHashForEmptyTxs) || m.dataCache.IsDAIncluded(dataHash.String()))
 	return isIncluded, nil
+}
+
+// SetRollkitHeightToDAHeight stores the mapping from a Rollkit block height to the corresponding
+// DA (Data Availability) layer heights where the block's header and data were included.
+// This mapping is persisted in the store metadata and is used to track which DA heights
+// contain the block components for a given Rollkit height.
+//
+// For blocks with empty transactions, both header and data use the same DA height since
+// empty transaction data is not actually published to the DA layer.
+func (m *Manager) SetRollkitHeightToDAHeight(ctx context.Context, height uint64) error {
+	header, data, err := m.store.GetBlockData(ctx, height)
+	if err != nil {
+		return err
+	}
+	headerHash, dataHash := header.Hash(), data.DACommitment()
+	headerHeightBytes := make([]byte, 8)
+	daHeightForHeader, ok := m.headerCache.GetDAIncludedHeight(headerHash.String())
+	if !ok {
+		return fmt.Errorf("header hash %s not found in cache", headerHash)
+	}
+	binary.LittleEndian.PutUint64(headerHeightBytes, daHeightForHeader)
+	if err := m.store.SetMetadata(ctx, fmt.Sprintf("%s/%d/h", RollkitHeightToDAHeightKey, height), headerHeightBytes); err != nil {
+		return err
+	}
+	dataHeightBytes := make([]byte, 8)
+	// For empty transactions, use the same DA height as the header
+	if bytes.Equal(dataHash, dataHashForEmptyTxs) {
+		binary.LittleEndian.PutUint64(dataHeightBytes, daHeightForHeader)
+	} else {
+		daHeightForData, ok := m.dataCache.GetDAIncludedHeight(dataHash.String())
+		if !ok {
+			return fmt.Errorf("data hash %s not found in cache", dataHash.String())
+		}
+		binary.LittleEndian.PutUint64(dataHeightBytes, daHeightForData)
+	}
+	if err := m.store.SetMetadata(ctx, fmt.Sprintf("%s/%d/d", RollkitHeightToDAHeightKey, height), dataHeightBytes); err != nil {
+		return err
+	}
+	return nil
 }
 
 // GetExecutor returns the executor used by the manager.

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -194,11 +194,11 @@ func TestIsDAIncluded(t *testing.T) {
 	require.False(m.IsDAIncluded(ctx, height))
 
 	// Set the hash as DAIncluded and verify IsDAIncluded returns true
-	m.headerCache.SetDAIncluded(header.Hash().String())
+	m.headerCache.SetDAIncluded(header.Hash().String(), uint64(1))
 	require.False(m.IsDAIncluded(ctx, height))
 
 	// Set the data as DAIncluded and verify IsDAIncluded returns true
-	m.dataCache.SetDAIncluded(data.DACommitment().String())
+	m.dataCache.SetDAIncluded(data.DACommitment().String(), uint64(1))
 	require.True(m.IsDAIncluded(ctx, height))
 }
 
@@ -1063,5 +1063,140 @@ func TestConfigurationDefaults(t *testing.T) {
 		require.Error(err)
 		require.Contains(err.Error(), "corrupted data")
 		require.Contains(err.Error(), "insufficient bytes for length prefix")
+	})
+}
+
+// TestSetRollkitHeightToDAHeight tests the SetRollkitHeightToDAHeight method which maps
+// rollkit block heights to their corresponding DA heights for both headers and data.
+// This method is critical for tracking which DA heights contain specific rollkit blocks.
+func TestSetRollkitHeightToDAHeight(t *testing.T) {
+	t.Run("Success_WithTransactions", func(t *testing.T) {
+		require := require.New(t)
+		ctx := context.Background()
+		m, mockStore := getManager(t, nil, 0, 0)
+
+		// Create a block with transactions
+		header, data := types.GetRandomBlock(5, 3, "testchain")
+		height := uint64(5)
+
+		// Mock store expectations
+		mockStore.On("GetBlockData", mock.Anything, height).Return(header, data, nil)
+
+		// Set DA included heights in cache
+		headerHeight := uint64(10)
+		dataHeight := uint64(11)
+		m.headerCache.SetDAIncluded(header.Hash().String(), headerHeight)
+		m.dataCache.SetDAIncluded(data.DACommitment().String(), dataHeight)
+
+		// Mock metadata storage
+		headerKey := fmt.Sprintf("%s/%d/h", RollkitHeightToDAHeightKey, height)
+		dataKey := fmt.Sprintf("%s/%d/d", RollkitHeightToDAHeightKey, height)
+		mockStore.On("SetMetadata", mock.Anything, headerKey, mock.Anything).Return(nil)
+		mockStore.On("SetMetadata", mock.Anything, dataKey, mock.Anything).Return(nil)
+
+		// Call the method
+		err := m.SetRollkitHeightToDAHeight(ctx, height)
+		require.NoError(err)
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("Success_EmptyTransactions", func(t *testing.T) {
+		require := require.New(t)
+		ctx := context.Background()
+		m, mockStore := getManager(t, nil, 0, 0)
+
+		// Create a block with no transactions
+		header, data := types.GetRandomBlock(5, 0, "testchain")
+		height := uint64(5)
+
+		// Mock store expectations
+		mockStore.On("GetBlockData", mock.Anything, height).Return(header, data, nil)
+
+		// Only set header as DA included (data uses special empty hash)
+		headerHeight := uint64(10)
+		m.headerCache.SetDAIncluded(header.Hash().String(), headerHeight)
+		// Note: we don't set data in cache for empty transactions
+
+		// Mock metadata storage - both should use header height for empty transactions
+		headerKey := fmt.Sprintf("%s/%d/h", RollkitHeightToDAHeightKey, height)
+		dataKey := fmt.Sprintf("%s/%d/d", RollkitHeightToDAHeightKey, height)
+		mockStore.On("SetMetadata", mock.Anything, headerKey, mock.Anything).Return(nil)
+		mockStore.On("SetMetadata", mock.Anything, dataKey, mock.Anything).Return(nil)
+
+		// Call the method
+		err := m.SetRollkitHeightToDAHeight(ctx, height)
+		require.NoError(err)
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("Error_HeaderNotInCache", func(t *testing.T) {
+		require := require.New(t)
+		ctx := context.Background()
+		m, mockStore := getManager(t, nil, 0, 0)
+
+		// Create a block
+		header, data := types.GetRandomBlock(5, 3, "testchain")
+		height := uint64(5)
+
+		// Mock store expectations
+		mockStore.On("GetBlockData", mock.Anything, height).Return(header, data, nil)
+
+		// Don't set header in cache, but set data
+		m.dataCache.SetDAIncluded(data.DACommitment().String(), uint64(11))
+
+		// Call the method - should fail
+		err := m.SetRollkitHeightToDAHeight(ctx, height)
+		require.Error(err)
+		require.Contains(err.Error(), "header hash")
+		require.Contains(err.Error(), "not found in cache")
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("Error_DataNotInCache_NonEmptyTxs", func(t *testing.T) {
+		require := require.New(t)
+		ctx := context.Background()
+		m, mockStore := getManager(t, nil, 0, 0)
+
+		// Create a block with transactions
+		header, data := types.GetRandomBlock(5, 3, "testchain")
+		height := uint64(5)
+
+		// Mock store expectations
+		mockStore.On("GetBlockData", mock.Anything, height).Return(header, data, nil)
+
+		// Set header but not data in cache
+		m.headerCache.SetDAIncluded(header.Hash().String(), uint64(10))
+
+		// Mock metadata storage for header (should succeed)
+		headerKey := fmt.Sprintf("%s/%d/h", RollkitHeightToDAHeightKey, height)
+		mockStore.On("SetMetadata", mock.Anything, headerKey, mock.Anything).Return(nil)
+
+		// Call the method - should fail on data lookup
+		err := m.SetRollkitHeightToDAHeight(ctx, height)
+		require.Error(err)
+		require.Contains(err.Error(), "data hash")
+		require.Contains(err.Error(), "not found in cache")
+
+		mockStore.AssertExpectations(t)
+	})
+
+	t.Run("Error_BlockNotFound", func(t *testing.T) {
+		require := require.New(t)
+		ctx := context.Background()
+		m, mockStore := getManager(t, nil, 0, 0)
+
+		height := uint64(999) // Non-existent height
+
+		// Mock store expectations
+		mockStore.On("GetBlockData", mock.Anything, height).Return(nil, nil, errors.New("block not found"))
+
+		// Call the method - should fail
+		err := m.SetRollkitHeightToDAHeight(ctx, height)
+		require.Error(err)
+
+		mockStore.AssertExpectations(t)
 	})
 }

--- a/block/manager_test.go
+++ b/block/manager_test.go
@@ -1084,7 +1084,7 @@ func TestSetRollkitHeightToDAHeight(t *testing.T) {
 
 		// Set DA included heights in cache
 		headerHeight := uint64(10)
-		dataHeight := uint64(11)
+		dataHeight := uint64(20)
 		m.headerCache.SetDAIncluded(header.Hash().String(), headerHeight)
 		m.dataCache.SetDAIncluded(data.DACommitment().String(), dataHeight)
 

--- a/block/retriever.go
+++ b/block/retriever.go
@@ -133,7 +133,7 @@ func (m *Manager) handlePotentialHeader(ctx context.Context, bz []byte, daHeight
 		return true
 	}
 	headerHash := header.Hash().String()
-	m.headerCache.SetDAIncluded(headerHash)
+	m.headerCache.SetDAIncluded(headerHash, daHeight)
 	m.sendNonBlockingSignalToDAIncluderCh()
 	m.logger.Info("header marked as DA included", "headerHeight", header.Height(), "headerHash", headerHash)
 	if !m.headerCache.IsSeen(headerHash) {
@@ -168,7 +168,7 @@ func (m *Manager) handlePotentialData(ctx context.Context, bz []byte, daHeight u
 	}
 
 	dataHashStr := signedData.Data.DACommitment().String()
-	m.dataCache.SetDAIncluded(dataHashStr)
+	m.dataCache.SetDAIncluded(dataHashStr, daHeight)
 	m.sendNonBlockingSignalToDAIncluderCh()
 	m.logger.Info("signed data marked as DA included", "dataHash", dataHashStr, "daHeight", daHeight, "height", signedData.Height())
 	if !m.dataCache.IsSeen(dataHashStr) {

--- a/block/retriever_test.go
+++ b/block/retriever_test.go
@@ -528,9 +528,9 @@ func TestProcessNextDAHeader_HeaderAndDataAlreadySeen(t *testing.T) {
 
 	// Mark both header and data as seen and DA included
 	headerCache.SetSeen(headerHash)
-	headerCache.SetDAIncluded(headerHash)
+	headerCache.SetDAIncluded(headerHash, uint64(10))
 	dataCache.SetSeen(dataHash)
-	dataCache.SetDAIncluded(dataHash)
+	dataCache.SetDAIncluded(dataHash, uint64(10))
 
 	// Set up mocks with explicit logging
 	mockDAClient.On("GetIDs", mock.Anything, daHeight, mock.Anything).Return(&coreda.GetIDsResult{

--- a/block/submitter.go
+++ b/block/submitter.go
@@ -172,7 +172,7 @@ func (m *Manager) submitHeadersToDA(ctx context.Context, headersToSubmit []*type
 		},
 		func(submitted []*types.SignedHeader, res *coreda.ResultSubmit, gasPrice float64) {
 			for _, header := range submitted {
-				m.headerCache.SetDAIncluded(header.Hash().String())
+				m.headerCache.SetDAIncluded(header.Hash().String(), res.Height)
 			}
 			lastSubmittedHeaderHeight := uint64(0)
 			if l := len(submitted); l > 0 {
@@ -197,7 +197,7 @@ func (m *Manager) submitDataToDA(ctx context.Context, signedDataToSubmit []*type
 		},
 		func(submitted []*types.SignedData, res *coreda.ResultSubmit, gasPrice float64) {
 			for _, signedData := range submitted {
-				m.dataCache.SetDAIncluded(signedData.DACommitment().String())
+				m.dataCache.SetDAIncluded(signedData.Data.DACommitment().String(), res.Height)
 			}
 			lastSubmittedDataHeight := uint64(0)
 			if l := len(submitted); l > 0 {

--- a/block/submitter_test.go
+++ b/block/submitter_test.go
@@ -99,7 +99,7 @@ func TestSubmitDataToDA_Success(t *testing.T) {
 		},
 		mockDASetup: func(da *mocks.DA) {
 			da.On("Submit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-				Return([]coreda.ID{[]byte("id")}, nil)
+				Return([]coreda.ID{getDummyID(1, []byte("commitment"))}, nil)
 		},
 	})
 }
@@ -118,7 +118,7 @@ func TestSubmitHeadersToDA_Success(t *testing.T) {
 		},
 		mockDASetup: func(da *mocks.DA) {
 			da.On("Submit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-				Return([]coreda.ID{[]byte("id")}, nil)
+				Return([]coreda.ID{getDummyID(1, []byte("commitment"))}, nil)
 		},
 	})
 }
@@ -265,15 +265,15 @@ func runRetryPartialFailuresCase[T any](t *testing.T, tc retryPartialFailuresCas
 	da.On("Submit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			t.Logf("DA Submit call 1: args=%#v", args)
-		}).Once().Return([]coreda.ID{[]byte("id2")}, nil)
+		}).Once().Return([]coreda.ID{getDummyID(1, []byte("commitment2"))}, nil)
 	da.On("Submit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			t.Logf("DA Submit call 2: args=%#v", args)
-		}).Once().Return([]coreda.ID{[]byte("id3")}, nil)
+		}).Once().Return([]coreda.ID{getDummyID(1, []byte("commitment3"))}, nil)
 	da.On("Submit", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			t.Logf("DA Submit call 3: args=%#v", args)
-		}).Once().Return([]coreda.ID{[]byte("id4")}, nil)
+		}).Once().Return([]coreda.ID{getDummyID(1, []byte("commitment4"))}, nil)
 
 	err = tc.submitToDA(m, ctx, items)
 	assert.NoError(t, err)
@@ -553,4 +553,11 @@ func TestSubmitDataToDA_WithMetricsRecorder(t *testing.T) {
 
 	// Verify that RecordMetrics was called
 	mockSequencer.AssertExpectations(t)
+}
+
+func getDummyID(height uint64, commitment []byte) coreda.ID {
+	id := make([]byte, len(commitment)+8)
+	binary.LittleEndian.PutUint64(id, height)
+	copy(id[8:], commitment)
+	return id
 }

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -60,16 +60,21 @@ func (c *Cache[T]) SetSeen(hash string) {
 
 // IsDAIncluded returns true if the hash has been DA-included
 func (c *Cache[T]) IsDAIncluded(hash string) bool {
-	daIncluded, ok := c.daIncluded.Load(hash)
-	if !ok {
-		return false
-	}
-	return daIncluded.(bool)
+	_, ok := c.daIncluded.Load(hash)
+	return ok
 }
 
-// SetDAIncluded sets the hash as DA-included
-func (c *Cache[T]) SetDAIncluded(hash string) {
-	c.daIncluded.Store(hash, true)
+func (c *Cache[T]) GetDAIncludedHeight(hash string) (uint64, bool) {
+	daIncluded, ok := c.daIncluded.Load(hash)
+	if !ok {
+		return 0, false
+	}
+	return daIncluded.(uint64), true
+}
+
+// SetDAIncluded sets the hash as DA-included with the given height
+func (c *Cache[T]) SetDAIncluded(hash string, height uint64) {
+	c.daIncluded.Store(hash, height)
 }
 
 const (
@@ -168,12 +173,12 @@ func (c *Cache[T]) SaveToDisk(folderPath string) error {
 	}
 
 	// prepare daIncluded map
-	daIncludedToSave := make(map[string]bool)
+	daIncludedToSave := make(map[string]uint64)
 	c.daIncluded.Range(func(k, v interface{}) bool {
 		keyStr, okKey := k.(string)
-		valBool, okVal := v.(bool)
+		valUint64, okVal := v.(uint64)
 		if okKey && okVal {
-			daIncludedToSave[keyStr] = valBool
+			daIncludedToSave[keyStr] = valUint64
 		}
 		return true
 	})
@@ -213,7 +218,7 @@ func (c *Cache[T]) LoadFromDisk(folderPath string) error {
 	}
 
 	// load daIncluded
-	daIncludedMap, err := loadMapGob[string, bool](filepath.Join(folderPath, daIncludedFilename))
+	daIncludedMap, err := loadMapGob[string, uint64](filepath.Join(folderPath, daIncludedFilename))
 	if err != nil {
 		return fmt.Errorf("failed to load daIncluded: %w", err)
 	}

--- a/specs/src/specs/block-validity.md
+++ b/specs/src/specs/block-validity.md
@@ -72,11 +72,10 @@ Block.Verify()
 
 ```
 
-## [Block](https://github.com/rollkit/rollkit/blob/main/types/block.go#L26)
+## [Data](https://github.com/rollkit/rollkit/blob/main/types/data.go#L25)
 
 | **Field Name** | **Valid State**                         | **Validation**                     |
 |----------------|-----------------------------------------|------------------------------------|
-| SignedHeader   | Header of the block, signed by proposer | (See SignedHeader)                 |
 | Data           | Transaction data of the block           | Data.Hash == SignedHeader.DataHash |
 
 ## [SignedHeader](https://github.com/rollkit/rollkit/blob/main/types/signed_header.go#L16)

--- a/types/da.go
+++ b/types/da.go
@@ -57,6 +57,7 @@ func SubmitWithHelpers(
 				Message:        "failed to submit blobs: " + err.Error(),
 				IDs:            ids,
 				SubmittedCount: uint64(len(ids)),
+				Height:         0,
 			},
 		}
 	}
@@ -71,13 +72,22 @@ func SubmitWithHelpers(
 		}
 	}
 
+	// Get height from the first ID
+	var height uint64
+	if len(ids) > 0 {
+		height, _, err = coreda.SplitID(ids[0])
+		if err != nil {
+			logger.Error("failed to split ID", "error", err)
+		}
+	}
+
 	logger.Debug("DA submission successful via helper", "num_ids", len(ids))
 	return coreda.ResultSubmit{
 		BaseResult: coreda.BaseResult{
 			Code:           coreda.StatusSuccess,
 			IDs:            ids,
 			SubmittedCount: uint64(len(ids)),
-			Height:         0,
+			Height:         height,
 			BlobSize:       0,
 		},
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Expose Rollkit height to DA Height mapping

Closes: https://github.com/rollkit/rollkit/issues/2360

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Tracks and stores the specific height at which data is included in the DA layer, enabling precise synchronization and mapping between Rollkit and DA block heights.
	- Enhanced logging to provide more detailed context on DA inclusion events.

- **Bug Fixes**
	- Ensures correct association of DA inclusion heights with headers and data, improving block processing accuracy and error handling.

- **Documentation**
	- Updated block validity specifications to clarify focus on data validation and field requirements.

- **Tests**
	- Expanded tests to cover DA height tracking, error scenarios, concurrency, and metadata persistence, ensuring robust and reliable behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->