### PR TITLE
fix: Handle ErrHeightFromFuture correctly

### DIFF
--- a/block/retriever.go
+++ b/block/retriever.go
@@ -216,7 +216,8 @@ func (m *Manager) fetchBlobs(ctx context.Context, daHeight uint64) (coreda.Resul
 	if blobsRes.Code == coreda.StatusError {
 		err = fmt.Errorf("failed to retrieve block: %s", blobsRes.Message)
 	} else if blobsRes.Code == coreda.StatusHeightFromFuture {
-		err = fmt.Errorf("height from future: %s", blobsRes.Message)
+		// Keep the root cause intact for callers that may rely on errors.Is/As.
+		err = fmt.Errorf("%w: %s", coreda.ErrHeightFromFuture, blobsRes.Message)
 	}
 	return blobsRes, err
 }

--- a/block/retriever.go
+++ b/block/retriever.go
@@ -213,9 +213,10 @@ func (m *Manager) fetchBlobs(ctx context.Context, daHeight uint64) (coreda.Resul
 	defer cancel()
 	// TODO: we should maintain the original error instead of creating a new one as we lose context by creating a new error.
 	blobsRes := types.RetrieveWithHelpers(ctx, m.da, m.logger, daHeight)
-	if blobsRes.Code == coreda.StatusError {
+	switch blobsRes.Code {
+	case coreda.StatusError:
 		err = fmt.Errorf("failed to retrieve block: %s", blobsRes.Message)
-	} else if blobsRes.Code == coreda.StatusHeightFromFuture {
+	case coreda.StatusHeightFromFuture:
 		// Keep the root cause intact for callers that may rely on errors.Is/As.
 		err = fmt.Errorf("%w: %s", coreda.ErrHeightFromFuture, blobsRes.Message)
 	}

--- a/block/retriever.go
+++ b/block/retriever.go
@@ -88,6 +88,9 @@ func (m *Manager) processNextDAHeaderAndData(ctx context.Context) error {
 				m.handlePotentialData(ctx, bz, daHeight)
 			}
 			return nil
+		} else if strings.Contains(fetchErr.Error(), coreda.ErrHeightFromFuture.Error()) {
+			m.logger.Debug("height from future", "daHeight", daHeight, "reason", fetchErr.Error())
+			return fetchErr
 		}
 
 		// Track the error
@@ -212,6 +215,8 @@ func (m *Manager) fetchBlobs(ctx context.Context, daHeight uint64) (coreda.Resul
 	blobsRes := types.RetrieveWithHelpers(ctx, m.da, m.logger, daHeight)
 	if blobsRes.Code == coreda.StatusError {
 		err = fmt.Errorf("failed to retrieve block: %s", blobsRes.Message)
+	} else if blobsRes.Code == coreda.StatusHeightFromFuture {
+		err = fmt.Errorf("height from future: %s", blobsRes.Message)
 	}
 	return blobsRes, err
 }

--- a/block/retriever_test.go
+++ b/block/retriever_test.go
@@ -578,7 +578,7 @@ func TestRetrieveLoop_ProcessError_HeightFromFuture(t *testing.T) {
 	// Mock GetIDs to return future error for all retries
 	mockDAClient.On("GetIDs", mock.Anything, startDAHeight, []byte("placeholder")).Return(
 		nil, futureErr,
-	).Times(dAFetcherRetries)
+	).Once()
 
 	// Optional: Mock for the next height if needed
 	mockDAClient.On("GetIDs", mock.Anything, startDAHeight+1, []byte("placeholder")).Return(

--- a/core/da/da.go
+++ b/core/da/da.go
@@ -92,6 +92,7 @@ const (
 	StatusError
 	StatusIncorrectAccountSequence
 	StatusContextCanceled
+	StatusHeightFromFuture
 )
 
 // BaseResult contains basic information returned by DA layer.

--- a/da/jsonrpc/client.go
+++ b/da/jsonrpc/client.go
@@ -59,6 +59,7 @@ func (api *API) GetIDs(ctx context.Context, height uint64, _ []byte) (*da.GetIDs
 	api.Logger.Debug("Making RPC call", "method", "GetIDs", "height", height, "namespace", string(api.Namespace))
 	res, err := api.Internal.GetIDs(ctx, height, api.Namespace)
 	if err != nil {
+		// Using strings.contains since JSON RPC serialization doesn't preserve error wrapping
 		// Check if the error is specifically BlobNotFound, otherwise log and return
 		if strings.Contains(err.Error(), da.ErrBlobNotFound.Error()) { // Use the error variable directly
 			api.Logger.Debug("RPC call indicates blobs not found", "method", "GetIDs", "height", height)

--- a/da/jsonrpc/client.go
+++ b/da/jsonrpc/client.go
@@ -3,9 +3,9 @@ package jsonrpc
 import (
 	"context"
 	"encoding/hex"
-	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"cosmossdk.io/log"
 	"github.com/filecoin-project/go-jsonrpc"
@@ -42,7 +42,7 @@ func (api *API) Get(ctx context.Context, ids []da.ID, _ []byte) ([]da.Blob, erro
 	api.Logger.Debug("Making RPC call", "method", "Get", "num_ids", len(ids), "namespace", string(api.Namespace))
 	res, err := api.Internal.Get(ctx, ids, api.Namespace)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if strings.Contains(err.Error(), context.Canceled.Error()) {
 			api.Logger.Debug("RPC call canceled due to context cancellation", "method", "Get")
 			return res, context.Canceled
 		}
@@ -60,15 +60,15 @@ func (api *API) GetIDs(ctx context.Context, height uint64, _ []byte) (*da.GetIDs
 	res, err := api.Internal.GetIDs(ctx, height, api.Namespace)
 	if err != nil {
 		// Check if the error is specifically BlobNotFound, otherwise log and return
-		if errors.Is(err, da.ErrBlobNotFound) { // Use the error variable directly
+		if strings.Contains(err.Error(), da.ErrBlobNotFound.Error()) { // Use the error variable directly
 			api.Logger.Debug("RPC call indicates blobs not found", "method", "GetIDs", "height", height)
 			return nil, err // Return the specific ErrBlobNotFound
 		}
-		if errors.Is(err, da.ErrHeightFromFuture) {
+		if strings.Contains(err.Error(), da.ErrHeightFromFuture.Error()) {
 			api.Logger.Debug("RPC call indicates height from future", "method", "GetIDs", "height", height)
 			return nil, err // Return the specific ErrHeightFromFuture
 		}
-		if errors.Is(err, context.Canceled) {
+		if strings.Contains(err.Error(), context.Canceled.Error()) {
 			api.Logger.Debug("RPC call canceled due to context cancellation", "method", "GetIDs")
 			return res, context.Canceled
 		}
@@ -127,7 +127,7 @@ func (api *API) Submit(ctx context.Context, blobs []da.Blob, gasPrice float64, _
 	api.Logger.Debug("Making RPC call", "method", "Submit", "num_blobs", len(blobs), "gas_price", gasPrice, "namespace", string(api.Namespace))
 	res, err := api.Internal.Submit(ctx, blobs, gasPrice, api.Namespace)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if strings.Contains(err.Error(), context.Canceled.Error()) {
 			api.Logger.Debug("RPC call canceled due to context cancellation", "method", "Submit")
 			return res, context.Canceled
 		}
@@ -180,7 +180,7 @@ func (api *API) SubmitWithOptions(ctx context.Context, inputBlobs []da.Blob, gas
 	api.Logger.Debug("Making RPC call", "method", "SubmitWithOptions", "num_blobs_original", len(inputBlobs), "num_blobs_to_submit", len(blobsToSubmit), "gas_price", gasPrice, "namespace", string(api.Namespace))
 	res, err := api.Internal.SubmitWithOptions(ctx, blobsToSubmit, gasPrice, api.Namespace, options)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if strings.Contains(err.Error(), context.Canceled.Error()) {
 			api.Logger.Debug("RPC call canceled due to context cancellation", "method", "SubmitWithOptions")
 			return res, context.Canceled
 		}

--- a/da/jsonrpc/errors.go
+++ b/da/jsonrpc/errors.go
@@ -16,5 +16,6 @@ func getKnownErrorsMapping() jsonrpc.Errors {
 	errs.Register(jsonrpc.ErrorCode(coreda.StatusIncorrectAccountSequence), &coreda.ErrTxIncorrectAccountSequence)
 	errs.Register(jsonrpc.ErrorCode(coreda.StatusContextDeadline), &coreda.ErrContextDeadline)
 	errs.Register(jsonrpc.ErrorCode(coreda.StatusContextCanceled), &coreda.ErrContextCanceled)
+	errs.Register(jsonrpc.ErrorCode(coreda.StatusHeightFromFuture), &coreda.ErrHeightFromFuture)
 	return errs
 }

--- a/types/da.go
+++ b/types/da.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"cosmossdk.io/log"
 
@@ -99,12 +100,22 @@ func RetrieveWithHelpers(
 	idsResult, err := da.GetIDs(ctx, dataLayerHeight, NameSpacePlaceholder)
 	if err != nil {
 		// Handle specific "not found" error
-		if errors.Is(err, coreda.ErrBlobNotFound) {
+		if strings.Contains(err.Error(), coreda.ErrBlobNotFound.Error()) {
 			logger.Debug("Retrieve helper: Blobs not found at height", "height", dataLayerHeight)
 			return coreda.ResultRetrieve{
 				BaseResult: coreda.BaseResult{
 					Code:    coreda.StatusNotFound,
 					Message: coreda.ErrBlobNotFound.Error(),
+					Height:  dataLayerHeight,
+				},
+			}
+		}
+		if strings.Contains(err.Error(), coreda.ErrHeightFromFuture.Error()) {
+			logger.Debug("Retrieve helper: Blobs not found at height", "height", dataLayerHeight)
+			return coreda.ResultRetrieve{
+				BaseResult: coreda.BaseResult{
+					Code:    coreda.StatusHeightFromFuture,
+					Message: coreda.ErrHeightFromFuture.Error(),
 					Height:  dataLayerHeight,
 				},
 			}

--- a/types/da_test.go
+++ b/types/da_test.go
@@ -173,6 +173,13 @@ func TestRetrieveWithHelpers(t *testing.T) {
 			expectedHeight: dataLayerHeight,
 		},
 		{
+			name:           "height from future error during GetIDs",
+			getIDsErr:      coreda.ErrHeightFromFuture,
+			expectedCode:   coreda.StatusHeightFromFuture,
+			expectedErrMsg: coreda.ErrHeightFromFuture.Error(),
+			expectedHeight: dataLayerHeight,
+		},
+		{
 			name:           "generic error during GetIDs",
 			getIDsErr:      errors.New("failed to connect to DA"),
 			expectedCode:   coreda.StatusError,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

- For full node, During retrieval from DA, when ErrHeightFromFuture is encountered, it should stop retrying the DA multiple times consecutively. 
- JSON RPC serialization doesn't preserve error wrapping correctly so need to use strings.Contains instead for detecting errors.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Improved error handling for "height from future" scenarios, providing clearer feedback when data is requested from a future block height.
- **Bug Fixes**
  - Enhanced detection and reporting of specific error conditions related to data availability, ensuring more accurate status codes and messages.
- **Tests**
  - Added a test case to verify correct handling and reporting of the "height from future" error condition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->