### PR TITLE
ci: break out integration tests from unit 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,9 @@ jobs:
     name: Combine and Upload Coverage
     needs: [unit_test, integration_test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
     steps:
       - uses: actions/checkout@v4
       - name: Download unit test coverage report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -148,8 +148,8 @@ jobs:
           path: ./integration-coverage
       - name: Combine coverage reports
         run: |
-          ls -R
-          go tool cover -mode=set -o combined-coverage.txt unit-coverage/coverage.txt integration-coverage/coverage.txt
+          go install github.com/wadey/gocovmerge@latest
+          gocovmerge ./coverage.txt ./node/coverage.txt > combined-coverage.txt
       - name: Upload combined coverage report
         uses: codecov/codecov-action@v5.4.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,8 @@ jobs:
   integration_test:
     name: Run Integration Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: set up go

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,7 +94,7 @@ jobs:
         with:
           go-version-file: ./go.mod
       - name: Run integration test
-        run: make test-integration
+        run: make test-integration-cover
       - name: Upload integration test coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,7 +149,7 @@ jobs:
       - name: Combine coverage reports
         run: |
           go install github.com/wadey/gocovmerge@latest
-          gocovmerge ./coverage.txt ./node/coverage.txt > combined-coverage.txt
+          gocovmerge unit-coverage/coverage.txt integration-coverage/coverage.txt > combined-coverage.txt
       - name: Upload combined coverage report
         uses: codecov/codecov-action@v5.4.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -146,12 +146,9 @@ jobs:
         with:
           name: integration-test-coverage-report-${{ github.sha }}
           path: ./integration-coverage
-      - name: Combine coverage reports
-        run: |
-          go install github.com/wadey/gocovmerge@latest
-          gocovmerge unit-coverage/coverage.txt integration-coverage/coverage.txt > combined-coverage.txt
       - name: Upload combined coverage report
         uses: codecov/codecov-action@v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./combined-coverage.txt
+          files: ./unit-coverage/coverage.txt,./integration-coverage/coverage.txt
+          flags: combined

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-test-coverage-report-${{ github.sha }}
-          path: ./coverage.txt
+          path: ./node/coverage.txt
 
   e2e-tests:
     name: Run E2E System Tests
@@ -144,8 +144,7 @@ jobs:
       - name: Combine coverage reports
         run: |
           ls -R
-          go install github.com/ory/go-acc@latest
-          go-acc merge ./unit-coverage/coverage.txt ./integration-coverage/coverage.txt > combined-coverage.txt
+          go tool cover -mode=set -o combined-coverage.txt unit-coverage/coverage.txt integration-coverage/coverage.txt
       - name: Upload combined coverage report
         uses: codecov/codecov-action@v5.4.3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,14 +76,32 @@ jobs:
           go-version-file: ./go.mod
       - name: Run unit test
         run: make test-cover
-      - name: upload coverage report
-        uses: codecov/codecov-action@v5.4.3
+      - name: Upload unit test coverage report
+        uses: actions/upload-artifact@v4
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./coverage.txt
+          name: unit-test-coverage-report-${{ github.sha }}
+          path: ./coverage.txt
+
+  integration_test:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: set up go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ./go.mod
+      - name: Run integration test
+        run: make test-integration
+      - name: Upload integration test coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-coverage-report-${{ github.sha }}
+          path: ./coverage.txt
 
   e2e-tests:
     name: Run E2E System Tests
+    needs: build_all-apps
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -96,6 +114,7 @@ jobs:
 
   evm-tests:
     name: Run EVM Execution Tests
+    needs: build_all-apps
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -105,3 +124,30 @@ jobs:
           go-version-file: ./go.mod
       - name: EVM Tests
         run: make test-evm
+
+  combine_and_upload_coverage:
+    name: Combine and Upload Coverage
+    needs: [unit_test, integration_test]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download unit test coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: unit-test-coverage-report-${{ github.sha }}
+          path: ./unit-coverage
+      - name: Download integration test coverage report
+        uses: actions/download-artifact@v4
+        with:
+          name: integration-test-coverage-report-${{ github.sha }}
+          path: ./integration-coverage
+      - name: Combine coverage reports
+        run: |
+          ls -R
+          go install github.com/ory/go-acc@latest
+          go-acc merge ./unit-coverage/coverage.txt ./integration-coverage/coverage.txt > combined-coverage.txt
+      - name: Upload combined coverage report
+        uses: codecov/codecov-action@v5.4.3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./combined-coverage.txt

--- a/node/execution_test.go
+++ b/node/execution_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package node
 
 import (

--- a/node/full_node_integration_test.go
+++ b/node/full_node_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package node
 
 import (

--- a/node/full_node_test.go
+++ b/node/full_node_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package node
 
 import (

--- a/node/helpers.go
+++ b/node/helpers.go
@@ -1,3 +1,4 @@
+//nolint:unused
 package node
 
 import (

--- a/node/helpers_test.go
+++ b/node/helpers_test.go
@@ -1,3 +1,4 @@
+//nolint:unused
 package node
 
 import (

--- a/node/single_sequencer_integration_test.go
+++ b/node/single_sequencer_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package node
 
 import (

--- a/node/single_sequencer_test.go
+++ b/node/single_sequencer_test.go
@@ -1,3 +1,5 @@
+//go:build !integration
+
 package node
 
 import (

--- a/pkg/sync/sync_service_test.go
+++ b/pkg/sync/sync_service_test.go
@@ -79,8 +79,7 @@ func TestHeaderSyncServiceRestart(t *testing.T) {
 	_ = svc.Stop(ctx)
 	cancel()
 
-	restartedKV := sync.MutexWrap(datastore.NewMapDatastore())
-	p2pClient, err = p2p.NewClient(conf, nodeKey, restartedKV, logger, p2p.NopMetrics())
+	p2pClient, err = p2p.NewClient(conf, nodeKey, mainKV, logger, p2p.NopMetrics())
 	require.NoError(t, err)
 
 	// Start p2p client again
@@ -90,7 +89,7 @@ func TestHeaderSyncServiceRestart(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = p2pClient.Close() })
 
-	svc, err = NewHeaderSyncService(restartedKV, conf, genesisDoc, p2pClient, logger)
+	svc, err = NewHeaderSyncService(mainKV, conf, genesisDoc, p2pClient, logger)
 	require.NoError(t, err)
 	err = svc.Start(ctx)
 	require.NoError(t, err)

--- a/pkg/sync/sync_service_test.go
+++ b/pkg/sync/sync_service_test.go
@@ -79,7 +79,8 @@ func TestHeaderSyncServiceRestart(t *testing.T) {
 	_ = svc.Stop(ctx)
 	cancel()
 
-	p2pClient, err = p2p.NewClient(conf, nodeKey, mainKV, logger, p2p.NopMetrics())
+	restartedKV := sync.MutexWrap(datastore.NewMapDatastore())
+	p2pClient, err = p2p.NewClient(conf, nodeKey, restartedKV, logger, p2p.NopMetrics())
 	require.NoError(t, err)
 
 	// Start p2p client again
@@ -89,7 +90,7 @@ func TestHeaderSyncServiceRestart(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = p2pClient.Close() })
 
-	svc, err = NewHeaderSyncService(mainKV, conf, genesisDoc, p2pClient, logger)
+	svc, err = NewHeaderSyncService(restartedKV, conf, genesisDoc, p2pClient, logger)
 	require.NoError(t, err)
 	err = svc.Start(ctx)
 	require.NoError(t, err)

--- a/scripts/test.mk
+++ b/scripts/test.mk
@@ -7,8 +7,14 @@ clean-testcache:
 ## test: Running unit tests for all go.mods
 test:
 	@echo "--> Running unit tests"
-	@go run -tags=run scripts/test.go
+	@go run -tags='run integration' scripts/test.go
 .PHONY: test
+
+## test-e2e: Running e2e tests
+test-integration: 
+	@echo "--> Running e2e tests"
+	@cd node && go test -mod=readonly -failfast -timeout=15m -tags='integration' ./... -cover
+.PHONY: test-integration
 
 ## test-e2e: Running e2e tests
 test-e2e: build build-da build-evm-single

--- a/scripts/test.mk
+++ b/scripts/test.mk
@@ -13,7 +13,7 @@ test:
 ## test-e2e: Running e2e tests
 test-integration: 
 	@echo "--> Running e2e tests"
-	@cd node && go test -mod=readonly -failfast -timeout=15m -tags='integration' ./... -cover
+	@cd node && go test -mod=readonly -failfast -timeout=15m -tags='integration' ./... 
 .PHONY: test-integration
 
 ## test-e2e: Running e2e tests
@@ -25,9 +25,14 @@ test-e2e: build build-da build-evm-single
 ## cover: generate to code coverage report.
 cover:
 	@echo "--> Generating Code Coverage"
-	@go install github.com/ory/go-acc@latest
-	@go-acc -o coverage.txt ./...
+	@go tool cover -mode=set -o coverage.txt ./...
 .PHONY: cover
+
+## test-integration-cover: generate code coverage report for integration tests.
+test-integration-cover:
+	@echo "--> Running integration tests with coverage"
+	@cd node && go test -mod=readonly -failfast -timeout=15m -tags='integration' -coverprofile=coverage.txt -covermode=atomic ./...
+.PHONY: test-integration-cover
 
 ## test-cover: generate code coverage report.
 test-cover:

--- a/scripts/test.mk
+++ b/scripts/test.mk
@@ -22,12 +22,6 @@ test-e2e: build build-da build-evm-single
 	@cd test/e2e && go test -mod=readonly -failfast -timeout=15m -tags='e2e evm' ./... --binary=$(CURDIR)/build/testapp --evm-binary=$(CURDIR)/build/evm-single
 .PHONY: test-e2e
 
-## cover: generate to code coverage report.
-cover:
-	@echo "--> Generating Code Coverage"
-	@go tool cover -mode=set -o coverage.txt ./...
-.PHONY: cover
-
 ## test-integration-cover: generate code coverage report for integration tests.
 test-integration-cover:
 	@echo "--> Running integration tests with coverage"


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

This pr splits the unit tests from integration in node. this allows the integration tests to have a custom job for integration test as the integration tests were flaky 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new commands to run integration tests and generate integration test coverage reports.

- **Refactor**
  - Updated test and coverage commands for improved integration test handling and coverage reporting.
  - Adjusted test job workflow to separate unit and integration test coverage, with combined reporting.

- **Chores**
  - Introduced build tags and linter directives to better organize test files and suppress unused code warnings.
  - Improved test isolation by using separate in-memory datastores during service restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->