### PR TITLE
refactor: custom HTTP endpoint registration

### DIFF
--- a/pkg/rpc/server/http.go
+++ b/pkg/rpc/server/http.go
@@ -11,7 +11,7 @@ func RegisterCustomHTTPEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/health/live", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "OK")
+		fmt.Fprintln(w, "{ status: OK }")
 	})
 
 	// Example for adding more custom endpoints:

--- a/pkg/rpc/server/http.go
+++ b/pkg/rpc/server/http.go
@@ -1,0 +1,23 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// RegisterCustomHTTPEndpoints is the designated place to add new, non-gRPC, plain HTTP handlers.
+// Additional custom HTTP endpoints can be registered on the mux here.
+func RegisterCustomHTTPEndpoints(mux *http.ServeMux) {
+	mux.HandleFunc("/health/live", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "OK")
+	})
+
+	// Example for adding more custom endpoints:
+	// mux.HandleFunc("/custom/myendpoint", func(w http.ResponseWriter, r *http.Request) {
+	//     // Your handler logic here
+	//     w.WriteHeader(http.StatusOK)
+	//     fmt.Fprintln(w, "My custom endpoint!")
+	// })
+}

--- a/pkg/rpc/server/http.go
+++ b/pkg/rpc/server/http.go
@@ -11,7 +11,7 @@ func RegisterCustomHTTPEndpoints(mux *http.ServeMux) {
 	mux.HandleFunc("/health/live", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintln(w, "{ status: OK }")
+		fmt.Fprintln(w, "OK")
 	})
 
 	// Example for adding more custom endpoints:

--- a/pkg/rpc/server/http_test.go
+++ b/pkg/rpc/server/http_test.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegisterCustomHTTPEndpoints(t *testing.T) {
+	// Create a new ServeMux
+	mux := http.NewServeMux()
+
+	// Register custom HTTP endpoints
+	RegisterCustomHTTPEndpoints(mux)
+
+	// Create a new HTTP test server with the mux
+	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
+
+	// Make an HTTP GET request to the /health/live endpoint
+	resp, err := http.Get(testServer.URL + "/health/live")
+	assert.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// Read the response body
+	body, err := io.ReadAll(resp.Body)
+	assert.NoError(t, err)
+
+	// Check the response body content
+	assert.Equal(t, "OK\n", string(body)) // fmt.Fprintln adds a newline
+}

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -237,6 +237,9 @@ func NewServiceHandler(store store.Store, peerManager p2p.P2PRPC) (http.Handler,
 	healthPath, healthHandler := rpc.NewHealthServiceHandler(healthServer)
 	mux.Handle(healthPath, healthHandler)
 
+	// Register custom HTTP endpoints
+	RegisterCustomHTTPEndpoints(mux)
+
 	// Use h2c to support HTTP/2 without TLS
 	return h2c.NewHandler(mux, &http2.Server{
 		IdleTimeout:          120 * time.Second,

--- a/test/docker-e2e/doc.go
+++ b/test/docker-e2e/doc.go
@@ -1,0 +1,4 @@
+/*
+Package docker_e2e provides end-to-end tests for the Docker integration.
+*/
+package docker_e2e


### PR DESCRIPTION
## Overview

This commit introduces a new file `pkg/rpc/server/http.go` to provide a centralized location for registering custom, non-gRPC, plain HTTP endpoints.

A new function `RegisterCustomHTTPEndpoints(mux *http.ServeMux)` is defined in this file. The existing `/health/live` endpoint has been moved into this function. The `NewServiceHandler` in `pkg/rpc/server/server.go` now calls `RegisterCustomHTTPEndpoints` to include these custom routes.

This change helps to keep the `server.go` file cleaner and makes it easier to manage and add new custom HTTP endpoints in the future.

A test file `pkg/rpc/server/http_test.go` has been added with `TestRegisterCustomHTTPEndpoints` to ensure that endpoints registered via this new structure are correctly served.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->



closes https://github.com/rollkit/rollkit/issues/2375


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new liveness health check endpoint at /health/live, returning a 200 OK status and "OK" response.
- **Tests**
  - Added tests to verify the correct registration and response of the /health/live endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->