### PR TITLE
ci: build evm single app on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
     # skip building images for merge groups as they are already built on PRs and main
     if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -41,6 +43,8 @@ jobs:
     # skip building images for merge groups as they are already built on PRs and main
     if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ on:
         type: string
 
 jobs:
-  build-docker-image:
-    name: Build Docker Image
+  build-rollkit-image:
+    name: Build Rollkit Docker Image
     # skip building images for merge groups as they are already built on PRs and main
     if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
@@ -28,7 +28,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image with PR tag
+      - name: Build and push rollkit Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -36,9 +36,37 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/${{ github.repository_owner }}/rollkit:${{ inputs.image-tag }}
 
+  build-rollkit-evm-single-image:
+    name: Build Rollkit EVM Single Docker Image
+    # skip building images for merge groups as they are already built on PRs and main
+    if: github.event_name != 'merge_group'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push rollkit-evm-single Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/evm/single/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/${{ github.repository_owner }}/rollkit-evm-single:${{ inputs.image-tag }}
+
   docker-tests:
     name: Docker E2E Tests
-    needs: build-docker-image
+    needs: build-rollkit-image
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/apps/evm/single/Dockerfile
+++ b/apps/evm/single/Dockerfile
@@ -2,10 +2,15 @@ FROM golang:1.24-alpine AS build-env
 
 WORKDIR /src
 
+ADD core core
+
+COPY go.mod go.sum ./
+RUN go mod download
+
 COPY . .
 
 WORKDIR /src/apps/evm/single
-RUN CGO_ENABLED=0 GOOS=linux go build -o evm-single .
+RUN go mod tidy && CGO_ENABLED=0 GOOS=linux go build -o evm-single .
 
 FROM alpine:3.18.3
 

--- a/apps/evm/single/Dockerfile
+++ b/apps/evm/single/Dockerfile
@@ -1,30 +1,19 @@
-# Make sure to build this from the root of the directory: rollkit
-# docker build -f apps/evm/single/Dockerfile -t ghcr.io/rollkit/rollkit-evm-single:<version> .
-
 FROM golang:1.24-alpine AS build-env
 
 WORKDIR /src
 
 COPY . .
 
-# Uncomment the following lines to build the binary from source in the dockerfile directly
-# WORKDIR /src/apps/evm/single
-
-# RUN go mod tidy -compat=1.19 && \
-#     CGO_ENABLED=0 go build -o /src/evm-single .
-
+WORKDIR /src/apps/evm/single
+RUN CGO_ENABLED=0 GOOS=linux go build -o evm-single .
 
 FROM alpine:3.18.3
 
+RUN apk --no-cache add ca-certificates
+
 WORKDIR /root
 
-# Copy the binary from evm-single
-# Make sure to build it first with the following command:
-# GOOS=linux GOARCH=amd64 go build -o evm-single .
-COPY apps/evm/single/evm-single /usr/bin/evm-single
-
-# Uncomment the following lines to build the binary from source in the dockerfile directly
-# COPY --from=build-env /src/evm-single /usr/bin/evm-single
+COPY --from=build-env /src/apps/evm/single/evm-single /usr/bin/evm-single
 COPY apps/evm/single/entrypoint.sh /usr/bin/entrypoint.sh
 RUN chmod +x /usr/bin/entrypoint.sh
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

I noticed the evm image isn't being pushed, the Dockerfile existed to be used for local testing (unsure if it's being actively used right now?)

This PR updates it to use a multi stage build, and pushes to the ghcr registry. This will allow for testing w/tastora

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Docker image build and push process for the EVM single application, making it available as a separate image.
- **Chores**
  - Renamed the main Docker image build workflow for clarity.
  - Updated workflow dependencies to reflect the new job names.
  - Improved the Dockerfile for the EVM single application to streamline and automate the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->