### PR TITLE
fix: evm-single sequencer metrics

### DIFF
--- a/apps/evm/single/cmd/run.go
+++ b/apps/evm/single/cmd/run.go
@@ -60,10 +60,10 @@ var RunCmd = &cobra.Command{
 			return err
 		}
 
-		singleMetrics, err := single.NopMetrics()
-		if err != nil {
-			return err
-		}
+	singleMetrics, err := single.DefaultMetricsProvider(nodeConfig.Instrumentation.IsPrometheusEnabled())(nodeConfig.ChainID)
+	if err != nil {
+		return err
+	}
 
 		sequencer, err := single.NewSequencer(
 			context.Background(),

--- a/apps/evm/single/cmd/run.go
+++ b/apps/evm/single/cmd/run.go
@@ -60,7 +60,7 @@ var RunCmd = &cobra.Command{
 			return err
 		}
 
-	singleMetrics, err := single.DefaultMetricsProvider(nodeConfig.Instrumentation.IsPrometheusEnabled())(nodeConfig.ChainID)
+	singleMetrics, err := single.NewMetrics(nodeConfig.Instrumentation.IsPrometheusEnabled())()
 	if err != nil {
 		return err
 	}

--- a/apps/evm/single/cmd/run.go
+++ b/apps/evm/single/cmd/run.go
@@ -60,7 +60,7 @@ var RunCmd = &cobra.Command{
 			return err
 		}
 
-	singleMetrics, err := single.NewMetrics(nodeConfig.Instrumentation.IsPrometheusEnabled())()
+	singleMetrics, err := single.DefaultMetricsProvider(nodeConfig.Instrumentation.IsPrometheusEnabled())(nodeConfig.ChainID)
 	if err != nil {
 		return err
 	}

--- a/block/da_includer.go
+++ b/block/da_includer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+
+	coreda "github.com/rollkit/rollkit/core/da"
 )
 
 // DAIncluderLoop is responsible for advancing the DAIncludedHeight by checking if blocks after the current height
@@ -63,5 +65,13 @@ func (m *Manager) incrementDAIncludedHeight(ctx context.Context) error {
 	if !m.daIncludedHeight.CompareAndSwap(currentHeight, newHeight) {
 		return fmt.Errorf("failed to set DA included height: %d", newHeight)
 	}
+
+	// Update sequencer metrics if the sequencer supports it
+	if seq, ok := m.sequencer.(interface {
+		RecordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64)
+	}); ok {
+		seq.RecordMetrics(m.gasPrice, 0, coreda.StatusSuccess, m.pendingHeaders.numPendingHeaders(), newHeight)
+	}
+
 	return nil
 }

--- a/block/da_includer.go
+++ b/block/da_includer.go
@@ -67,9 +67,7 @@ func (m *Manager) incrementDAIncludedHeight(ctx context.Context) error {
 	}
 
 	// Update sequencer metrics if the sequencer supports it
-	if seq, ok := m.sequencer.(interface {
-		RecordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64)
-	}); ok {
+	if seq, ok := m.sequencer.(MetricsRecorder); ok {
 		seq.RecordMetrics(m.gasPrice, 0, coreda.StatusSuccess, m.pendingHeaders.numPendingHeaders(), newHeight)
 	}
 

--- a/block/da_includer_test.go
+++ b/block/da_includer_test.go
@@ -419,7 +419,7 @@ func TestIncrementDAIncludedHeight_WithMetricsRecorder(t *testing.T) {
 	binary.LittleEndian.PutUint64(lastSubmittedBytes, startDAIncludedHeight)
 
 	store.On("GetMetadata", mock.Anything, LastSubmittedHeightKey).Return(lastSubmittedBytes, nil).Maybe() // For pendingHeaders init
-	store.On("Height", mock.Anything).Return(uint64(7), nil).Maybe() // 7 - 4 = 3 pending headers
+	store.On("Height", mock.Anything).Return(uint64(7), nil).Maybe()                                       // 7 - 4 = 3 pending headers
 
 	// Initialize pendingHeaders properly
 	pendingHeaders, err := NewPendingHeaders(store, logger)
@@ -433,11 +433,11 @@ func TestIncrementDAIncludedHeight_WithMetricsRecorder(t *testing.T) {
 
 	// Expect RecordMetrics to be called with the correct parameters
 	mockSequencer.On("RecordMetrics",
-		float64(1.5),                    // gasPrice
-		uint64(0),                       // blobSize
-		coreda.StatusSuccess,            // statusCode
-		uint64(3),                       // numPendingBlocks (7 - 4 = 3)
-		expectedDAIncludedHeight,        // includedBlockHeight
+		float64(1.5),             // gasPrice
+		uint64(0),                // blobSize
+		coreda.StatusSuccess,     // statusCode
+		uint64(3),                // numPendingBlocks (7 - 4 = 3)
+		expectedDAIncludedHeight, // includedBlockHeight
 	).Once()
 
 	err = m.incrementDAIncludedHeight(context.Background())

--- a/block/manager.go
+++ b/block/manager.go
@@ -69,6 +69,13 @@ var (
 // This allows for overriding the behavior in tests.
 type publishBlockFunc func(ctx context.Context) error
 
+// MetricsRecorder defines the interface for sequencers that support recording metrics.
+// This interface is used to avoid duplication of the anonymous interface definition
+// across multiple files in the block package.
+type MetricsRecorder interface {
+	RecordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64)
+}
+
 func defaultSignaturePayloadProvider(header *types.Header) ([]byte, error) {
 	return header.MarshalBinary()
 }

--- a/block/submitter.go
+++ b/block/submitter.go
@@ -109,7 +109,7 @@ func (m *Manager) submitHeadersToDA(ctx context.Context) error {
 
 			// Update sequencer metrics if the sequencer supports it
 			if seq, ok := m.sequencer.(MetricsRecorder); ok {
-				seq.RecordMetrics(gasPrice, uint64(res.BlobSize), res.Code, m.pendingHeaders.numPendingHeaders(), lastSubmittedHeight)
+				seq.RecordMetrics(gasPrice, res.BlobSize, res.Code, m.pendingHeaders.numPendingHeaders(), lastSubmittedHeight)
 			}
 		case coreda.StatusNotIncludedInBlock, coreda.StatusAlreadyInMempool:
 			m.logger.Error("DA layer submission failed", "error", res.Message, "attempt", attempt)
@@ -265,7 +265,7 @@ func (m *Manager) submitDataToDA(ctx context.Context, signedData *types.SignedDa
 			// Update sequencer metrics if the sequencer supports it
 			if seq, ok := m.sequencer.(MetricsRecorder); ok {
 				daIncludedHeight := m.GetDAIncludedHeight()
-				seq.RecordMetrics(gasPrice, uint64(res.BlobSize), res.Code, m.pendingHeaders.numPendingHeaders(), daIncludedHeight)
+				seq.RecordMetrics(gasPrice, res.BlobSize, res.Code, m.pendingHeaders.numPendingHeaders(), daIncludedHeight)
 			}
 
 			return nil

--- a/block/submitter.go
+++ b/block/submitter.go
@@ -108,9 +108,7 @@ func (m *Manager) submitHeadersToDA(ctx context.Context) error {
 			m.logger.Debug("resetting DA layer submission options", "backoff", backoff, "gasPrice", gasPrice)
 
 			// Update sequencer metrics if the sequencer supports it
-			if seq, ok := m.sequencer.(interface {
-				RecordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64)
-			}); ok {
+			if seq, ok := m.sequencer.(MetricsRecorder); ok {
 				seq.RecordMetrics(gasPrice, uint64(res.BlobSize), res.Code, m.pendingHeaders.numPendingHeaders(), lastSubmittedHeight)
 			}
 		case coreda.StatusNotIncludedInBlock, coreda.StatusAlreadyInMempool:
@@ -265,9 +263,7 @@ func (m *Manager) submitDataToDA(ctx context.Context, signedData *types.SignedDa
 			m.sendNonBlockingSignalToDAIncluderCh()
 
 			// Update sequencer metrics if the sequencer supports it
-			if seq, ok := m.sequencer.(interface {
-				RecordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64)
-			}); ok {
+			if seq, ok := m.sequencer.(MetricsRecorder); ok {
 				daIncludedHeight := m.GetDAIncludedHeight()
 				seq.RecordMetrics(gasPrice, uint64(res.BlobSize), res.Code, m.pendingHeaders.numPendingHeaders(), daIncludedHeight)
 			}

--- a/sequencers/single/sequencer.go
+++ b/sequencers/single/sequencer.go
@@ -122,7 +122,9 @@ func (c *Sequencer) GetNextBatch(ctx context.Context, req coresequencer.GetNextB
 	}, nil
 }
 
-func (c *Sequencer) recordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks int, includedBlockHeight uint64) {
+// RecordMetrics updates the metrics with the given values.
+// This method is intended to be called by the block manager after submitting data to the DA layer.
+func (c *Sequencer) RecordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64) {
 	if c.metrics != nil {
 		c.metrics.GasPrice.Set(gasPrice)
 		c.metrics.LastBlobSize.Set(float64(blobSize))
@@ -130,6 +132,11 @@ func (c *Sequencer) recordMetrics(gasPrice float64, blobSize uint64, statusCode 
 		c.metrics.NumPendingBlocks.Set(float64(numPendingBlocks))
 		c.metrics.IncludedBlockHeight.Set(float64(includedBlockHeight))
 	}
+}
+
+// recordMetrics is a private method that updates the metrics with the given values.
+func (c *Sequencer) recordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64) {
+	c.RecordMetrics(gasPrice, blobSize, statusCode, numPendingBlocks, includedBlockHeight)
 }
 
 func (c *Sequencer) exponentialBackoff(backoff time.Duration) time.Duration {

--- a/sequencers/single/sequencer.go
+++ b/sequencers/single/sequencer.go
@@ -134,11 +134,6 @@ func (c *Sequencer) RecordMetrics(gasPrice float64, blobSize uint64, statusCode 
 	}
 }
 
-// recordMetrics is a private method that updates the metrics with the given values.
-func (c *Sequencer) recordMetrics(gasPrice float64, blobSize uint64, statusCode coreda.StatusCode, numPendingBlocks uint64, includedBlockHeight uint64) {
-	c.RecordMetrics(gasPrice, blobSize, statusCode, numPendingBlocks, includedBlockHeight)
-}
-
 func (c *Sequencer) exponentialBackoff(backoff time.Duration) time.Duration {
 	backoff *= 2
 	if backoff == 0 {

--- a/sequencers/single/sequencer_test.go
+++ b/sequencers/single/sequencer_test.go
@@ -513,27 +513,4 @@ func TestSequencer_RecordMetrics(t *testing.T) {
 		}
 	})
 
-	t.Run("Private recordMetrics Method", func(t *testing.T) {
-		// Create a sequencer with metrics
-		metrics, err := NopMetrics()
-		require.NoError(t, err)
-
-		seq := &Sequencer{
-			logger:  log.NewNopLogger(),
-			metrics: metrics,
-		}
-
-		// Test values
-		gasPrice := 3.0
-		blobSize := uint64(4096)
-		statusCode := coreda.StatusTooBig
-		numPendingBlocks := uint64(7)
-		includedBlockHeight := uint64(300)
-
-		// Call the private recordMetrics method - should not panic or error
-		seq.recordMetrics(gasPrice, blobSize, statusCode, numPendingBlocks, includedBlockHeight)
-
-		// Verify the method completes successfully
-		assert.NotNil(t, seq.metrics)
-	})
 }


### PR DESCRIPTION
## Overview

Sequencer specific metrics (GasPrice, LastBlobSize, TransactionStatus, TransactionStatus, IncludedBlockHeight) were not displayed on the prometheus metrics endpoint.
Only rollkit_sequencer_* (block_size, height, latest_block_height,num_txs,total_txs) were displayed.

This PR update the evm-single run command to include missing metrics.

```bash
curl -s localhost:26660/metrics | grep -i pending
# HELP sequencer_num_pending_blocks The number of pending blocks for DA submission.
# TYPE sequencer_num_pending_blocks gauge
sequencer_num_pending_blocks{chain_id="rollkit-test"} 7
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced metrics reporting for sequencer operations, including updates after data availability submissions and block height changes.
  - Introduced a public method for recording sequencer metrics, providing more detailed tracking of gas price, blob size, transaction status, pending blocks, and block heights.
  - Added a standardized interface to unify metrics recording across components.
- **Tests**
  - Added comprehensive tests to verify metrics recording during data availability submissions and block height increments.
  - Introduced mocks and test coverage to ensure metrics integration behaves correctly under various scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->