### PR TITLE
ci: docker e2e test default to local build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,6 +81,7 @@ jobs:
       - name: Run Docker E2E Tests
         run: make test-docker-e2e
         env:
+          ROLLKIT_IMAGE_REPO: ghcr.io/${{ github.repository }}
           ROLLKIT_IMAGE_TAG: ${{ inputs.image-tag }}
 
   build_all-apps:

--- a/scripts/build.mk
+++ b/scripts/build.mk
@@ -66,8 +66,17 @@ build-da:
         @echo "    Check the binary with: $(CURDIR)/build/local-da"
 .PHONY: build-da
 
+## docker-build: Build Docker image for local testing
+docker-build:
+	@echo "--> Building Docker image for local testing"
+	@docker build -t rollkit:local-dev .
+	@echo "--> Docker image built: rollkit:local-dev"
+	@echo "--> Checking if image exists locally..."
+	@docker images rollkit:local-dev
+.PHONY: docker-build
+
 ## clean: clean and build
-clean: 
+clean:
 	@echo "--> Cleaning Testapp CLI"
 	@rm -rf $(CURDIR)/build/
 	@echo "--> Testapp CLI Cleaned!"

--- a/scripts/test.mk
+++ b/scripts/test.mk
@@ -68,8 +68,8 @@ docker-build-if-local:
 ## docker-cleanup-if-local: Clean up local Docker image if using local repository
 docker-cleanup-if-local:
 	@if [ -z "$(ROLLKIT_IMAGE_REPO)" ] || [ "$(ROLLKIT_IMAGE_REPO)" = "rollkit" ]; then \
-		echo "--> Cleaning up local Docker image..."; \
-		docker rmi rollkit:local-dev 2>/dev/null || echo "Image rollkit:local-dev not found or already removed"; \
+		echo "--> Untagging local Docker image (preserving layers for faster rebuilds)..."; \
+		docker rmi rollkit:local-dev --no-prune 2>/dev/null || echo "Image rollkit:local-dev not found or already removed"; \
 	else \
 		echo "--> Using remote repository, no cleanup needed"; \
 	fi

--- a/scripts/test.mk
+++ b/scripts/test.mk
@@ -48,7 +48,10 @@ test-evm:
 test-docker-e2e: docker-build-if-local
 	@echo "--> Running Docker E2E tests"
 	@echo "--> Verifying Docker image exists locally..."
-	@docker images rollkit:local-dev | grep rollkit || (echo "ERROR: rollkit:local-dev image not found. Run 'make docker-build' first." && exit 1)
+	@if [ -z "$(ROLLKIT_IMAGE_REPO)" ] || [ "$(ROLLKIT_IMAGE_REPO)" = "rollkit" ]; then \
+		echo "--> Verifying Docker image exists locally..."; \
+		docker image inspect rollkit:local-dev >/dev/null 2>&1 || (echo "ERROR: rollkit:local-dev image not found. Run 'make docker-build' first." && exit 1); \
+	fi
 	@cd test/docker-e2e && go test -mod=readonly -failfast -timeout=30m ./...
 	@$(MAKE) docker-cleanup-if-local
 

--- a/test/docker-e2e/docker_test.go
+++ b/test/docker-e2e/docker_test.go
@@ -229,15 +229,16 @@ func (s *DockerTestSuite) StartRollkitNode(ctx context.Context, bridgeNode tasto
 
 // getRollkitImage returns the Docker image configuration for Rollkit
 // Uses ROLLKIT_IMAGE_REPO and ROLLKIT_IMAGE_TAG environment variables if set
+// Defaults to locally built image using a unique tag to avoid registry conflicts
 func getRollkitImage() tastoradocker.DockerImage {
 	repo := strings.TrimSpace(os.Getenv("ROLLKIT_IMAGE_REPO"))
 	if repo == "" {
-		repo = "ghcr.io/rollkit/rollkit"
+		repo = "rollkit"
 	}
 
 	tag := strings.TrimSpace(os.Getenv("ROLLKIT_IMAGE_TAG"))
 	if tag == "" {
-		tag = "latest"
+		tag = "local-dev"
 	}
 
 	return tastoradocker.DockerImage{


### PR DESCRIPTION
# Pull Request: Use Local Docker Build for E2E Tests by Default

## Summary

This PR modifies the Docker E2E testing framework to use locally built Docker images by default instead of attempting to pull from `ghcr.io/rollkit/rollkit`. This resolves issues where developers encounter "pull access denied" errors when running Docker E2E tests locally.

## Benefits

1. __Developer Experience__: Eliminates "pull access denied" errors for local development
2. __Self-Contained Testing__: Tests use the current codebase instead of potentially outdated registry images
3. __Automatic Cleanup__: Prevents accumulation of test images in the local Docker environment
4. __CI/CD Compatibility__: Maintains ability to override image repository and tag for production environments

## Usage

### Local Development (Default)

```bash
make test-docker-e2e
```

This will automatically:

- Build the Docker image as `rollkit:local-dev`
- Run the Docker E2E tests
- Clean up the image after tests complete

### CI/CD (Override)

```bash
ROLLKIT_IMAGE_REPO=ghcr.io/rollkit/rollkit ROLLKIT_IMAGE_TAG=v1.0.0 make test-docker-e2e
```

## Testing

- Verified that `make test-docker-e2e` builds the image locally and runs tests successfully
- Confirmed that environment variable overrides still work for CI/CD scenarios
- Tested cleanup functionality to ensure images are properly removed after tests

## Breaking Changes

None. This change only affects the default behavior for local development. All existing CI/CD configurations using environment variables will continue to work unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Makefile target to build a local Docker image for development and testing.
  - Introduced a composite test target to run both unit and Docker-based end-to-end tests with a single command.

- **Improvements**
  - Enhanced Docker-based end-to-end test workflow to use a locally built image by default and clean up after tests.
  - Updated environment variable handling in test workflows for better local development support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->