### PR TITLE
test: Add sequencer restart/recovery test and revert ExecuteTxs to use previous block hash

### DIFF
--- a/execution/evm/execution.go
+++ b/execution/evm/execution.go
@@ -181,16 +181,16 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 		txsPayload[i] = "0x" + hex.EncodeToString(tx)
 	}
 
-	_, _, prevGasLimit, _, err := c.getBlockInfo(ctx, blockHeight-1)
+	prevBlockHash, _, prevGasLimit, _, err := c.getBlockInfo(ctx, blockHeight-1)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get block info: %w", err)
 	}
 
 	c.mu.Lock()
 	args := engine.ForkchoiceStateV1{
-		HeadBlockHash:      c.currentHeadBlockHash,
-		SafeBlockHash:      c.currentSafeBlockHash,
-		FinalizedBlockHash: c.currentFinalizedBlockHash,
+		HeadBlockHash:      prevBlockHash,
+		SafeBlockHash:      prevBlockHash,
+		FinalizedBlockHash: prevBlockHash,
 	}
 	c.mu.Unlock()
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Add sequencer restart/recovery E2E test which is test 2 in https://github.com/rollkit/rollkit/issues/2351 and revert ExecuteTxs to use previous block hash

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
