### PR TITLE
chore: lumen entrypoint in docker compose bis

### DIFF
--- a/execution/evm/docker/docker-compose-full-node.yml
+++ b/execution/evm/docker/docker-compose-full-node.yml
@@ -35,54 +35,31 @@ services:
       - ./chain:/root/chain:ro
       - ./jwttoken:/root/jwt:ro
       - logs-full-node:/root/logs
+    entrypoint: /bin/sh -c
     command:
-      - node
-      - --chain
-      - /root/chain/genesis.json
-      - --metrics
-      - 0.0.0.0:9001
-      - --log.file.directory
-      - /root/logs
-      - --authrpc.addr
-      - 0.0.0.0
-      - --authrpc.port
-      - "8551"
-      - --authrpc.jwtsecret
-      - /root/jwt/jwt.hex
-      - --http
-      - --http.addr
-      - 0.0.0.0
-      - --http.port
-      - "8545"
-      - --http.api
-      - eth,net,web3,txpool
-      - --ws
-      - --ws.addr
-      - 0.0.0.0
-      - --ws.port
-      - "8546"
-      - --ws.api
-      - eth,net,web3
-      - --engine.persistence-threshold
-      - "0"
-      - --engine.memory-block-buffer-target
-      - "0"
-      - --disable-discovery
-      - --txpool.pending-max-count
-      - "200000"
-      - --txpool.pending-max-size
-      - "200"
-      - --txpool.queued-max-count
-      - "200000"
-      - --txpool.queued-max-size
-      - "200"
-      - --txpool.max-account-slots
-      - "2048"
-      - --txpool.max-new-txns
-      - "2048"
-      - --txpool.additional-validation-tasks
-      - "16"
-      - --rollkit.enable
+      - |
+          lumen node \
+            --chain /root/chain/genesis.json \
+            --metrics 0.0.0.0:9001 \
+            --log.file.directory /root/logs \
+            --authrpc.addr 0.0.0.0 \
+            --authrpc.port 8551 \
+            --authrpc.jwtsecret /root/jwt/jwt.hex \
+            --http --http.addr 0.0.0.0 --http.port 8545 \
+            --http.api eth,net,web3,txpool \
+            --ws --ws.addr 0.0.0.0 --ws.port 8546 \
+            --ws.api eth,net,web3 \
+            --engine.persistence-threshold 0 \
+            --engine.memory-block-buffer-target 0 \
+            --disable-discovery \
+            --txpool.pending-max-count 200000 \
+            --txpool.pending-max-size 200 \
+            --txpool.queued-max-count 200000 \
+            --txpool.queued-max-size 200 \
+            --txpool.max-account-slots 2048 \
+            --txpool.max-new-txns 2048 \
+            --txpool.additional-validation-tasks 16 \
+            --rollkit.enable
 
 volumes:
   logs-full-node:

--- a/execution/evm/docker/docker-compose.yml
+++ b/execution/evm/docker/docker-compose.yml
@@ -38,54 +38,31 @@ services:
     # environment:
       # - RUST_LOG=info,lumen=debug,lumen_node=debug,lumen_rollkit=debug
       # - RUST_BACKTRACE=1
+    entrypoint: /bin/sh -c
     command:
-      - node
-      - --chain
-      - /root/chain/genesis.json
-      - --metrics
-      - 0.0.0.0:9001
-      - --log.file.directory
-      - /root/logs
-      - --authrpc.addr
-      - 0.0.0.0
-      - --authrpc.port
-      - "8551"
-      - --authrpc.jwtsecret
-      - /root/jwt/jwt.hex
-      - --http
-      - --http.addr
-      - 0.0.0.0
-      - --http.port
-      - "8545"
-      - --http.api
-      - eth,net,web3,txpool
-      - --ws
-      - --ws.addr
-      - 0.0.0.0
-      - --ws.port
-      - "8546"
-      - --ws.api
-      - eth,net,web3
-      - --engine.persistence-threshold
-      - "0"
-      - --engine.memory-block-buffer-target
-      - "0"
-      - --disable-discovery
-      - --txpool.pending-max-count
-      - "200000"
-      - --txpool.pending-max-size
-      - "200"
-      - --txpool.queued-max-count
-      - "200000"
-      - --txpool.queued-max-size
-      - "200"
-      - --txpool.max-account-slots
-      - "2048"
-      - --txpool.max-new-txns
-      - "2048"
-      - --txpool.additional-validation-tasks
-      - "16"
-      - --rollkit.enable
+      - |
+          lumen node \
+            --chain /root/chain/genesis.json \
+            --metrics 0.0.0.0:9001 \
+            --log.file.directory /root/logs \
+            --authrpc.addr 0.0.0.0 \
+            --authrpc.port 8551 \
+            --authrpc.jwtsecret /root/jwt/jwt.hex \
+            --http --http.addr 0.0.0.0 --http.port 8545 \
+            --http.api eth,net,web3,txpool \
+            --ws --ws.addr 0.0.0.0 --ws.port 8546 \
+            --ws.api eth,net,web3 \
+            --engine.persistence-threshold 0 \
+            --engine.memory-block-buffer-target 0 \
+            --disable-discovery \
+            --txpool.pending-max-count 200000 \
+            --txpool.pending-max-size 200 \
+            --txpool.queued-max-count 200000 \
+            --txpool.queued-max-size 200 \
+            --txpool.max-account-slots 2048 \
+            --txpool.max-new-txns 2048 \
+            --txpool.additional-validation-tasks 16 \
+            --rollkit.enable
 
 volumes:
   logs:


### PR DESCRIPTION
## Overview

Better readability and maintainability for lumen command thanks to supporting standard unix binaries on the lumen container image cf https://github.com/rollkit/lumen/commit/bbca148bba3c57682754a115f2b8481c6ddc1800 

Same as https://github.com/rollkit/rollkit/pull/2398 but on missed docker compose files in `execution/evm/docker`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Docker Compose service configurations to improve command execution formatting. No changes to service parameters or functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->