### PR TITLE
fix: getPeers size check

### DIFF
--- a/pkg/sync/sync_service.go
+++ b/pkg/sync/sync_service.go
@@ -382,10 +382,11 @@ func (syncService *SyncService[H]) getPeerIDs() []peer.ID {
 
 func getPeers(seeds string, logger log.Logger) []peer.ID {
 	var peerIDs []peer.ID
-	sl := strings.Split(seeds, ",")
-	if len(sl) == 0 {
+	if seeds == "" {
 		return peerIDs
 	}
+	sl := strings.Split(seeds, ",")
+
 	for _, seed := range sl {
 		maddr, err := multiaddr.NewMultiaddr(seed)
 		if err != nil {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
While trying to fix the testapp tutorial from the docs I stumbled upon that issue. 
By checking `[len(seeds) == 0]` before splitting, you avoid the common pitfall where [`strings.Split("", ",")]` returns a slice of length 1 containing an empty string `[""]`. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty input when processing peer seeds, ensuring more efficient and accurate results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->