### PR TITLE
Fix Typo in Executor Interface Documentation

### DIFF
--- a/core/execution/execution.go
+++ b/core/execution/execution.go
@@ -25,7 +25,7 @@ type Executor interface {
 	//
 	// Returns:
 	// - stateRoot: Hash representing initial state
-	// - maxBytes: Maximum allowed bytes for transacitons in a block
+	// - maxBytes: Maximum allowed bytes for transactions in a block
 	// - err: Any initialization errors
 	InitChain(ctx context.Context, genesisTime time.Time, initialHeight uint64, chainID string) (stateRoot []byte, maxBytes uint64, err error)
 


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a minor typo in the documentation comment for the Executor interface in `core/execution/execution.go`.  
- Changed "transacitons" to "transactions" for improved clarity and accuracy.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected a typo in a comment to improve clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->