### PR TITLE
fix: evm single docker compose startup

### DIFF
--- a/apps/evm/single/docker-compose.yml
+++ b/apps/evm/single/docker-compose.yml
@@ -61,6 +61,7 @@ services:
     volumes:
       - evm-single-data:/root/.evm-single/
     entrypoint: /usr/bin/entrypoint.sh
+    command: start
     environment:
       - EVM_ENGINE_URL=http://rollkit-reth:8551
       - EVM_ETH_URL=http://rollkit-reth:8545

--- a/apps/evm/single/entrypoint.sh
+++ b/apps/evm/single/entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+sleep 5
+
 # Function to extract --home value from arguments
 get_home_dir() {
   home_dir="$HOME/.evm-single"


### PR DESCRIPTION
rollkit container was crashing because of wrong startup orchestration. This PR fixes it.