### PR TITLE
fix!(evm): add max txs bytes to get txs

### DIFF
--- a/.github/workflows/check_consts_drift.yml
+++ b/.github/workflows/check_consts_drift.yml
@@ -27,64 +27,73 @@ jobs:
       - name: Compare Files
         id: diff_files
         run: |
-          LOCAL_FILE="da/jsonrpc/internal/consts.go" # Relative path from repo root
+          LOCAL_FILES=("da/jsonrpc/internal/consts.go" "execution/evm/internal/consts.go") # Relative paths from repo root
           CELESTIA_FILE="${{ steps.fetch_celestia_consts.outputs.celestia_file_path }}"
 
-          if [ ! -f "$LOCAL_FILE" ]; then
-            echo "Local consts.go file not found at $LOCAL_FILE"
-            exit 1
-          fi
           if [ ! -f "$CELESTIA_FILE" ]; then
             echo "Fetched Celestia consts file not found at $CELESTIA_FILE"
             # This should ideally be caught by the previous step's check
             exit 1
           fi
 
-          echo "Comparing $LOCAL_FILE (excluding last line) with $CELESTIA_FILE (excluding last line)"
+          any_diff_found=false
+          all_diff_outputs=""
 
-          LOCAL_FILE_TMP=$(mktemp)
-          CELESTIA_FILE_TMP=$(mktemp)
-          # Ensure temporary files are removed on exit
-          trap 'rm -f "$LOCAL_FILE_TMP" "$CELESTIA_FILE_TMP"' EXIT
-
-          head -n -1 "$LOCAL_FILE" > "$LOCAL_FILE_TMP"
-          if [ $? -ne 0 ]; then
-            echo "Error processing local file '$LOCAL_FILE' with head."
-            exit 1
-          fi
-          head -n -1 "$CELESTIA_FILE" > "$CELESTIA_FILE_TMP"
-          if [ $? -ne 0 ]; then
-            echo "Error processing fetched Celestia file '$CELESTIA_FILE' with head."
-            exit 1
-          fi
-
-          # Perform the diff and handle its exit code robustly
-          diff_command_output=""
-          if ! diff_command_output=$(diff -u "$LOCAL_FILE_TMP" "$CELESTIA_FILE_TMP"); then
-            # diff exited with non-zero status
-            diff_exit_code=$?
-            if [ $diff_exit_code -eq 1 ]; then
-              # Exit code 1 means files are different
-              echo "Files are different (excluding last line)."
-              echo "diff_output<<EOF" >> $GITHUB_OUTPUT
-              echo "$diff_command_output" >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
-              echo "files_differ=true" >> $GITHUB_OUTPUT
-              exit 1 # Fail the step
-            else
-              # Exit code > 1 means diff encountered an error
-              echo "Error: diff command failed with exit code $diff_exit_code."
-              echo "Diff command output/error: $diff_command_output"
-              # Output error information for the issue
-              echo "diff_output<<EOF" >> $GITHUB_OUTPUT
-              echo "Diff command error (exit code $diff_exit_code):" >> $GITHUB_OUTPUT
-              echo "$diff_command_output" >> $GITHUB_OUTPUT
-              echo "EOF" >> $GITHUB_OUTPUT
-              echo "files_differ=true" >> $GITHUB_OUTPUT # Treat as a difference to create an issue
-              exit $diff_exit_code
+          for LOCAL_FILE in "${LOCAL_FILES[@]}"; do
+            if [ ! -f "$LOCAL_FILE" ]; then
+              echo "Local consts.go file not found at $LOCAL_FILE"
+              exit 1
             fi
+
+            echo "Comparing first 34 lines of $LOCAL_FILE with first 34 lines of $CELESTIA_FILE"
+
+            LOCAL_FILE_TMP=$(mktemp)
+            CELESTIA_FILE_TMP=$(mktemp)
+            # Ensure temporary files are removed on exit
+            trap 'rm -f "$LOCAL_FILE_TMP" "$CELESTIA_FILE_TMP"' EXIT
+
+            head -n 34 "$LOCAL_FILE" > "$LOCAL_FILE_TMP"
+            if [ $? -ne 0 ]; then
+              echo "Error processing local file '$LOCAL_FILE' with head."
+              exit 1
+            fi
+            head -n 34 "$CELESTIA_FILE" > "$CELESTIA_FILE_TMP"
+            if [ $? -ne 0 ]; then
+              echo "Error processing fetched Celestia file '$CELESTIA_FILE' with head."
+              exit 1
+            fi
+
+            # Perform the diff and handle its exit code robustly
+            diff_command_output=""
+            if ! diff_command_output=$(diff -u "$LOCAL_FILE_TMP" "$CELESTIA_FILE_TMP"); then
+              # diff exited with non-zero status
+              diff_exit_code=$?
+              if [ $diff_exit_code -eq 1 ]; then
+                # Exit code 1 means files are different
+                echo "Files are different for $LOCAL_FILE (first 34 lines)."
+                all_diff_outputs+="Diff for $LOCAL_FILE:"$'\n'"$diff_command_output"$'\n\n'
+                any_diff_found=true
+              else
+                # Exit code > 1 means diff encountered an error
+                echo "Error: diff command failed with exit code $diff_exit_code for $LOCAL_FILE."
+                echo "Diff command output/error: $diff_command_output"
+                all_diff_outputs+="Diff command error for $LOCAL_FILE (exit code $diff_exit_code):"$'\n'"$diff_command_output"$'\n\n'
+                any_diff_found=true
+              fi
+            else
+              # diff exited with 0, files are identical
+              echo "Files are identical for $LOCAL_FILE (first 34 lines)."
+            fi
+
+            rm -f "$LOCAL_FILE_TMP" "$CELESTIA_FILE_TMP"
+          done
+
+          if [ "$any_diff_found" = true ]; then
+            echo "diff_output<<EOF" >> $GITHUB_OUTPUT
+            echo "$all_diff_outputs" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            echo "files_differ=true" >> $GITHUB_OUTPUT
+            exit 1 # Fail the step
           else
-            # diff exited with 0, files are identical
-            echo "Files are identical (excluding last line)."
             echo "files_differ=false" >> $GITHUB_OUTPUT
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 <!-- New features or capabilities -->
--
+- Added transaction size limit check in EVM execution layer to prevent exceeding max block bytes ([#2456](https://github.com/rollkit/rollkit/pull/2456))
 
 ### Changed
 

--- a/apps/evm/based/go.mod
+++ b/apps/evm/based/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/buger/goterm v1.0.4 // indirect
 	github.com/celestiaorg/go-header v0.6.6 // indirect
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2 // indirect
-	github.com/celestiaorg/go-square/v2 v2.2.0 // indirect
+	github.com/celestiaorg/go-square/v2 v2.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/compose-spec/compose-go/v2 v2.6.0 // indirect

--- a/apps/evm/based/go.sum
+++ b/apps/evm/based/go.sum
@@ -107,8 +107,8 @@ github.com/celestiaorg/go-header v0.6.6 h1:17GvSXU/w8L1YWHZP4pYm9/4YHA8iy5Ku2wTE
 github.com/celestiaorg/go-header v0.6.6/go.mod h1:RdnlTmsyuNerztNiJiQE5G/EGEH+cErhQ83xNjuGcaQ=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
-github.com/celestiaorg/go-square/v2 v2.2.0 h1:zJnUxCYc65S8FgUfVpyG/osDcsnjzo/JSXw/Uwn8zp4=
-github.com/celestiaorg/go-square/v2 v2.2.0/go.mod h1:j8kQUqJLYtcvCQMQV6QjEhUdaF7rBTXF74g8LbkR0Co=
+github.com/celestiaorg/go-square/v2 v2.3.0 h1:tVh6sZy1d2l5maVXUpc7eoTXdb3ptJVJt/U8z2XUWgQ=
+github.com/celestiaorg/go-square/v2 v2.3.0/go.mod h1:6M2txj0j6dkoE+cgwyG0EqrEPhbZpM2R1lsWEopMIBc=
 github.com/celestiaorg/utils v0.1.0 h1:WsP3O8jF7jKRgLNFmlDCwdThwOFMFxg0MnqhkLFVxPo=
 github.com/celestiaorg/utils v0.1.0/go.mod h1:vQTh7MHnvpIeCQZ2/Ph+w7K1R2UerDheZbgJEJD2hSU=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/apps/evm/single/go.mod
+++ b/apps/evm/single/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/buger/goterm v1.0.4 // indirect
 	github.com/celestiaorg/go-header v0.6.6 // indirect
 	github.com/celestiaorg/go-libp2p-messenger v0.2.2 // indirect
-	github.com/celestiaorg/go-square/v2 v2.2.0 // indirect
+	github.com/celestiaorg/go-square/v2 v2.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/compose-spec/compose-go/v2 v2.6.0 // indirect

--- a/apps/evm/single/go.sum
+++ b/apps/evm/single/go.sum
@@ -107,8 +107,8 @@ github.com/celestiaorg/go-header v0.6.6 h1:17GvSXU/w8L1YWHZP4pYm9/4YHA8iy5Ku2wTE
 github.com/celestiaorg/go-header v0.6.6/go.mod h1:RdnlTmsyuNerztNiJiQE5G/EGEH+cErhQ83xNjuGcaQ=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2 h1:osoUfqjss7vWTIZrrDSy953RjQz+ps/vBFE7bychLEc=
 github.com/celestiaorg/go-libp2p-messenger v0.2.2/go.mod h1:oTCRV5TfdO7V/k6nkx7QjQzGrWuJbupv+0o1cgnY2i4=
-github.com/celestiaorg/go-square/v2 v2.2.0 h1:zJnUxCYc65S8FgUfVpyG/osDcsnjzo/JSXw/Uwn8zp4=
-github.com/celestiaorg/go-square/v2 v2.2.0/go.mod h1:j8kQUqJLYtcvCQMQV6QjEhUdaF7rBTXF74g8LbkR0Co=
+github.com/celestiaorg/go-square/v2 v2.3.0 h1:tVh6sZy1d2l5maVXUpc7eoTXdb3ptJVJt/U8z2XUWgQ=
+github.com/celestiaorg/go-square/v2 v2.3.0/go.mod h1:6M2txj0j6dkoE+cgwyG0EqrEPhbZpM2R1lsWEopMIBc=
 github.com/celestiaorg/utils v0.1.0 h1:WsP3O8jF7jKRgLNFmlDCwdThwOFMFxg0MnqhkLFVxPo=
 github.com/celestiaorg/utils v0.1.0/go.mod h1:vQTh7MHnvpIeCQZ2/Ph+w7K1R2UerDheZbgJEJD2hSU=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=

--- a/execution/evm/go.mod
+++ b/execution/evm/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.1
 
 require (
+	github.com/celestiaorg/go-square/v2 v2.3.0
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/golang-jwt/jwt/v5 v5.2.2
 	github.com/rollkit/rollkit/core v0.0.0-20250312114929-104787ba1a4c
@@ -218,7 +219,7 @@ require (
 	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f // indirect
 	google.golang.org/grpc v1.71.0 // indirect
-	google.golang.org/protobuf v1.36.4 // indirect
+	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/execution/evm/go.sum
+++ b/execution/evm/go.sum
@@ -84,6 +84,8 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b h1:otBG+dV+YK+Soembj
 github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0BsqsP2LwDJ9aOkm/6J86V6lyAXCoQWGw3K50=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXer/kZD8Ri1aaunCxIEsOst1BVJswV0o=
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/celestiaorg/go-square/v2 v2.3.0 h1:tVh6sZy1d2l5maVXUpc7eoTXdb3ptJVJt/U8z2XUWgQ=
+github.com/celestiaorg/go-square/v2 v2.3.0/go.mod h1:6M2txj0j6dkoE+cgwyG0EqrEPhbZpM2R1lsWEopMIBc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -778,8 +780,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250115164207-1a7da9e5054f/go.
 google.golang.org/grpc v1.0.5/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.71.0 h1:kF77BGdPTQ4/JZWMlb9VpJ5pa25aqvVqogsxNHHdeBg=
 google.golang.org/grpc v1.71.0/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd/8Ec=
-google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
-google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/cenkalti/backoff.v1 v1.1.0 h1:Arh75ttbsvlpVA7WtVpH4u9h6Zl46xuptxqLxPiSo4Y=

--- a/execution/evm/internal/consts.go
+++ b/execution/evm/internal/consts.go
@@ -1,0 +1,34 @@
+package appconsts
+
+import (
+	"time"
+
+	"github.com/celestiaorg/go-square/v2/share"
+)
+
+// The following defaults correspond to initial parameters of the network that can be changed, not via app versions
+// but other means such as on-chain governance, or the node's local config
+const (
+	// DefaultGovMaxSquareSize is the default value for the governance modifiable
+	// max square size.
+	DefaultGovMaxSquareSize = 64
+
+	// DefaultMaxBytes is the default value for the governance modifiable
+	// maximum number of bytes allowed in a valid block.
+	DefaultMaxBytes = DefaultGovMaxSquareSize * DefaultGovMaxSquareSize * share.ContinuationSparseShareContentSize
+
+	// DefaultMinGasPrice is the default min gas price that gets set in the app.toml file.
+	// The min gas price acts as a filter. Transactions below that limit will not pass
+	// a node's `CheckTx` and thus not be proposed by that node.
+	DefaultMinGasPrice = 0.002 // utia
+
+	// DefaultUnbondingTime is the default time a validator must wait
+	// to unbond in a proof of stake system. Any validator within this
+	// time can be subject to slashing under conditions of misbehavior.
+	DefaultUnbondingTime = 3 * 7 * 24 * time.Hour
+
+	// DefaultNetworkMinGasPrice is used by x/minfee to prevent transactions from being
+	// included in a block if they specify a gas price lower than this.
+	// Only applies to app version >= 2
+	DefaultNetworkMinGasPrice = 0.000001 // utia
+)

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.17.0 // indirect
 	github.com/buger/goterm v1.0.4 // indirect
+	github.com/celestiaorg/go-square/v2 v2.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/compose-spec/compose-go/v2 v2.6.0 // indirect

--- a/test/e2e/go.sum
+++ b/test/e2e/go.sum
@@ -90,6 +90,8 @@ github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0 h1:nvj0OLI3YqYXe
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/celestiaorg/go-header v0.6.6 h1:17GvSXU/w8L1YWHZP4pYm9/4YHA8iy5Ku2wTEKYYkCU=
 github.com/celestiaorg/go-header v0.6.6/go.mod h1:RdnlTmsyuNerztNiJiQE5G/EGEH+cErhQ83xNjuGcaQ=
+github.com/celestiaorg/go-square/v2 v2.3.0 h1:tVh6sZy1d2l5maVXUpc7eoTXdb3ptJVJt/U8z2XUWgQ=
+github.com/celestiaorg/go-square/v2 v2.3.0/go.mod h1:6M2txj0j6dkoE+cgwyG0EqrEPhbZpM2R1lsWEopMIBc=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

This pr adds a transaction count check disallowing the system to attempt to create blobs that are greater than the max amount in celestia 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced default network parameter constants for block size, gas pricing, and validator unbonding time, providing baseline values for network operation and transaction validation.

* **Improvements**
  * Enforced a maximum byte-size limit when collecting pending transactions, ensuring returned transactions do not exceed a predefined size.
  * Enhanced workflow to compare multiple configuration files for consistency, with consolidated reporting of differences.

* **Dependency Updates**
  * Upgraded `github.com/celestiaorg/go-square/v2` to version `v2.3.0` across multiple modules.
  * Updated `google.golang.org/protobuf` to version `v1.36.6` in one module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->