### PR TITLE
Fix Typo in HTTP Port Comment

### DIFF
--- a/test/docker-e2e/base_test.go
+++ b/test/docker-e2e/base_test.go
@@ -50,7 +50,7 @@ func (s *DockerTestSuite) TestBasicDockerE2E() {
 	s.T().Run("submit a transaction to the rollkit chain", func(t *testing.T) {
 		rollkitNode := s.rollkitChain.GetNodes()[0]
 
-		// the http port resolvable by the test runner.
+// The http port resolvable by the test runner.
 		httpPort := rollkitNode.GetHostHTTPPort()
 
 		client, err := NewClient("localhost", httpPort)

--- a/test/docker-e2e/base_test.go
+++ b/test/docker-e2e/base_test.go
@@ -50,7 +50,7 @@ func (s *DockerTestSuite) TestBasicDockerE2E() {
 	s.T().Run("submit a transaction to the rollkit chain", func(t *testing.T) {
 		rollkitNode := s.rollkitChain.GetNodes()[0]
 
-		// the http port resolvable by teh test runner.
+		// the http port resolvable by the test runner.
 		httpPort := rollkitNode.GetHostHTTPPort()
 
 		client, err := NewClient("localhost", httpPort)


### PR DESCRIPTION


---


**Description:**  
This pull request corrects a minor typo in a comment within test/docker-e2e/base_test.go, changing "teh" to "the" for improved clarity and professionalism in the codebase. 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Corrected a typo in a comment to improve clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->