### PR TITLE
Remove redundant slashes from timestamp verification comment in execValidate

### DIFF
--- a/block/manager.go
+++ b/block/manager.go
@@ -808,7 +808,7 @@ func (m *Manager) execValidate(lastState types.State, header *types.SignedHeader
 		return fmt.Errorf("invalid height: expected %d, got %d", expectedHeight, header.Height())
 	}
 
-	// // Verify that the header's timestamp is strictly greater than the last block's time
+	// Verify that the header's timestamp is strictly greater than the last block's time
 	headerTime := header.Time()
 	if header.Height() > 1 && lastState.LastBlockTime.After(headerTime) {
 		return fmt.Errorf("block time must be strictly increasing: got %v, last block time was %v",


### PR DESCRIPTION
Cleaned up the comment above the timestamp verification logic in the execValidate function by removing an extra slash. This improves code readability and maintains consistent comment formatting throughout the file. No functional changes were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Cleaned up a comment by removing an extra commented-out slash for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->