### PR TITLE
docs: clarify no default for EvidenceParams.MaxBytes

### DIFF
--- a/specs/lazy-adr/adr-004-core-types.md
+++ b/specs/lazy-adr/adr-004-core-types.md
@@ -176,6 +176,7 @@ type EvidenceParams struct {
     // This sets the maximum size of total evidence in bytes that can be committed in a single block.
     // and should fall comfortably under the max block bytes.
     // Default is 1048576 or 1MB
+    // Rollkit does not set a default here; the actual value depends on the implementation or configuration.
     MaxBytes int64
 }
 


### PR DESCRIPTION
### Desciption

- This PR updates the comment for `EvidenceParams.MaxBytes` in `specs/lazy-adr/adr-004-core-types.md` to clarify that Rollkit does not set a default value for this parameter. The previous comment referenced the Tendermint/CometBFT default (1048576 or 1MB), which may be misleading since Rollkit does not implement or enforce this default in code.
- Ensure documentation accurately reflects the current state of the Rollkit codebase.
- Avoid misleading users about default parameter values that are not implemented.

### Checklist

- [x] Documentation updated
- [ ] No code changes required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified in the documentation that the default value for MaxBytes is not set by Rollkit and may vary based on implementation or configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->