### PR TITLE
chore: remove timestamp hack

### DIFF
--- a/execution/evm/execution.go
+++ b/execution/evm/execution.go
@@ -181,14 +181,9 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 		txsPayload[i] = "0x" + hex.EncodeToString(tx)
 	}
 
-	prevBlockHash, _, prevGasLimit, prevTimestamp, err := c.getBlockInfo(ctx, blockHeight-1)
+	prevBlockHash, _, prevGasLimit, _, err := c.getBlockInfo(ctx, blockHeight-1)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get block info: %w", err)
-	}
-
-	ts := uint64(timestamp.Unix())
-	if ts <= prevTimestamp {
-		ts = prevTimestamp + 1 // Subsequent blocks must have a higher timestamp.
 	}
 
 	args := engine.ForkchoiceStateV1{
@@ -203,7 +198,7 @@ func (c *EngineClient) ExecuteTxs(ctx context.Context, txs [][]byte, blockHeight
 	// Create rollkit-compatible payload attributes with flattened structure
 	rollkitPayloadAttrs := map[string]interface{}{
 		// Standard Ethereum payload attributes (flattened) - using camelCase as expected by JSON
-		"timestamp":             ts,
+		"timestamp":             timestamp.Unix(),
 		"prevRandao":            c.derivePrevRandao(blockHeight),
 		"suggestedFeeRecipient": c.feeRecipient,
 		"withdrawals":           []*types.Withdrawal{},


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

This pr removes the +1 timestamp in order to avoid clock drift between lumen and rollkit. 

closes #2464 

based off of work from https://github.com/rollkit/lumen/pull/19

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified block timestamp handling to use the current block's timestamp directly, removing previous logic that enforced strictly increasing timestamps between blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->