### PR TITLE
Fix ed25519 signature usage in getProof

### DIFF
--- a/da/cmd/local-da/local.go
+++ b/da/cmd/local-da/local.go
@@ -225,7 +225,7 @@ func (d *LocalDA) getHash(blob []byte) []byte {
 }
 
 func (d *LocalDA) getProof(id, blob []byte) []byte {
-	sign, _ := d.privKey.Sign(rand.Reader, d.getHash(blob), &ed25519.Options{})
+	sign := ed25519.Sign(d.privKey, d.getHash(blob))
 	return sign
 }
 


### PR DESCRIPTION
Corrected the implementation of the getProof function to use the standard ed25519.Sign method for generating signatures. The previous code incorrectly attempted to use a non-existent Sign method on ed25519.PrivateKey, which would not compile. This change ensures proper and secure signature generation according to the Go standard library.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of signature generation for proofs, ensuring more consistent and secure handling of digital signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->