### PR TITLE
chore: mutex -> RWmutex in sequencer 

### DIFF
--- a/sequencers/single/queue.go
+++ b/sequencers/single/queue.go
@@ -28,7 +28,7 @@ func newPrefixKV(kvStore ds.Batching, prefix string) ds.Batching {
 type BatchQueue struct {
 	queue        []coresequencer.Batch
 	maxQueueSize int // maximum number of batches allowed in queue (0 = unlimited)
-	mu           sync.Mutex
+	mu           sync.RWMutex
 	db           ds.Batching
 }
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

small change, to use a RW mutex to avoid blocking on reads. The other change here we can make is do something like a linkedlist in order to avoid mutex contention entirely with async writes. we havent observed an overhead in the single sequencer in benchmarking so there is a reason to do it now as it adds complexity 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
