### PR TITLE
chore(types): Fix invalid loop

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -300,7 +300,7 @@ func getBlockDataWith(nTxs int) *Data {
 		Txs: make(Txs, nTxs),
 	}
 
-	for i := range nTxs {
+	for i := 0; i < nTxs; i++ {
 		data.Txs[i] = GetRandomTx()
 	}
 


### PR DESCRIPTION
Replaces for i := range nTxs with an index-based loop for i := 0; i < nTxs; i++ (you can’t range over an int).