### PR TITLE
test: use b.Loop() to simplify the code and improve performance

### DIFF
--- a/block/internal/syncing/syncer_benchmark_test.go
+++ b/block/internal/syncing/syncer_benchmark_test.go
@@ -38,8 +38,7 @@ func BenchmarkSyncerIO(b *testing.B) {
 	}
 	for name, spec := range cases {
 		b.Run(name, func(b *testing.B) {
-			b.ResetTimer()
-			for i := 0; i < b.N; i++ {
+			for b.Loop() {
 				fixt := newBenchFixture(b, spec.heights, spec.shuffledTx, spec.daDelay, spec.execDelay, true)
 
 				// run both loops


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

B.Loop intentionally defeats compiler optimizations such as inlining so that the benchmark is not entirely optimized away. Currently, however, it may cause benchmarks to become slower in some cases due to increased allocation; see https://go.dev/issue/73137.

Before this change:

```shell
go test -run=^$ -bench=. ./block/internal/syncing -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/evstack/ev-node/block/internal/syncing
cpu: Apple M1
BenchmarkSyncerIO/slow_producer-10         	      37	  27149786 ns/op
BenchmarkSyncerIO/slow_consumer-10         	      42	  27843880 ns/op
PASS
ok  	github.com/evstack/ev-node/block/internal/syncing	3.339s
```

After:

```shell
go test -run=^$ -bench=. ./block/internal/syncing -timeout=1h
goos: darwin
goarch: arm64
pkg: github.com/evstack/ev-node/block/internal/syncing
cpu: Apple M1
BenchmarkSyncerIO/slow_producer-10         	      40	  27021698 ns/op
BenchmarkSyncerIO/slow_consumer-10         	      42	  28333081 ns/op
PASS
ok  	github.com/evstack/ev-node/block/internal/syncing	3.070s
```
