### PR TITLE
refactor(block): improve cancellation

### DIFF
--- a/block/internal/executing/executor.go
+++ b/block/internal/executing/executor.go
@@ -381,11 +381,13 @@ func (e *Executor) produceBlock() error {
 		return fmt.Errorf("failed to save block: %w", err)
 	}
 
-	if err := e.store.SetHeight(e.ctx, newHeight); err != nil {
+	// Once the SaveBlockData has been saved we must update the height and the state.
+	// context.TODO() should be reverted to the real context (e.ctx) once https://github.com/evstack/ev-node/issues/2274 has been implemented, this prevents context cancellation
+	if err := e.store.SetHeight(context.TODO(), newHeight); err != nil {
 		return fmt.Errorf("failed to update store height: %w", err)
 	}
 
-	if err := e.updateState(e.ctx, newState); err != nil {
+	if err := e.updateState(context.TODO(), newState); err != nil {
 		return fmt.Errorf("failed to update state: %w", err)
 	}
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

Once the SaveBlockData has been saved we must update the height and the state.
context.TODO() should be reverted to the real context (e.ctx) once https://github.com/evstack/ev-node/issues/2274 has been implemented, this prevents context cancellation messing up state.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
