### PR TITLE
refactor:  remove obsolete // +build tag

### DIFF
--- a/scripts/run-evm-nodes.go
+++ b/scripts/run-evm-nodes.go
@@ -1,5 +1,4 @@
 //go:build run_evm
-// +build run_evm
 
 package main
 

--- a/scripts/run.go
+++ b/scripts/run.go
@@ -1,5 +1,4 @@
 //go:build run
-// +build run
 
 package main
 

--- a/scripts/test_cover.go
+++ b/scripts/test_cover.go
@@ -1,5 +1,4 @@
 //go:build cover
-// +build cover
 
 package main
 

--- a/scripts/tidy.go
+++ b/scripts/tidy.go
@@ -1,5 +1,4 @@
 //go:build tidy
-// +build tidy
 
 package main
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

From Go 1.17, the preferred syntax for build constraints is `//go:build`,
which replaces the old `// +build` form. The old style is now considered
deprecated but still supported for backward compatibility.

This change removes the obsolete `// +build xxx` line, keeping only the
modern `//go:build xxx` directive.

More info: https://github.com/golang/go/issues/41184 and https://go.dev/doc/go1.17#build-lines

Design Doc / Proposal：
https://go.dev/design/draft-gobuild


