### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/pkg/rpc/server/da_visualization.go
+++ b/pkg/rpc/server/da_visualization.go
@@ -118,7 +118,7 @@ func (s *DAVisualizationServer) handleDASubmissions(w http.ResponseWriter, r *ht
 
 	// If not an aggregator, return empty submissions with a message
 	if !s.isAggregator {
-		response := map[string]interface{}{
+		response := map[string]any{
 			"is_aggregator": false,
 			"submissions":   []DASubmissionInfo{},
 			"total":         0,
@@ -139,7 +139,7 @@ func (s *DAVisualizationServer) handleDASubmissions(w http.ResponseWriter, r *ht
 	}
 
 	// Build response
-	response := map[string]interface{}{
+	response := map[string]any{
 		"submissions": reversed,
 		"total":       len(reversed),
 	}
@@ -192,7 +192,7 @@ func (s *DAVisualizationServer) handleDABlobDetails(w http.ResponseWriter, r *ht
 	}
 
 	blob := blobs[0]
-	response := map[string]interface{}{
+	response := map[string]any{
 		"id":              blobID,
 		"height":          height,
 		"commitment":      hex.EncodeToString(commitment),
@@ -215,7 +215,7 @@ func (s *DAVisualizationServer) handleDAStats(w http.ResponseWriter, r *http.Req
 
 	// If not an aggregator, return empty stats
 	if !s.isAggregator {
-		stats := map[string]interface{}{
+		stats := map[string]any{
 			"is_aggregator":     false,
 			"total_submissions": 0,
 			"message":           "This node is not an aggregator and does not submit to the DA layer",
@@ -264,7 +264,7 @@ func (s *DAVisualizationServer) handleDAStats(w http.ResponseWriter, r *http.Req
 		lastSubmission = &s.submissions[len(s.submissions)-1].Timestamp
 	}
 
-	stats := map[string]interface{}{
+	stats := map[string]any{
 		"total_submissions": totalSubmissions,
 		"success_count":     successCount,
 		"error_count":       errorCount,
@@ -272,7 +272,7 @@ func (s *DAVisualizationServer) handleDAStats(w http.ResponseWriter, r *http.Req
 		"total_blob_size":   totalBlobSize,
 		"avg_blob_size":     avgBlobSize,
 		"avg_gas_price":     avgGasPrice,
-		"time_range": map[string]interface{}{
+		"time_range": map[string]any{
 			"first": firstSubmission,
 			"last":  lastSubmission,
 		},
@@ -292,7 +292,7 @@ func (s *DAVisualizationServer) handleDAHealth(w http.ResponseWriter, r *http.Re
 
 	// If not an aggregator, return simplified health status
 	if !s.isAggregator {
-		health := map[string]interface{}{
+		health := map[string]any{
 			"is_aggregator":     false,
 			"status":            "n/a",
 			"message":           "This node is not an aggregator and does not submit to the DA layer",
@@ -409,12 +409,12 @@ func (s *DAVisualizationServer) handleDAHealth(w http.ResponseWriter, r *http.Re
 		}
 	}
 
-	health := map[string]interface{}{
+	health := map[string]any{
 		"status":             healthStatus,
 		"is_healthy":         isHealthy,
 		"connection_status":  connectionStatus,
 		"connection_healthy": connectionHealthy,
-		"metrics": map[string]interface{}{
+		"metrics": map[string]any{
 			"recent_error_rate":    fmt.Sprintf("%.1f%%", errorRate),
 			"recent_errors":        recentErrors,
 			"recent_successes":     recentSuccesses,
@@ -454,7 +454,7 @@ func (s *DAVisualizationServer) handleDAVisualizationHTML(w http.ResponseWriter,
 			}
 			return s[start:end]
 		},
-		"len": func(items interface{}) int {
+		"len": func(items any) int {
 			// Handle different types gracefully
 			switch v := items.(type) {
 			case []DASubmissionInfo:

--- a/pkg/rpc/server/da_visualization_non_aggregator_test.go
+++ b/pkg/rpc/server/da_visualization_non_aggregator_test.go
@@ -43,7 +43,7 @@ func TestNonAggregatorHandleDASubmissions(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
-	var response map[string]interface{}
+	var response map[string]any
 	err = json.Unmarshal(rr.Body.Bytes(), &response)
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func TestNonAggregatorHandleDASubmissions(t *testing.T) {
 	assert.Equal(t, float64(0), response["total"])
 	assert.Contains(t, response["message"], "not an aggregator")
 
-	submissions, ok := response["submissions"].([]interface{})
+	submissions, ok := response["submissions"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 0, len(submissions))
 }
@@ -73,7 +73,7 @@ func TestNonAggregatorHandleDAStats(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
-	var response map[string]interface{}
+	var response map[string]any
 	err = json.Unmarshal(rr.Body.Bytes(), &response)
 	require.NoError(t, err)
 
@@ -99,7 +99,7 @@ func TestNonAggregatorHandleDAHealth(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
-	var response map[string]interface{}
+	var response map[string]any
 	err = json.Unmarshal(rr.Body.Bytes(), &response)
 	require.NoError(t, err)
 

--- a/pkg/rpc/server/da_visualization_test.go
+++ b/pkg/rpc/server/da_visualization_test.go
@@ -136,16 +136,16 @@ func TestHandleDASubmissions(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
 
-	var response map[string]interface{}
+	var response map[string]any
 	err = json.Unmarshal(rr.Body.Bytes(), &response)
 	require.NoError(t, err)
 
 	assert.Equal(t, float64(1), response["total"])
-	submissions, ok := response["submissions"].([]interface{})
+	submissions, ok := response["submissions"].([]any)
 	require.True(t, ok)
 	assert.Equal(t, 1, len(submissions))
 
-	submission := submissions[0].(map[string]interface{})
+	submission := submissions[0].(map[string]any)
 	assert.Equal(t, float64(100), submission["height"])
 	assert.Equal(t, float64(1024), submission["blob_size"])
 	assert.Equal(t, 0.5, submission["gas_price"])


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.
