### PR TITLE
docs: add version notice warning about pre-v1 releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ev-node is the basis of the Evolve Stack. For more in-depth information about Ev
 [![GoDoc](https://godoc.org/github.com/evstack/ev-node?status.svg)](https://godoc.org/github.com/evstack/ev-node)
 <!-- markdownlint-enable MD013 -->
 
-> **⚠️ Version Notice**: Do not use tags or releases before v1.0.0. Pre-v1 releases are not considered stable and may contain breaking changes.
+> **⚠️ Version Notice**: Do not use tags or releases before v1.*. Pre-v1 releases are not stable and should be considered abandoned. 
 
 ## Using Evolve
 


### PR DESCRIPTION
This PR adds a prominent warning in the README to inform users not to use tags or releases before v1.0.0, as they are not considered stable and may contain breaking changes.

Fixes #2823

Generated with [Claude Code](https://claude.ai/code)