### PR TITLE
refactor: replace interface{} with any for clarity and modernization

### DIFF
--- a/block/internal/submitting/da_submitter.go
+++ b/block/internal/submitting/da_submitter.go
@@ -364,20 +364,20 @@ func mergeSubmitOptions(baseOptions []byte, signingAddress string) ([]byte, erro
 		return baseOptions, nil
 	}
 
-	var optionsMap map[string]interface{}
+	var optionsMap map[string]any
 
 	// If base options are provided, try to parse them as JSON
 	if len(baseOptions) > 0 {
 		// Try to unmarshal existing options, ignoring errors for non-JSON input
 		if err := json.Unmarshal(baseOptions, &optionsMap); err != nil {
 			// Not valid JSON - start with empty map
-			optionsMap = make(map[string]interface{})
+			optionsMap = make(map[string]any)
 		}
 	}
 
 	// Ensure map is initialized even if unmarshal returned nil
 	if optionsMap == nil {
-		optionsMap = make(map[string]interface{})
+		optionsMap = make(map[string]any)
 	}
 
 	// Add or override the signing address

--- a/block/internal/submitting/da_submitter_options_test.go
+++ b/block/internal/submitting/da_submitter_options_test.go
@@ -22,7 +22,7 @@ func TestMergeSubmitOptions_EmptyBaseOptions(t *testing.T) {
 	result, err := mergeSubmitOptions([]byte{}, signingAddress)
 	require.NoError(t, err)
 
-	var resultMap map[string]interface{}
+	var resultMap map[string]any
 	err = json.Unmarshal(result, &resultMap)
 	require.NoError(t, err)
 
@@ -36,7 +36,7 @@ func TestMergeSubmitOptions_ValidJSON(t *testing.T) {
 	result, err := mergeSubmitOptions(baseOptions, signingAddress)
 	require.NoError(t, err)
 
-	var resultMap map[string]interface{}
+	var resultMap map[string]any
 	err = json.Unmarshal(result, &resultMap)
 	require.NoError(t, err)
 
@@ -52,7 +52,7 @@ func TestMergeSubmitOptions_InvalidJSON(t *testing.T) {
 	result, err := mergeSubmitOptions(baseOptions, signingAddress)
 	require.NoError(t, err)
 
-	var resultMap map[string]interface{}
+	var resultMap map[string]any
 	err = json.Unmarshal(result, &resultMap)
 	require.NoError(t, err)
 
@@ -68,7 +68,7 @@ func TestMergeSubmitOptions_OverrideExistingAddress(t *testing.T) {
 	result, err := mergeSubmitOptions(baseOptions, newAddress)
 	require.NoError(t, err)
 
-	var resultMap map[string]interface{}
+	var resultMap map[string]any
 	err = json.Unmarshal(result, &resultMap)
 	require.NoError(t, err)
 
@@ -82,7 +82,7 @@ func TestMergeSubmitOptions_NilBaseOptions(t *testing.T) {
 	result, err := mergeSubmitOptions(nil, signingAddress)
 	require.NoError(t, err)
 
-	var resultMap map[string]interface{}
+	var resultMap map[string]any
 	err = json.Unmarshal(result, &resultMap)
 	require.NoError(t, err)
 
@@ -102,17 +102,17 @@ func TestMergeSubmitOptions_ComplexJSON(t *testing.T) {
 	result, err := mergeSubmitOptions(baseOptions, signingAddress)
 	require.NoError(t, err)
 
-	var resultMap map[string]interface{}
+	var resultMap map[string]any
 	err = json.Unmarshal(result, &resultMap)
 	require.NoError(t, err)
 
 	// Check nested structure is preserved
-	nested, ok := resultMap["nested"].(map[string]interface{})
+	nested, ok := resultMap["nested"].(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "value", nested["key"])
 
 	// Check array is preserved
-	array, ok := resultMap["array"].([]interface{})
+	array, ok := resultMap["array"].([]any)
 	require.True(t, ok)
 	assert.Len(t, array, 3)
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Inspired by https://github.com/evstack/ev-node/pull/2781 and replace all.



This change replaces occurrences of interface{} with the predeclared identifier any, introduced in Go 1.18 as an alias for interface{}.

As noted in the [Go 1.18 Release Notes](https://go.dev/doc/go1.18#language):
This improves readability and aligns the codebase with modern Go conventions.