### PR TITLE
fix: remove duplicate error logging in light node shutdown

### DIFF
--- a/node/light.go
+++ b/node/light.go
@@ -163,7 +163,6 @@ func (ln *LightNode) Run(parentCtx context.Context) error {
 		} else {
 			ln.Logger.Error().Err(multiErr).Msg("error during shutdown")
 		}
-		ln.Logger.Error().Err(err).Msg("error during shutdown")
 	}
 
 	if ctx.Err() != nil {


### PR DESCRIPTION
Removed duplicate error logging statement that used the wrong variable.
The shutdown errors are already properly logged through multiErr unwrapping,
so the extra line was redundant and could log nil or only the last error
instead of all accumulated shutdown errors.