### PR TITLE
chore: reduce log noise

### DIFF
--- a/block/internal/syncing/da_retriever.go
+++ b/block/internal/syncing/da_retriever.go
@@ -211,8 +211,10 @@ func (r *DARetriever) processBlobs(ctx context.Context, blobs [][]byte, daHeight
 		}
 
 		events = append(events, event)
+	}
 
-		r.logger.Info().Uint64("height", height).Uint64("da_height", daHeight).Msg("processed block from DA")
+	if len(events) > 0 {
+		r.logger.Info().Int("count", len(events)).Uint64("da_height", daHeight).Msg("processed blocks from DA")
 	}
 
 	return events
@@ -249,7 +251,7 @@ func (r *DARetriever) tryDecodeHeader(bz []byte, daHeight uint64) *types.SignedH
 	headerHash := header.Hash().String()
 	r.cache.SetHeaderDAIncluded(headerHash, daHeight, header.Height())
 
-	r.logger.Info().
+	r.logger.Debug().
 		Str("header_hash", headerHash).
 		Uint64("da_height", daHeight).
 		Uint64("height", header.Height()).
@@ -280,7 +282,7 @@ func (r *DARetriever) tryDecodeData(bz []byte, daHeight uint64) *types.Data {
 	dataHash := signedData.Data.DACommitment().String()
 	r.cache.SetDataDAIncluded(dataHash, daHeight, signedData.Height())
 
-	r.logger.Info().
+	r.logger.Debug().
 		Str("data_hash", dataHash).
 		Uint64("da_height", daHeight).
 		Uint64("height", signedData.Height()).


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

this pr proposes reducing log noise when syncing from da. In our case we recommend p2p is set so now the node can be far ahead of da sync height and this causes log pollution 



```
PM INF syncing block component=syncer height=12380514
2025-11-20T12:12:46.853Z	DEBUG	rpc	go-jsonrpc@v0.9.0/client.go:686	rpc result	{"type": "*da.GetIDsResult"}
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=0D2D3E53BE88E96F41578E446A1D3C4A693AEF10BC19121FF4453AE1903BDD03 height=11911920
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=493FFE6C3A5B3CADC81EEAE5D2B3576AA0B2A9A2716559AC748933558A673CE5 height=11911921
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=1BA321C9080D7128EAAEE82767AF71B1A83CEAD258A74C7FC413BCD80FAC3618 height=11911922
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=FFF1F67F1E4E436B60351284418E693044D142883BA2E224EE6A9669C06073B6 height=11911923
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=BE1975489E9AD910E1BF7E182861BF129AD8B7DFF78E9C776461D7883711A5BA height=11911924
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=7BEEA104648CFB68A3CF601788B164AC1597B12D0E39694B7A4E132296E87BC5 height=11911925
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=19CAF2D4E3B2F74B1C02815BBECED277DDD70584F093EA15B196D2D9C60C1A00 height=11911926
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=319F177811412603CDD0212C7DFE5B8592DC1B0E44CC58B904D10F95FCEB1E2F height=11911927
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=6300007D19E5F66CA4885E5EC1E6CDB0D6B5940AFED36C66EF622DDC3F69FB65 height=11911928
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=AB2FA1541398A7CEEADDA33E0CAB2187F46AF1726E10570E81C64075F9EBD7A6 height=11911929
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=49DAF21622E10CF12A0471BA6FECEA0E3CBF798E4EF817A6C309B78E09E27948 height=11911930
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=34750BF409D2D59C39212184436FE0E389E8EB4F168E08BD20665BCCDA3D7402 height=11911931
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=D347C371B6FC55213F2A5A84A0E532433752BCED81F40CF5CB51A6982678F60A height=11911932
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=90139B80A6E653A218A763237951FC74EE5D5DB85E1970A1EEE6BBD24E1A5030 height=11911933
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=7398F875392E9619C7C0232EF3445A7EDAF774A0C180453ECCC2AAA241357F67 height=11911934
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=152B48472B3F8C51EFE07C977469F668EBA2B294DC45A01F47B5A824CD85DF91 height=11911935
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=86E1E3FB3D33DF40B2A86750DE91348705150CD377B97462C0A52502BCB0BDC1 height=11911936
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=F8492A623800AF8C83E925387F98B0D53E89215F3DD4744EE81E69C5A7741E96 height=11911937
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=A3BEF0997B705B643237C196882E55E024ABD335DD5A42D37F57D2286FF1797B height=11911938
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=D068BD46F59895126C2E68DD1459335E18146702285D391A2670A9D9C37386EA height=11911939
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=AA54758DE29046F2C1C06688EBEFED24FFAEFD9ED3F221252F91DEED2EB363AD height=11911940
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=AD62B5EA1F1A845F3E12071BE8214F38DDFCFFCEE4900F010A4873F32B1F8055 height=11911941
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=712A42AD336CA101FBF58946469AD42F58383174451F1BC52FB2CCF7EF095A9D height=11911942
12:12PM INF optimistically marked header as DA included component=da_retriever da_height=8854157 header_hash=D58E3B656F9D874EF5E4F04F262EFB946D095B1EACB43F0176EC146972C133F1 height=11911943
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911927
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911941
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911942
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911925
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911933
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911940
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911923
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911930
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911932
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911935
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911937
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911939
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911920
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911924
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911938
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911922
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911926
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911929
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911934
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911936
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911943
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911921
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911928
12:12PM INF processed block from DA component=da_retriever da_height=8854157 height=11911931
```

here are the logs today 
