### PR TITLE
chore: fix inconsistent method name in retryWithBackoffOnPayloadStatus comment

### DIFF
--- a/execution/evm/execution.go
+++ b/execution/evm/execution.go
@@ -67,7 +67,7 @@ func validatePayloadStatus(status engine.PayloadStatusV1) error {
 	}
 }
 
-// retryWithBackoff executes a function with exponential backoff retry logic.
+// retryWithBackoffOnPayloadStatus executes a function with exponential backoff retry logic.
 // It implements the Engine API specification's recommendation to retry SYNCING
 // status with exponential backoff. The function:
 //   - Retries only on ErrPayloadSyncing (transient failures)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->



Corrected the comment for `retryWithBackoffOnPayloadStatus` function to match the actual method name. 

The comment previously referred to the function as "retryWithBackoff" which was inconsistent with the actual function name "retryWithBackoffOnPayloadStatus". This change ensures documentation accuracy and code clarity.


