### PR TITLE
refactor: remove obsolete // +build tag

### DIFF
--- a/execution/evm/test/execution_test.go
+++ b/execution/evm/test/execution_test.go
@@ -1,5 +1,4 @@
 //go:build evm
-// +build evm
 
 package test
 

--- a/execution/evm/test/test_helpers.go
+++ b/execution/evm/test/test_helpers.go
@@ -1,5 +1,4 @@
 //go:build evm
-// +build evm
 
 package test
 

--- a/test/e2e/evm_da_restart_e2e_test.go
+++ b/test/e2e/evm_da_restart_e2e_test.go
@@ -1,5 +1,4 @@
 //go:build evm
-// +build evm
 
 // Package e2e contains end-to-end tests for Rollkit's EVM integration.
 //

--- a/test/e2e/evm_full_node_e2e_test.go
+++ b/test/e2e/evm_full_node_e2e_test.go
@@ -1,5 +1,4 @@
 //go:build evm
-// +build evm
 
 // Package e2e contains end-to-end tests for Evolve's EVM integration.
 //

--- a/test/e2e/evm_sequencer_e2e_test.go
+++ b/test/e2e/evm_sequencer_e2e_test.go
@@ -1,5 +1,4 @@
 //go:build evm
-// +build evm
 
 // Package e2e contains end-to-end tests for Evolve's EVM integration.
 //

--- a/test/e2e/evm_test_common.go
+++ b/test/e2e/evm_test_common.go
@@ -1,5 +1,4 @@
 //go:build evm
-// +build evm
 
 // Package e2e contains shared utilities for EVM end-to-end tests.
 //


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Go 1.17 introduced a new `//go:build` syntax that replaces the legacy
`// +build` form. This change cleans up the old tag.

More info: https://github.com/golang/go/issues/41184

