### PR TITLE
fix(docs): remove blog link from sidebar to fix 404

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -323,11 +323,11 @@ function sidebarHome() {
         },
       ],
     },
-    {
-      text: "Blog",
-      collapsed: true,
-      items: [{ text: "Overview", link: "/blog/overview" }],
-    },
+    // {
+    //   text: "Blog",
+    //   collapsed: true,
+    //   items: [{ text: "Overview", link: "/blog/overview" }],
+    // },
     {
       text: "API Documentation",
       collapsed: true,


### PR DESCRIPTION
The Blog section in the sidebar referenced /blog/overview but the blog directory was never created. Comment out the sidebar entry to match the already-commented nav entry.

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
