### PR TITLE
fix(sync): reduce P2P init timeout and fallback to DA sync

### DIFF
--- a/pkg/sync/sync_service.go
+++ b/pkg/sync/sync_service.go
@@ -436,11 +436,14 @@ func (syncService *SyncService[H]) initFromP2PWithRetry(ctx context.Context, pee
 		return true, nil
 	}
 
-	// block with exponential backoff until initialization succeeds or context is canceled.
+	// block with exponential backoff until initialization succeeds, context is canceled, or timeout.
+	// If timeout is reached, we return nil to allow startup to continue - DA sync will
+	// provide headers and WriteToStoreAndBroadcast will lazily initialize the store/syncer.
 	backoff := 1 * time.Second
 	maxBackoff := 10 * time.Second
 
-	timeoutTimer := time.NewTimer(time.Minute * 10)
+	p2pInitTimeout := 30 * time.Second
+	timeoutTimer := time.NewTimer(p2pInitTimeout)
 	defer timeoutTimer.Stop()
 
 	for {
@@ -455,7 +458,10 @@ func (syncService *SyncService[H]) initFromP2PWithRetry(ctx context.Context, pee
 		case <-ctx.Done():
 			return ctx.Err()
 		case <-timeoutTimer.C:
-			return fmt.Errorf("timeout reached while trying to initialize the store after 10 minutes: %w", err)
+			syncService.logger.Warn().
+				Dur("timeout", p2pInitTimeout).
+				Msg("P2P header sync initialization timed out, deferring to DA sync")
+			return nil
 		case <-time.After(backoff):
 		}
 


### PR DESCRIPTION
Previously, P2P header sync initialization would block for up to 10 minutes retrying when peers were unavailable (e.g., blocked by gater). This prevented DA sync from starting, leaving the node stuck.


Closes: #2994
