### PR TITLE
chore: remove double p2p setting

### DIFF
--- a/pkg/cmd/p2p.go
+++ b/pkg/cmd/p2p.go
@@ -96,9 +96,7 @@ var NetInfoCmd = &cobra.Command{
 		// Iterate through all listen addresses
 		fmt.Fprintf(w, "📡 Listen Addrs:")
 		for i, addr := range netInfo.ListenAddresses {
-			fullAddress := fmt.Sprintf("%s/p2p/%s", addr, nodeID)
 			fmt.Fprintf(w, "   [%d] Addr: \033[1;36m%s\033[0m\n", i+1, addr)
-			fmt.Fprintf(w, "       Full: \033[1;32m%s\033[0m\n", fullAddress)
 		}
 
 		fmt.Fprintf(w, "%s\n", strings.Repeat("-", 50))

--- a/pkg/cmd/p2p_test.go
+++ b/pkg/cmd/p2p_test.go
@@ -46,8 +46,9 @@ func TestNetInfoCmd_Success(t *testing.T) {
 	mockP2P := new(testmocks.MockP2PRPC)
 
 	mockNodeID := "12D3KooWExampleNodeID1234567890"
-	mockListenAddr1 := "/ip4/127.0.0.1/tcp/7676"
-	mockListenAddr2 := "/ip6/::1/tcp/7677"
+	// Listen addresses include peer ID (as returned by the P2P layer)
+	mockListenAddr1 := "/ip4/127.0.0.1/tcp/7676/p2p/" + mockNodeID
+	mockListenAddr2 := "/ip6/::1/tcp/7677/p2p/" + mockNodeID
 	mockPeerID1Str := "12D3KooWJHLDoXhmgYe6FEbujPzMQJvJ9JyGwRR2VjRM4f7Udvte"
 	mockPeerAddr1Str := "/ip4/192.168.1.100/tcp/7676"
 	mockPeerID2Str := "12D3KooWJHLDoXhmgYe6FEbujPzMQJvJ9JyGwRR2VjRM4f7Udvte"
@@ -114,9 +115,7 @@ func TestNetInfoCmd_Success(t *testing.T) {
 	assert.Contains(output, fmt.Sprintf("Node ID:      \033[1;36m%s\033[0m", mockNodeID))
 	assert.Contains(output, "Listen Addrs:")
 	assert.Contains(output, fmt.Sprintf("Addr: \033[1;36m%s\033[0m", mockListenAddr1))
-	assert.Contains(output, fmt.Sprintf("Full: \033[1;32m%s/p2p/%s\033[0m", mockListenAddr1, mockNodeID))
 	assert.Contains(output, fmt.Sprintf("Addr: \033[1;36m%s\033[0m", mockListenAddr2))
-	assert.Contains(output, fmt.Sprintf("Full: \033[1;32m%s/p2p/%s\033[0m", mockListenAddr2, mockNodeID))
 
 	assert.Contains(output, "CONNECTED PEERS: \033[1;33m2\033[0m")
 	assert.Contains(output, "PEER ID")
@@ -140,8 +139,9 @@ func TestNetInfoCmd_NoPeers(t *testing.T) {
 	mockP2P := new(testmocks.MockP2PRPC)
 
 	mockNodeID := "12D3KooWExampleNodeID1234567890"
-	mockListenAddr1 := "/ip4/127.0.0.1/tcp/7676"
-	mockListenAddr2 := "/ip6/::1/tcp/7677"
+	// Listen addresses include peer ID (as returned by the P2P layer)
+	mockListenAddr1 := "/ip4/127.0.0.1/tcp/7676/p2p/" + mockNodeID
+	mockListenAddr2 := "/ip6/::1/tcp/7677/p2p/" + mockNodeID
 
 	mockNetInfo := p2p.NetworkInfo{
 		ID:            mockNodeID,
@@ -192,9 +192,7 @@ func TestNetInfoCmd_NoPeers(t *testing.T) {
 	assert.Contains(output, fmt.Sprintf("Node ID:      \033[1;36m%s\033[0m", mockNodeID))
 	assert.Contains(output, "Listen Addrs:")
 	assert.Contains(output, fmt.Sprintf("Addr: \033[1;36m%s\033[0m", mockListenAddr1))
-	assert.Contains(output, fmt.Sprintf("Full: \033[1;32m%s/p2p/%s\033[0m", mockListenAddr1, mockNodeID))
 	assert.Contains(output, fmt.Sprintf("Addr: \033[1;36m%s\033[0m", mockListenAddr2))
-	assert.Contains(output, fmt.Sprintf("Full: \033[1;32m%s/p2p/%s\033[0m", mockListenAddr2, mockNodeID))
 
 	assert.Contains(output, "CONNECTED PEERS: \033[1;33m0\033[0m")
 	assert.Contains(output, "No peers connected")

--- a/pkg/p2p/client.go
+++ b/pkg/p2p/client.go
@@ -410,8 +410,13 @@ func (c *Client) GetPeers() ([]peer.AddrInfo, error) {
 
 func (c *Client) GetNetworkInfo() (NetworkInfo, error) {
 	var addrs []string
+	peerIDSuffix := "/p2p/" + c.host.ID().String()
 	for _, a := range c.host.Addrs() {
-		addr := fmt.Sprintf("%s/p2p/%s", a, c.host.ID())
+		addr := a.String()
+		// Only append peer ID if not already present
+		if !strings.HasSuffix(addr, peerIDSuffix) {
+			addr = addr + peerIDSuffix
+		}
 		addrs = append(addrs, addr)
 	}
 

--- a/scripts/run-evm-nodes.go
+++ b/scripts/run-evm-nodes.go
@@ -608,7 +608,7 @@ func isProjectRoot(dir string) bool {
 	markers := []string{
 		"apps/evm",
 		"execution/evm",
-		"da",
+		"block",
 		"scripts",
 		"go.mod",
 	}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

this pr removes  the double p2p/<>/p2p/<> as its malformed to have it twice but the system allows it 