### PR TITLE
[WIP] test: use ev-reth pr-106 image to validate reth v1.10.1 upgrade

### DIFF
--- a/execution/evm/test/test_helpers.go
+++ b/execution/evm/test/test_helpers.go
@@ -66,6 +66,7 @@ func SetupTestRethNode(t *testing.T) *reth.Node {
 	dockerCli, dockerNetID := getTestScopedDockerSetup(t)
 
 	n, err := reth.NewNodeBuilderWithTestName(t, fmt.Sprintf("%s-%s", t.Name(), randomString(6))).
+		WithTag("pr-106").
 		WithDockerClient(dockerCli).
 		WithDockerNetworkID(dockerNetID).
 		WithGenesis([]byte(reth.DefaultEvolveGenesisJSON())).

--- a/test/docker-e2e/docker_test.go
+++ b/test/docker-e2e/docker_test.go
@@ -271,6 +271,7 @@ type RethSetupConfig struct {
 func (s *DockerTestSuite) SetupRethNode(ctx context.Context, name string) RethSetupConfig {
 	rethNode, err := reth.NewNodeBuilder(s.T()).
 		WithName(name).
+		WithTag("pr-106").
 		WithGenesis([]byte(reth.DefaultEvolveGenesisJSON())).
 		WithDockerClient(s.dockerClient).
 		WithDockerNetworkID(s.dockerNetworkID).


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

This PR is bumping the E2E tests to use the version of reth built from 1.10.1 to verify they all pass. https://github.com/evstack/ev-reth/pull/106

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
