### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/block/internal/syncing/syncer.go
+++ b/block/internal/syncing/syncer.go
@@ -893,11 +893,7 @@ func (s *Syncer) gracePeriodForEpoch(epochStart, epochEnd uint64) uint64 {
 		extra = (avgBytes - threshold) / threshold
 	}
 
-	grace := baseGracePeriodEpochs + extra
-	if grace > maxGracePeriodEpochs {
-		grace = maxGracePeriodEpochs
-	}
-	return grace
+	return min(baseGracePeriodEpochs+extra, maxGracePeriodEpochs)
 }
 
 // VerifyForcedInclusionTxs checks that every forced-inclusion tx submitted


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code structure for grace period calculations, streamlining logic while maintaining identical functionality and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->