### PR TITLE
feat(metrics): track blocks synchronized by source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- Add `sequencer_blocks_synchronized_total` Prometheus counter metric tracking blocks synced by source (DA/P2P) [#3254](https://github.com/evstack/ev-node/pull/3254)
 - Make it easier to override `DefaultMaxBlobSize` by ldflags [#3235](https://github.com/evstack/ev-node/pull/3235)
 - Add solo sequencer (simple in memory single sequencer without force inclusion) [#3235](https://github.com/evstack/ev-node/pull/3235)
 - Improve reaper to sustain txs burst better [#3236](https://github.com/evstack/ev-node/pull/3236)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- Add `sequencer_blocks_synchronized_total` Prometheus counter metric tracking blocks synced by source (DA/P2P) [#3254](https://github.com/evstack/ev-node/pull/3254)
+- Add `sequencer_blocks_synchronized_total` Prometheus counter metric tracking blocks synced by source (DA/P2P) [#3259](https://github.com/evstack/ev-node/pull/3259)
 - Make it easier to override `DefaultMaxBlobSize` by ldflags [#3235](https://github.com/evstack/ev-node/pull/3235)
 - Add solo sequencer (simple in memory single sequencer without force inclusion) [#3235](https://github.com/evstack/ev-node/pull/3235)
 - Improve reaper to sustain txs burst better [#3236](https://github.com/evstack/ev-node/pull/3236)

--- a/block/internal/common/event.go
+++ b/block/internal/common/event.go
@@ -11,10 +11,17 @@ type EventSource string
 
 const (
 	// SourceDA indicates the event came from the DA layer
-	SourceDA EventSource = "DA"
+	SourceDA EventSource = "da"
 	// SourceP2P indicates the event came from P2P network
-	SourceP2P EventSource = "P2P"
+	SourceP2P EventSource = "p2p"
+	// SourceRaft indicates the event came from Raft consensus recovery
+	SourceRaft EventSource = "raft"
 )
+
+// AllEventSources returns all possible event sources.
+func AllEventSources() []EventSource {
+	return []EventSource{SourceDA, SourceP2P, SourceRaft}
+}
 
 // DAHeightEvent represents a DA event for caching
 type DAHeightEvent struct {

--- a/block/internal/common/metrics.go
+++ b/block/internal/common/metrics.go
@@ -67,6 +67,9 @@ type Metrics struct {
 	// Forced inclusion metrics
 	ForcedInclusionTxsInGracePeriod metrics.Gauge   // Number of forced inclusion txs currently in grace period
 	ForcedInclusionTxsMalicious     metrics.Counter // Total number of forced inclusion txs marked as malicious
+
+	// Syncer metrics
+	BlocksSynchronized map[EventSource]metrics.Counter // Blocks synchronized by source (P2P or DA)
 }
 
 // PrometheusMetrics returns Metrics built using Prometheus client library
@@ -80,6 +83,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 		OperationDuration:      make(map[string]metrics.Histogram),
 		DASubmitterFailures:    make(map[DASubmitterFailureReason]metrics.Counter),
 		DASubmitterLastFailure: make(map[DASubmitterFailureReason]metrics.Gauge),
+		BlocksSynchronized:     make(map[EventSource]metrics.Counter),
 	}
 
 	// Original metrics
@@ -223,6 +227,19 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 		}, labels).With(labelsAndValues...)
 	}
 
+	// Syncer metrics
+	for _, source := range []EventSource{SourceDA, SourceP2P} {
+		m.BlocksSynchronized[source] = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: MetricsSubsystem,
+			Name:      "blocks_synchronized_total",
+			Help:      "Total number of blocks synchronized by source",
+			ConstLabels: map[string]string{
+				"source": string(source),
+			},
+		}, labels).With(labelsAndValues...)
+	}
+
 	return m
 }
 
@@ -251,6 +268,9 @@ func NopMetrics() *Metrics {
 		// Forced inclusion metrics
 		ForcedInclusionTxsInGracePeriod: discard.NewGauge(),
 		ForcedInclusionTxsMalicious:     discard.NewCounter(),
+
+		// Syncer metrics
+		BlocksSynchronized: make(map[EventSource]metrics.Counter),
 	}
 
 	// Initialize maps with no-op metrics
@@ -263,6 +283,11 @@ func NopMetrics() *Metrics {
 	for _, reason := range AllDASubmitterFailureReasons() {
 		m.DASubmitterFailures[reason] = discard.NewCounter()
 		m.DASubmitterLastFailure[reason] = discard.NewGauge()
+	}
+
+	// Initialize syncer no-op metrics
+	for _, source := range []EventSource{SourceDA, SourceP2P} {
+		m.BlocksSynchronized[source] = discard.NewCounter()
 	}
 
 	return m

--- a/block/internal/common/metrics.go
+++ b/block/internal/common/metrics.go
@@ -228,7 +228,7 @@ func PrometheusMetrics(namespace string, labelsAndValues ...string) *Metrics {
 	}
 
 	// Syncer metrics
-	for _, source := range []EventSource{SourceDA, SourceP2P} {
+	for _, source := range AllEventSources() {
 		m.BlocksSynchronized[source] = prometheus.NewCounterFrom(stdprometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: MetricsSubsystem,
@@ -286,7 +286,7 @@ func NopMetrics() *Metrics {
 	}
 
 	// Initialize syncer no-op metrics
-	for _, source := range []EventSource{SourceDA, SourceP2P} {
+	for _, source := range AllEventSources() {
 		m.BlocksSynchronized[source] = discard.NewCounter()
 	}
 

--- a/block/internal/syncing/syncer.go
+++ b/block/internal/syncing/syncer.go
@@ -715,6 +715,7 @@ func (s *Syncer) trySyncNextBlockWithState(ctx context.Context, event *common.DA
 	headerHash := header.Hash().String()
 
 	s.logger.Info().Uint64("height", nextHeight).Str("source", string(event.Source)).Msg("syncing block")
+	s.metrics.BlocksSynchronized[event.Source].Add(1)
 
 	// Compared to the executor logic where the current block needs to be applied first,
 	// here only the previous block needs to be applied to proceed to the verification.

--- a/block/internal/syncing/syncer.go
+++ b/block/internal/syncing/syncer.go
@@ -715,7 +715,6 @@ func (s *Syncer) trySyncNextBlockWithState(ctx context.Context, event *common.DA
 	headerHash := header.Hash().String()
 
 	s.logger.Info().Uint64("height", nextHeight).Str("source", string(event.Source)).Msg("syncing block")
-	s.metrics.BlocksSynchronized[event.Source].Add(1)
 
 	// Compared to the executor logic where the current block needs to be applied first,
 	// here only the previous block needs to be applied to proceed to the verification.
@@ -785,6 +784,9 @@ func (s *Syncer) trySyncNextBlockWithState(ctx context.Context, event *common.DA
 	// Update in-memory state after successful commit
 	s.SetLastState(newState)
 	s.metrics.Height.Set(float64(newState.LastBlockHeight))
+	if counter, ok := s.metrics.BlocksSynchronized[event.Source]; ok {
+		counter.Add(1)
+	}
 
 	// Mark as seen
 	s.cache.SetHeaderSeen(headerHash, header.Height())

--- a/block/internal/syncing/syncer.go
+++ b/block/internal/syncing/syncer.go
@@ -1229,7 +1229,7 @@ func (s *Syncer) RecoverFromRaft(ctx context.Context, raftState *raft.RaftBlockS
 		event := &common.DAHeightEvent{
 			Header: &header,
 			Data:   &data,
-			Source: "",
+			Source: common.SourceRaft,
 		}
 		err := s.trySyncNextBlockWithState(ctx, event, currentState)
 		if err != nil {


### PR DESCRIPTION
## Summary

- Add `sequencer_blocks_synchronized_total` Prometheus counter with `source` label (DA/P2P)
- Counter increments each time a block is synced in the syncer
- Resets on process restart

## Test plan

- [ ] Run node and verify `sequencer_blocks_synchronized_total{source="DA"}` and `sequencer_blocks_synchronized_total{source="P2P"}` appear in `/metrics`
- [ ] Confirm counters increment as blocks are synced from each source

🤖 Generated with [Claude Code](https://claude.com/claude-code)