### PR TITLE
fix(rpc): derive /raft/node leadership from raft leader ID

### DIFF
--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -208,6 +208,13 @@ func (n *Node) NodeID() string {
 	return n.config.NodeID
 }
 
+func (n *Node) LeaderID() string {
+	if n == nil || n.raft == nil {
+		return ""
+	}
+	return n.leaderID()
+}
+
 func (n *Node) leaderID() string {
 	_, id := n.raft.LeaderWithID()
 	return string(id)

--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -257,6 +257,11 @@ func (n *Node) NodeID() string {
 	return n.config.NodeID
 }
 
+// LeaderID returns the server ID of the current cluster leader.
+// Returns an empty string if the receiver is nil, raft is uninitialized, or no
+// leader has been elected yet. The value may be momentarily stale between raft
+// leadership changes; callers that need a strong guarantee should cross-check
+// with HasQuorum.
 func (n *Node) LeaderID() string {
 	if n == nil || n.raft == nil {
 		return ""

--- a/pkg/rpc/server/http.go
+++ b/pkg/rpc/server/http.go
@@ -139,11 +139,16 @@ func RegisterCustomHTTPEndpoints(mux *http.ServeMux, s store.Store, pm p2p.P2PRP
 				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 				return
 			}
+			leaderID := raftNode.LeaderID()
+			isLeader := raftNode.IsLeader()
+			if leaderID != "" {
+				isLeader = leaderID == raftNode.NodeID()
+			}
 			rsp := struct {
 				IsLeader bool   `json:"is_leader"`
 				NodeID   string `json:"node_id"`
 			}{
-				IsLeader: raftNode.IsLeader(),
+				IsLeader: isLeader,
 				NodeID:   raftNode.NodeID(),
 			}
 			w.Header().Set("Content-Type", "application/json")

--- a/pkg/rpc/server/http_test.go
+++ b/pkg/rpc/server/http_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -43,6 +44,106 @@ func TestRegisterCustomHTTPEndpoints(t *testing.T) {
 	assert.Equal(t, "OK\n", string(body))
 
 	mockStore.AssertExpectations(t)
+}
+
+type testRaftNodeSource struct {
+	isLeader bool
+	leaderID string
+	nodeID   string
+}
+
+func (t testRaftNodeSource) IsLeader() bool {
+	return t.isLeader
+}
+
+func (t testRaftNodeSource) LeaderID() string {
+	return t.leaderID
+}
+
+func (t testRaftNodeSource) NodeID() string {
+	return t.nodeID
+}
+
+func TestRegisterCustomHTTPEndpoints_RaftNodeStatus(t *testing.T) {
+	mux := http.NewServeMux()
+	logger := zerolog.Nop()
+
+	raftNode := testRaftNodeSource{
+		isLeader: false,
+		leaderID: "node-a",
+		nodeID:   "node-a",
+	}
+
+	RegisterCustomHTTPEndpoints(mux, nil, nil, config.DefaultConfig(), nil, logger, raftNode)
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/raft/node", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test-only request to httptest server
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		IsLeader bool   `json:"is_leader"`
+		NodeID   string `json:"node_id"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.True(t, body.IsLeader)
+	assert.Equal(t, "node-a", body.NodeID)
+}
+
+func TestRegisterCustomHTTPEndpoints_RaftNodeStatusFallsBackWithoutLeaderID(t *testing.T) {
+	mux := http.NewServeMux()
+	logger := zerolog.Nop()
+
+	raftNode := testRaftNodeSource{
+		isLeader: false,
+		leaderID: "",
+		nodeID:   "node-a",
+	}
+
+	RegisterCustomHTTPEndpoints(mux, nil, nil, config.DefaultConfig(), nil, logger, raftNode)
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/raft/node", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test-only request to httptest server
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body struct {
+		IsLeader bool   `json:"is_leader"`
+		NodeID   string `json:"node_id"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.False(t, body.IsLeader)
+	assert.Equal(t, "node-a", body.NodeID)
+}
+
+func TestRegisterCustomHTTPEndpoints_RaftNodeStatusMethodNotAllowed(t *testing.T) {
+	mux := http.NewServeMux()
+	logger := zerolog.Nop()
+
+	RegisterCustomHTTPEndpoints(mux, nil, nil, config.DefaultConfig(), nil, logger, testRaftNodeSource{})
+
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/raft/node", nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test-only request to httptest server
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 }
 
 func TestHealthReady_aggregatorBlockDelay(t *testing.T) {

--- a/pkg/rpc/server/http_test.go
+++ b/pkg/rpc/server/http_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/evstack/ev-node/pkg/config"
-	"github.com/evstack/ev-node/test/mocks"
-	"github.com/evstack/ev-node/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/evstack/ev-node/pkg/config"
+	"github.com/evstack/ev-node/test/mocks"
+	"github.com/evstack/ev-node/types"
 )
 
 func TestRegisterCustomHTTPEndpoints(t *testing.T) {

--- a/pkg/rpc/server/http_test.go
+++ b/pkg/rpc/server/http_test.go
@@ -8,14 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/evstack/ev-node/pkg/config"
+	"github.com/evstack/ev-node/test/mocks"
+	"github.com/evstack/ev-node/types"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-
-	"github.com/evstack/ev-node/pkg/config"
-	"github.com/evstack/ev-node/test/mocks"
-	"github.com/evstack/ev-node/types"
 )
 
 func TestRegisterCustomHTTPEndpoints(t *testing.T) {
@@ -65,85 +64,82 @@ func (t testRaftNodeSource) NodeID() string {
 }
 
 func TestRegisterCustomHTTPEndpoints_RaftNodeStatus(t *testing.T) {
-	mux := http.NewServeMux()
-	logger := zerolog.Nop()
-
-	raftNode := testRaftNodeSource{
-		isLeader: false,
-		leaderID: "node-a",
-		nodeID:   "node-a",
-	}
-
-	RegisterCustomHTTPEndpoints(mux, nil, nil, config.DefaultConfig(), nil, logger, raftNode)
-
-	ts := httptest.NewServer(mux)
-	t.Cleanup(ts.Close)
-
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/raft/node", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test-only request to httptest server
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = resp.Body.Close() })
-
-	require.Equal(t, http.StatusOK, resp.StatusCode)
-
-	var body struct {
+	type bodyShape struct {
 		IsLeader bool   `json:"is_leader"`
 		NodeID   string `json:"node_id"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
-	assert.True(t, body.IsLeader)
-	assert.Equal(t, "node-a", body.NodeID)
-}
 
-func TestRegisterCustomHTTPEndpoints_RaftNodeStatusFallsBackWithoutLeaderID(t *testing.T) {
-	mux := http.NewServeMux()
-	logger := zerolog.Nop()
-
-	raftNode := testRaftNodeSource{
-		isLeader: false,
-		leaderID: "",
-		nodeID:   "node-a",
+	cases := []struct {
+		name           string
+		node           testRaftNodeSource
+		method         string
+		wantStatus     int
+		wantIsLeader   bool
+		wantNodeID     string
+		skipBodyDecode bool
+	}{
+		{
+			// leaderID == nodeID: handler derives is_leader=true from LeaderID(),
+			// regardless of the IsLeader() field on testRaftNodeSource.
+			name:         "leader matches — is_leader true",
+			node:         testRaftNodeSource{leaderID: "node-a", nodeID: "node-a"},
+			method:       http.MethodGet,
+			wantStatus:   http.StatusOK,
+			wantIsLeader: true,
+			wantNodeID:   "node-a",
+		},
+		{
+			// leaderID != nodeID: handler derives is_leader=false.
+			name:         "leader differs — is_leader false",
+			node:         testRaftNodeSource{leaderID: "node-b", nodeID: "node-a"},
+			method:       http.MethodGet,
+			wantStatus:   http.StatusOK,
+			wantIsLeader: false,
+			wantNodeID:   "node-a",
+		},
+		{
+			// empty leaderID: fallback — is_leader=false (no elected leader known).
+			name:         "empty leaderID fallback — is_leader false",
+			node:         testRaftNodeSource{leaderID: "", nodeID: "node-a"},
+			method:       http.MethodGet,
+			wantStatus:   http.StatusOK,
+			wantIsLeader: false,
+			wantNodeID:   "node-a",
+		},
+		{
+			name:           "non-GET method — 405",
+			node:           testRaftNodeSource{},
+			method:         http.MethodPost,
+			wantStatus:     http.StatusMethodNotAllowed,
+			skipBodyDecode: true,
+		},
 	}
 
-	RegisterCustomHTTPEndpoints(mux, nil, nil, config.DefaultConfig(), nil, logger, raftNode)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mux := http.NewServeMux()
+			RegisterCustomHTTPEndpoints(mux, nil, nil, config.DefaultConfig(), nil, zerolog.Nop(), tc.node)
 
-	ts := httptest.NewServer(mux)
-	t.Cleanup(ts.Close)
+			ts := httptest.NewServer(mux)
+			t.Cleanup(ts.Close)
 
-	req, err := http.NewRequest(http.MethodGet, ts.URL+"/raft/node", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test-only request to httptest server
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = resp.Body.Close() })
+			req, err := http.NewRequest(tc.method, ts.URL+"/raft/node", nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req) //nolint:gosec // test-only request to httptest server
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = resp.Body.Close() })
 
-	require.Equal(t, http.StatusOK, resp.StatusCode)
+			require.Equal(t, tc.wantStatus, resp.StatusCode)
+			if tc.skipBodyDecode {
+				return
+			}
 
-	var body struct {
-		IsLeader bool   `json:"is_leader"`
-		NodeID   string `json:"node_id"`
+			var body bodyShape
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.Equal(t, tc.wantIsLeader, body.IsLeader)
+			assert.Equal(t, tc.wantNodeID, body.NodeID)
+		})
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
-	assert.False(t, body.IsLeader)
-	assert.Equal(t, "node-a", body.NodeID)
-}
-
-func TestRegisterCustomHTTPEndpoints_RaftNodeStatusMethodNotAllowed(t *testing.T) {
-	mux := http.NewServeMux()
-	logger := zerolog.Nop()
-
-	RegisterCustomHTTPEndpoints(mux, nil, nil, config.DefaultConfig(), nil, logger, testRaftNodeSource{})
-
-	ts := httptest.NewServer(mux)
-	t.Cleanup(ts.Close)
-
-	req, err := http.NewRequest(http.MethodPost, ts.URL+"/raft/node", nil)
-	require.NoError(t, err)
-	resp, err := http.DefaultClient.Do(req) //nolint:gosec // test-only request to httptest server
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = resp.Body.Close() })
-
-	assert.Equal(t, http.StatusMethodNotAllowed, resp.StatusCode)
 }
 
 func TestHealthReady_aggregatorBlockDelay(t *testing.T) {

--- a/pkg/rpc/server/server.go
+++ b/pkg/rpc/server/server.go
@@ -368,6 +368,7 @@ func (p *P2PServer) GetNetInfo(
 
 type RaftNodeSource interface {
 	IsLeader() bool
+	LeaderID() string
 	NodeID() string
 }
 


### PR DESCRIPTION
Fixes https://github.com/evstack/ev-node/issues/3265


Tested this PR on a 3 members raft cluster, with this fix, the leader detection displayed on /raft/node endpoint is instantaneous instead of taking ~ 30 sedonds.

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public API for safe leader ID retrieval from raft nodes with null-safety checks.
  * Enhanced leader status detection with fallback mechanism for improved reliability.

* **Tests**
  * Added comprehensive HTTP endpoint tests covering leader status, empty leader scenarios, and HTTP method validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->