### PR TITLE
refactor: modernize sync/atomic usage with typed atomic apis

### DIFF
--- a/pkg/signer/aws/signer_test.go
+++ b/pkg/signer/aws/signer_test.go
@@ -154,12 +154,12 @@ func TestSign_RetryBehavior(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, der := generateTestEd25519DER(t)
 
-			var calls int32
+			var calls atomic.Int32
 			signer := newTestSigner(t, &mockKMSClient{
 				keyID:     awsTestKeyID,
 				pubKeyDER: der,
 				signFn: func(_ context.Context, _ *kms.SignInput) (*kms.SignOutput, error) {
-					atomic.AddInt32(&calls, 1)
+					calls.Add(1)
 					return nil, spec.signErr
 				},
 			}, spec.opts)
@@ -167,7 +167,7 @@ func TestSign_RetryBehavior(t *testing.T) {
 			_, err := signer.Sign(t.Context(), []byte("hello world"))
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), spec.errSubstr)
-			assert.Equal(t, spec.expectedCall, atomic.LoadInt32(&calls))
+			assert.Equal(t, spec.expectedCall, calls.Load())
 		})
 	}
 }

--- a/pkg/signer/gcp/signer_test.go
+++ b/pkg/signer/gcp/signer_test.go
@@ -164,12 +164,12 @@ func TestSign_RetryBehavior(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, publicKeyPEM := generateTestEd25519PEM(t)
 
-			var calls int32
+			var calls atomic.Int32
 			signer := newTestSigner(t, &mockKMSClient{
 				keyID:        myKeyID,
 				publicKeyPEM: publicKeyPEM,
 				signFn: func(_ context.Context, _ *kmspb.AsymmetricSignRequest) (*kmspb.AsymmetricSignResponse, error) {
-					atomic.AddInt32(&calls, 1)
+					calls.Add(1)
 					return nil, spec.signErr
 				},
 			}, spec.opts)
@@ -177,7 +177,7 @@ func TestSign_RetryBehavior(t *testing.T) {
 			_, err := signer.Sign(t.Context(), []byte("hello world"))
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), spec.errSubstr)
-			assert.Equal(t, spec.expectedCall, atomic.LoadInt32(&calls))
+			assert.Equal(t, spec.expectedCall, calls.Load())
 		})
 	}
 }
@@ -228,12 +228,12 @@ func TestSign_IntegrityFailures_RetryAndFail(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, publicKeyPEM := generateTestEd25519PEM(t)
 
-			var calls int32
+			var calls atomic.Int32
 			signer := newTestSigner(t, &mockKMSClient{
 				keyID:        myKeyID,
 				publicKeyPEM: publicKeyPEM,
 				signFn: func(_ context.Context, _ *kmspb.AsymmetricSignRequest) (*kmspb.AsymmetricSignResponse, error) {
-					atomic.AddInt32(&calls, 1)
+					calls.Add(1)
 					return spec.responseFn(), nil
 				},
 			}, &Options{MaxRetries: 1})
@@ -241,7 +241,7 @@ func TestSign_IntegrityFailures_RetryAndFail(t *testing.T) {
 			_, err := signer.Sign(t.Context(), []byte("hello world"))
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), spec.expectedErrSubstr)
-			assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "integrity failures should be retried")
+			assert.Equal(t, int32(2), calls.Load(), "integrity failures should be retried")
 		})
 	}
 }
@@ -249,13 +249,13 @@ func TestSign_IntegrityFailures_RetryAndFail(t *testing.T) {
 func TestSign_IntegrityCheckRecoversOnRetry(t *testing.T) {
 	_, publicKeyPEM := generateTestEd25519PEM(t)
 
-	var calls int32
+	var calls atomic.Int32
 	expectedSig := []byte("valid-signature")
 	mock := &mockKMSClient{
 		keyID:        myKeyID,
 		publicKeyPEM: publicKeyPEM,
 		signFn: func(_ context.Context, _ *kmspb.AsymmetricSignRequest) (*kmspb.AsymmetricSignResponse, error) {
-			attempt := atomic.AddInt32(&calls, 1)
+			attempt := calls.Add(1)
 			if attempt == 1 {
 				return &kmspb.AsymmetricSignResponse{
 					Name:               myKeyID,
@@ -278,7 +278,7 @@ func TestSign_IntegrityCheckRecoversOnRetry(t *testing.T) {
 	got, err := s.Sign(t.Context(), []byte("hello world"))
 	require.NoError(t, err)
 	assert.Equal(t, expectedSig, got)
-	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "second attempt should succeed")
+	assert.Equal(t, int32(2), calls.Load(), "second attempt should succeed")
 }
 
 func TestRetryBackoff_Capped(t *testing.T) {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


Replace legacy sync/atomic function-based API (AddInt32, LoadInt32, etc.) 
with Go 1.19+ typed atomic types (atomic.Int32, atomic.Int64, etc.).

This change:
- Improves code readability by removing explicit address-of operators
- Enhances type safety at compile-time
- Provides better API ergonomics with method-based access
- Aligns with modern Go best practices (More info https://github.com/golang/go/issues/50860)

The transformation is source-compatible and requires Go 1.19 or later.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated atomic operation patterns in test suite for improved code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->