### PR TITLE
refactor: replace context.WithCancel with t.Context

### DIFF
--- a/block/internal/submitting/submitter_test.go
+++ b/block/internal/submitting/submitter_test.go
@@ -235,8 +235,7 @@ func TestSubmitter_initializeDAIncludedHeight(t *testing.T) {
 }
 
 func TestSubmitter_processDAInclusionLoop_advances(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	// Clean up any existing visualization server
 	defer server.SetDAVisualizationServer(nil)
@@ -448,8 +447,7 @@ func (f *fakeSigner) GetPublic() (crypto.PubKey, error) { return nil, nil }
 func (f *fakeSigner) GetAddress() ([]byte, error)       { return []byte("addr"), nil }
 
 func TestSubmitter_CacheClearedOnHeightInclusion(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	cm, st := newTestCacheAndStore(t)
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

Inspired by https://github.com/evstack/ev-node/pull/3183 and replace all of the case.


The addition of the Context method to Go's testing.T provides significant improvements for writing concurrent tests. It allows better management of goroutines, ensuring they properly exit and preventing issues like deadlocks and unfinished processes.

More info: [golang/go#18368](https://github.com/golang/go/issues/18368)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tests to use Go's native test context instead of manual context creation, improving test reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->