### PR TITLE
test(config): use `synctest` in TestAddFlags for avoiding nondeterminism 

### DIFF
--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,6 +41,12 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestAddFlags(t *testing.T) {
+	// Freeze the time source feeding randString so AddFlags' internal DefaultConfig()
+	// and the per-assertion DefaultConfig() calls below produce the same DA.Namespace seed.
+	origNowUnix := nowUnix
+	nowUnix = func() int64 { return 2_000_000_000 }
+	t.Cleanup(func() { nowUnix = origNowUnix })
+
 	// Create a command with flags
 	cmd := &cobra.Command{Use: "test"}
 	AddGlobalFlags(cmd, "test") // Add basic flags first

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -41,133 +42,131 @@ func TestDefaultConfig(t *testing.T) {
 }
 
 func TestAddFlags(t *testing.T) {
-	// Freeze the time source feeding randString so AddFlags' internal DefaultConfig()
-	// and the per-assertion DefaultConfig() calls below produce the same DA.Namespace seed.
-	origNowUnix := nowUnix
-	nowUnix = func() int64 { return 2_000_000_000 }
-	t.Cleanup(func() { nowUnix = origNowUnix })
+	// AddFlags and the assertions below each call DefaultConfig(), whose DA.Namespace
+	// is randString-seeded by time.Now().Unix(); run in a synctest bubble so both calls observe the same fake clock.
+	synctest.Test(t, func(t *testing.T) {
+		// Create a command with flags
+		cmd := &cobra.Command{Use: "test"}
+		AddGlobalFlags(cmd, "test") // Add basic flags first
+		AddFlags(cmd)
 
-	// Create a command with flags
-	cmd := &cobra.Command{Use: "test"}
-	AddGlobalFlags(cmd, "test") // Add basic flags first
-	AddFlags(cmd)
+		// Get both persistent and regular flags
+		flags := cmd.Flags()
+		persistentFlags := cmd.PersistentFlags()
 
-	// Get both persistent and regular flags
-	flags := cmd.Flags()
-	persistentFlags := cmd.PersistentFlags()
+		// Test specific flags
+		assertFlagValue(t, flags, FlagDBPath, DefaultConfig().DBPath)
+		assertFlagValue(t, flags, FlagClearCache, DefaultConfig().ClearCache)
 
-	// Test specific flags
-	assertFlagValue(t, flags, FlagDBPath, DefaultConfig().DBPath)
-	assertFlagValue(t, flags, FlagClearCache, DefaultConfig().ClearCache)
+		// Node flags
+		assertFlagValue(t, flags, FlagAggregator, DefaultConfig().Node.Aggregator)
+		assertFlagValue(t, flags, FlagBasedSequencer, DefaultConfig().Node.BasedSequencer)
+		assertFlagValue(t, flags, FlagLight, DefaultConfig().Node.Light)
+		assertFlagValue(t, flags, FlagBlockTime, DefaultConfig().Node.BlockTime.Duration)
+		assertFlagValue(t, flags, FlagLazyAggregator, DefaultConfig().Node.LazyMode)
+		assertFlagValue(t, flags, FlagMaxPendingHeadersAndData, DefaultConfig().Node.MaxPendingHeadersAndData)
+		assertFlagValue(t, flags, FlagLazyBlockTime, DefaultConfig().Node.LazyBlockInterval.Duration)
+		assertFlagValue(t, flags, FlagReadinessWindowSeconds, DefaultConfig().Node.ReadinessWindowSeconds)
+		assertFlagValue(t, flags, FlagReadinessMaxBlocksBehind, DefaultConfig().Node.ReadinessMaxBlocksBehind)
+		assertFlagValue(t, flags, FlagScrapeInterval, DefaultConfig().Node.ScrapeInterval)
 
-	// Node flags
-	assertFlagValue(t, flags, FlagAggregator, DefaultConfig().Node.Aggregator)
-	assertFlagValue(t, flags, FlagBasedSequencer, DefaultConfig().Node.BasedSequencer)
-	assertFlagValue(t, flags, FlagLight, DefaultConfig().Node.Light)
-	assertFlagValue(t, flags, FlagBlockTime, DefaultConfig().Node.BlockTime.Duration)
-	assertFlagValue(t, flags, FlagLazyAggregator, DefaultConfig().Node.LazyMode)
-	assertFlagValue(t, flags, FlagMaxPendingHeadersAndData, DefaultConfig().Node.MaxPendingHeadersAndData)
-	assertFlagValue(t, flags, FlagLazyBlockTime, DefaultConfig().Node.LazyBlockInterval.Duration)
-	assertFlagValue(t, flags, FlagReadinessWindowSeconds, DefaultConfig().Node.ReadinessWindowSeconds)
-	assertFlagValue(t, flags, FlagReadinessMaxBlocksBehind, DefaultConfig().Node.ReadinessMaxBlocksBehind)
-	assertFlagValue(t, flags, FlagScrapeInterval, DefaultConfig().Node.ScrapeInterval)
+		// DA flags
+		assertFlagValue(t, flags, FlagDAAddress, DefaultConfig().DA.Address)
+		assertFlagValue(t, flags, FlagDAAuthToken, DefaultConfig().DA.AuthToken)
+		assertFlagValue(t, flags, FlagDABlockTime, DefaultConfig().DA.BlockTime.Duration)
+		assertFlagValue(t, flags, FlagDANamespace, DefaultConfig().DA.Namespace)
+		assertFlagValue(t, flags, FlagDADataNamespace, DefaultConfig().DA.DataNamespace)
+		assertFlagValue(t, flags, FlagDAForcedInclusionNamespace, DefaultConfig().DA.ForcedInclusionNamespace)
+		assertFlagValue(t, flags, FlagDASubmitOptions, DefaultConfig().DA.SubmitOptions)
+		assertFlagValue(t, flags, FlagDASigningAddresses, DefaultConfig().DA.SigningAddresses)
+		assertFlagValue(t, flags, FlagDAMempoolTTL, DefaultConfig().DA.MempoolTTL)
+		assertFlagValue(t, flags, FlagDAMaxSubmitAttempts, DefaultConfig().DA.MaxSubmitAttempts)
+		assertFlagValue(t, flags, FlagDARequestTimeout, DefaultConfig().DA.RequestTimeout.Duration)
 
-	// DA flags
-	assertFlagValue(t, flags, FlagDAAddress, DefaultConfig().DA.Address)
-	assertFlagValue(t, flags, FlagDAAuthToken, DefaultConfig().DA.AuthToken)
-	assertFlagValue(t, flags, FlagDABlockTime, DefaultConfig().DA.BlockTime.Duration)
-	assertFlagValue(t, flags, FlagDANamespace, DefaultConfig().DA.Namespace)
-	assertFlagValue(t, flags, FlagDADataNamespace, DefaultConfig().DA.DataNamespace)
-	assertFlagValue(t, flags, FlagDAForcedInclusionNamespace, DefaultConfig().DA.ForcedInclusionNamespace)
-	assertFlagValue(t, flags, FlagDASubmitOptions, DefaultConfig().DA.SubmitOptions)
-	assertFlagValue(t, flags, FlagDASigningAddresses, DefaultConfig().DA.SigningAddresses)
-	assertFlagValue(t, flags, FlagDAMempoolTTL, DefaultConfig().DA.MempoolTTL)
-	assertFlagValue(t, flags, FlagDAMaxSubmitAttempts, DefaultConfig().DA.MaxSubmitAttempts)
-	assertFlagValue(t, flags, FlagDARequestTimeout, DefaultConfig().DA.RequestTimeout.Duration)
+		// P2P flags
+		assertFlagValue(t, flags, FlagP2PListenAddress, DefaultConfig().P2P.ListenAddress)
+		assertFlagValue(t, flags, FlagP2PPeers, DefaultConfig().P2P.Peers)
+		assertFlagValue(t, flags, FlagP2PBlockedPeers, DefaultConfig().P2P.BlockedPeers)
+		assertFlagValue(t, flags, FlagP2PAllowedPeers, DefaultConfig().P2P.AllowedPeers)
+		assertFlagValue(t, flags, FlagP2PDisableConnectionGater, DefaultConfig().P2P.DisableConnectionGater)
 
-	// P2P flags
-	assertFlagValue(t, flags, FlagP2PListenAddress, DefaultConfig().P2P.ListenAddress)
-	assertFlagValue(t, flags, FlagP2PPeers, DefaultConfig().P2P.Peers)
-	assertFlagValue(t, flags, FlagP2PBlockedPeers, DefaultConfig().P2P.BlockedPeers)
-	assertFlagValue(t, flags, FlagP2PAllowedPeers, DefaultConfig().P2P.AllowedPeers)
-	assertFlagValue(t, flags, FlagP2PDisableConnectionGater, DefaultConfig().P2P.DisableConnectionGater)
+		// Instrumentation flags
+		instrDef := DefaultInstrumentationConfig()
+		assertFlagValue(t, flags, FlagPrometheus, instrDef.Prometheus)
+		assertFlagValue(t, flags, FlagPrometheusListenAddr, instrDef.PrometheusListenAddr)
+		assertFlagValue(t, flags, FlagMaxOpenConnections, instrDef.MaxOpenConnections)
+		assertFlagValue(t, flags, FlagPprof, instrDef.Pprof)
+		assertFlagValue(t, flags, FlagPprofListenAddr, instrDef.PprofListenAddr)
+		assertFlagValue(t, flags, FlagTracing, instrDef.Tracing)
+		assertFlagValue(t, flags, FlagTracingEndpoint, instrDef.TracingEndpoint)
+		assertFlagValue(t, flags, FlagTracingSampleRate, instrDef.TracingSampleRate)
+		assertFlagValue(t, flags, FlagTracingServiceName, instrDef.TracingServiceName)
 
-	// Instrumentation flags
-	instrDef := DefaultInstrumentationConfig()
-	assertFlagValue(t, flags, FlagPrometheus, instrDef.Prometheus)
-	assertFlagValue(t, flags, FlagPrometheusListenAddr, instrDef.PrometheusListenAddr)
-	assertFlagValue(t, flags, FlagMaxOpenConnections, instrDef.MaxOpenConnections)
-	assertFlagValue(t, flags, FlagPprof, instrDef.Pprof)
-	assertFlagValue(t, flags, FlagPprofListenAddr, instrDef.PprofListenAddr)
-	assertFlagValue(t, flags, FlagTracing, instrDef.Tracing)
-	assertFlagValue(t, flags, FlagTracingEndpoint, instrDef.TracingEndpoint)
-	assertFlagValue(t, flags, FlagTracingSampleRate, instrDef.TracingSampleRate)
-	assertFlagValue(t, flags, FlagTracingServiceName, instrDef.TracingServiceName)
+		// Logging flags (in persistent flags)
+		assertFlagValue(t, persistentFlags, FlagLogLevel, DefaultConfig().Log.Level)
+		assertFlagValue(t, persistentFlags, FlagLogFormat, "text")
+		assertFlagValue(t, persistentFlags, FlagLogTrace, false)
+		assertFlagValue(t, persistentFlags, FlagRootDir, DefaultRootDirWithName("test"))
 
-	// Logging flags (in persistent flags)
-	assertFlagValue(t, persistentFlags, FlagLogLevel, DefaultConfig().Log.Level)
-	assertFlagValue(t, persistentFlags, FlagLogFormat, "text")
-	assertFlagValue(t, persistentFlags, FlagLogTrace, false)
-	assertFlagValue(t, persistentFlags, FlagRootDir, DefaultRootDirWithName("test"))
+		// Signer flags
+		assertFlagValue(t, flags, FlagSignerPassphraseFile, "")
+		assertFlagValue(t, flags, FlagSignerType, "file")
+		assertFlagValue(t, flags, FlagSignerPath, DefaultConfig().Signer.SignerPath)
+		assertFlagValue(t, flags, FlagSignerKmsProvider, DefaultConfig().Signer.KMS.Provider)
+		assertFlagValue(t, flags, FlagSignerKmsAwsKeyID, DefaultConfig().Signer.KMS.AWS.KeyID)
+		assertFlagValue(t, flags, FlagSignerKmsAwsRegion, DefaultConfig().Signer.KMS.AWS.Region)
+		assertFlagValue(t, flags, FlagSignerKmsAwsProfile, DefaultConfig().Signer.KMS.AWS.Profile)
+		assertFlagValue(t, flags, FlagSignerKmsAwsTimeout, DefaultConfig().Signer.KMS.AWS.Timeout.Duration)
+		assertFlagValue(t, flags, FlagSignerKmsAwsMaxRetries, DefaultConfig().Signer.KMS.AWS.MaxRetries)
+		assertFlagValue(t, flags, FlagSignerKmsGcpKeyName, DefaultConfig().Signer.KMS.GCP.KeyName)
+		assertFlagValue(t, flags, FlagSignerKmsGcpCredentialsFile, DefaultConfig().Signer.KMS.GCP.CredentialsFile)
+		assertFlagValue(t, flags, FlagSignerKmsGcpTimeout, DefaultConfig().Signer.KMS.GCP.Timeout.Duration)
+		assertFlagValue(t, flags, FlagSignerKmsGcpMaxRetries, DefaultConfig().Signer.KMS.GCP.MaxRetries)
 
-	// Signer flags
-	assertFlagValue(t, flags, FlagSignerPassphraseFile, "")
-	assertFlagValue(t, flags, FlagSignerType, "file")
-	assertFlagValue(t, flags, FlagSignerPath, DefaultConfig().Signer.SignerPath)
-	assertFlagValue(t, flags, FlagSignerKmsProvider, DefaultConfig().Signer.KMS.Provider)
-	assertFlagValue(t, flags, FlagSignerKmsAwsKeyID, DefaultConfig().Signer.KMS.AWS.KeyID)
-	assertFlagValue(t, flags, FlagSignerKmsAwsRegion, DefaultConfig().Signer.KMS.AWS.Region)
-	assertFlagValue(t, flags, FlagSignerKmsAwsProfile, DefaultConfig().Signer.KMS.AWS.Profile)
-	assertFlagValue(t, flags, FlagSignerKmsAwsTimeout, DefaultConfig().Signer.KMS.AWS.Timeout.Duration)
-	assertFlagValue(t, flags, FlagSignerKmsAwsMaxRetries, DefaultConfig().Signer.KMS.AWS.MaxRetries)
-	assertFlagValue(t, flags, FlagSignerKmsGcpKeyName, DefaultConfig().Signer.KMS.GCP.KeyName)
-	assertFlagValue(t, flags, FlagSignerKmsGcpCredentialsFile, DefaultConfig().Signer.KMS.GCP.CredentialsFile)
-	assertFlagValue(t, flags, FlagSignerKmsGcpTimeout, DefaultConfig().Signer.KMS.GCP.Timeout.Duration)
-	assertFlagValue(t, flags, FlagSignerKmsGcpMaxRetries, DefaultConfig().Signer.KMS.GCP.MaxRetries)
+		// RPC flags
+		assertFlagValue(t, flags, FlagRPCAddress, DefaultConfig().RPC.Address)
+		assertFlagValue(t, flags, FlagRPCEnableDAVisualization, DefaultConfig().RPC.EnableDAVisualization)
 
-	// RPC flags
-	assertFlagValue(t, flags, FlagRPCAddress, DefaultConfig().RPC.Address)
-	assertFlagValue(t, flags, FlagRPCEnableDAVisualization, DefaultConfig().RPC.EnableDAVisualization)
+		// Raft flags
+		assertFlagValue(t, flags, FlagRaftEnable, DefaultConfig().Raft.Enable)
+		assertFlagValue(t, flags, FlagRaftNodeID, DefaultConfig().Raft.NodeID)
+		assertFlagValue(t, flags, FlagRaftAddr, DefaultConfig().Raft.RaftAddr)
+		assertFlagValue(t, flags, FlagRaftDir, DefaultConfig().Raft.RaftDir)
+		assertFlagValue(t, flags, FlagRaftBootstrap, DefaultConfig().Raft.Bootstrap)
+		assertFlagValue(t, flags, FlagRaftPeers, DefaultConfig().Raft.Peers)
+		assertFlagValue(t, flags, FlagRaftSnapCount, DefaultConfig().Raft.SnapCount)
+		assertFlagValue(t, flags, FlagRaftSendTimeout, DefaultConfig().Raft.SendTimeout)
+		assertFlagValue(t, flags, FlagRaftHeartbeatTimeout, DefaultConfig().Raft.HeartbeatTimeout)
+		assertFlagValue(t, flags, FlagRaftLeaderLeaseTimeout, DefaultConfig().Raft.LeaderLeaseTimeout)
+		assertFlagValue(t, flags, FlagRaftElectionTimeout, DefaultConfig().Raft.ElectionTimeout)
+		assertFlagValue(t, flags, FlagRaftSnapshotThreshold, DefaultConfig().Raft.SnapshotThreshold)
+		assertFlagValue(t, flags, FlagRaftTrailingLogs, DefaultConfig().Raft.TrailingLogs)
 
-	// Raft flags
-	assertFlagValue(t, flags, FlagRaftEnable, DefaultConfig().Raft.Enable)
-	assertFlagValue(t, flags, FlagRaftNodeID, DefaultConfig().Raft.NodeID)
-	assertFlagValue(t, flags, FlagRaftAddr, DefaultConfig().Raft.RaftAddr)
-	assertFlagValue(t, flags, FlagRaftDir, DefaultConfig().Raft.RaftDir)
-	assertFlagValue(t, flags, FlagRaftBootstrap, DefaultConfig().Raft.Bootstrap)
-	assertFlagValue(t, flags, FlagRaftPeers, DefaultConfig().Raft.Peers)
-	assertFlagValue(t, flags, FlagRaftSnapCount, DefaultConfig().Raft.SnapCount)
-	assertFlagValue(t, flags, FlagRaftSendTimeout, DefaultConfig().Raft.SendTimeout)
-	assertFlagValue(t, flags, FlagRaftHeartbeatTimeout, DefaultConfig().Raft.HeartbeatTimeout)
-	assertFlagValue(t, flags, FlagRaftLeaderLeaseTimeout, DefaultConfig().Raft.LeaderLeaseTimeout)
-	assertFlagValue(t, flags, FlagRaftElectionTimeout, DefaultConfig().Raft.ElectionTimeout)
-	assertFlagValue(t, flags, FlagRaftSnapshotThreshold, DefaultConfig().Raft.SnapshotThreshold)
-	assertFlagValue(t, flags, FlagRaftTrailingLogs, DefaultConfig().Raft.TrailingLogs)
+		// Pruning flags
+		assertFlagValue(t, flags, FlagPruningMode, DefaultConfig().Pruning.Mode)
+		assertFlagValue(t, flags, FlagPruningKeepRecent, DefaultConfig().Pruning.KeepRecent)
+		assertFlagValue(t, flags, FlagPruningInterval, DefaultConfig().Pruning.Interval.Duration)
 
-	// Pruning flags
-	assertFlagValue(t, flags, FlagPruningMode, DefaultConfig().Pruning.Mode)
-	assertFlagValue(t, flags, FlagPruningKeepRecent, DefaultConfig().Pruning.KeepRecent)
-	assertFlagValue(t, flags, FlagPruningInterval, DefaultConfig().Pruning.Interval.Duration)
+		// Count the number of flags we're explicitly checking
+		expectedFlagCount := 82 // Update this number if you add more flag checks above
 
-	// Count the number of flags we're explicitly checking
-	expectedFlagCount := 82 // Update this number if you add more flag checks above
+		// Get the actual number of flags (both regular and persistent)
+		actualFlagCount := 0
+		flags.VisitAll(func(flag *pflag.Flag) {
+			actualFlagCount++
+		})
+		persistentFlags.VisitAll(func(flag *pflag.Flag) {
+			actualFlagCount++
+		})
 
-	// Get the actual number of flags (both regular and persistent)
-	actualFlagCount := 0
-	flags.VisitAll(func(flag *pflag.Flag) {
-		actualFlagCount++
+		// Verify that the counts match
+		assert.Equal(
+			t,
+			expectedFlagCount,
+			actualFlagCount,
+			"Number of flags doesn't match. If you added a new flag, please update the test.",
+		)
 	})
-	persistentFlags.VisitAll(func(flag *pflag.Flag) {
-		actualFlagCount++
-	})
-
-	// Verify that the counts match
-	assert.Equal(
-		t,
-		expectedFlagCount,
-		actualFlagCount,
-		"Number of flags doesn't match. If you added a new flag, please update the test.",
-	)
 }
 
 func TestLoad(t *testing.T) {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -133,13 +133,10 @@ func DefaultConfig() Config {
 	}
 }
 
-// nowUnix returns the current Unix timestamp; package-level so tests can stub it.
-var nowUnix = func() int64 { return time.Now().Unix() }
-
 func randString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	result := make([]byte, length)
-	rng := rand.New(rand.NewSource(nowUnix())) //nolint:gosec // even half random is good enough here.
+	rng := rand.New(rand.NewSource(time.Now().Unix())) //nolint:gosec // even half random is good enough here.
 	for i := range result {
 		result[i] = charset[rng.Intn(len(charset))]
 	}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -133,10 +133,13 @@ func DefaultConfig() Config {
 	}
 }
 
+// nowUnix returns the current Unix timestamp; package-level so tests can stub it.
+var nowUnix = func() int64 { return time.Now().Unix() }
+
 func randString(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	result := make([]byte, length)
-	rng := rand.New(rand.NewSource(time.Now().Unix())) //nolint:gosec // even half random is good enough here.
+	rng := rand.New(rand.NewSource(nowUnix())) //nolint:gosec // even half random is good enough here.
 	for i := range result {
 		result[i] = charset[rng.Intn(len(charset))]
 	}


### PR DESCRIPTION
## Overview

Fixes a flaky `TestAddFlags` caused by non-deterministic defaults.
`DA.Namespace` used `randString` seeded with `time.Now().Unix()`, and `DefaultConfig()` was called twice in the test (once in `AddFlags`, once for the expected value). If the timestamp second changed between calls, the seeds diverged and the assertion failed.

This PR extracts the time source into a package-level `nowUnix` variable in `defaults.go`, allowing the test to fix the seed and make both calls deterministic.

Reproduced locally via `go test ./... -count=1`:                                                       
   
```
  --- FAIL: TestAddFlags (0.00s)                                                                         
      config_test.go:502:
          Error: Not equal:                                                                              
              expected: "5ofJh48irg"
              actual  : "Duu3osBRoN"                                                                     
          Test:    TestAddFlags                                                                          
          Messages: Flag evnode.da.namespace should have default value 5ofJh48irg
  FAIL    github.com/evstack/ev-node/pkg/config   3.396s   
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test stability for configuration flag assertions by implementing deterministic time handling, ensuring consistent behavior across repeated test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->