### PR TITLE
fix: reject unsupported net-info output formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reject unsupported `net-info --output` formats instead of falling back to text output [#3360](https://github.com/evstack/ev-node/pull/3360).
+
 ## v1.1.3
 
 ### Fixed

--- a/pkg/cmd/p2p.go
+++ b/pkg/cmd/p2p.go
@@ -40,6 +40,16 @@ var NetInfoCmd = &cobra.Command{
 			return fmt.Errorf("RPC address not found in node configuration")
 		}
 
+		outputFormat, err := cmd.Flags().GetString(flagOutput)
+		if err != nil {
+			return err
+		}
+		switch outputFormat {
+		case "text", "json":
+		default:
+			return fmt.Errorf("unsupported output format %q (supported: text, json)", outputFormat)
+		}
+
 		// Create HTTP client
 		httpClient := http.Client{
 			Transport: http.DefaultTransport,
@@ -73,11 +83,6 @@ var NetInfoCmd = &cobra.Command{
 		)
 		if err != nil {
 			return fmt.Errorf("GetPeerInfo RPC: %w", err)
-		}
-
-		outputFormat, err := cmd.Flags().GetString(flagOutput)
-		if err != nil {
-			return err
 		}
 
 		if outputFormat == "json" {

--- a/pkg/cmd/p2p_test.go
+++ b/pkg/cmd/p2p_test.go
@@ -199,3 +199,33 @@ func TestNetInfoCmd_NoPeers(t *testing.T) {
 
 	mockP2P.AssertExpectations(t)
 }
+
+func TestNetInfoCmd_InvalidOutputFormat(t *testing.T) {
+	require := require.New(t)
+
+	tempDir, err := os.MkdirTemp("", "evolve-test-home-invalid-output-*")
+	require.NoError(err)
+	defer os.RemoveAll(tempDir)
+
+	rpcAddr := "127.0.0.1:1"
+	v := viper.New()
+	v.Set(config.FlagRPCAddress, rpcAddr)
+	v.Set(config.FlagRootDir, tempDir)
+
+	rootCmd := &cobra.Command{Use: "root"}
+	rootCmd.PersistentFlags().String(config.FlagRootDir, tempDir, "Root directory for config and data")
+	rootCmd.PersistentFlags().String(config.FlagRPCAddress, rpcAddr, "RPC listen address")
+
+	err = v.BindPFlag(config.FlagRootDir, rootCmd.PersistentFlags().Lookup(config.FlagRootDir))
+	require.NoError(err)
+	err = v.BindPFlag(config.FlagRPCAddress, rootCmd.PersistentFlags().Lookup(config.FlagRPCAddress))
+	require.NoError(err)
+
+	NetInfoCmd.SetContext(context.WithValue(context.Background(), viperKey, v))
+	rootCmd.AddCommand(NetInfoCmd)
+
+	output, err := executeCommandC(rootCmd, "net-info", "--evnode.rpc.address="+rpcAddr, "--output", "yaml")
+
+	require.Error(err, "Command should reject unsupported output format: %s", output)
+	require.Contains(err.Error(), `unsupported output format "yaml"`)
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This PR adds validation for the `net-info --output` flag.

Previously, `net-info` only handled `json` specially and silently fell back to text output for any other value. For example, `--output yaml` would still run the RPC requests and print text output, which is surprising for users and makes invalid CLI input harder to catch.

The command now accepts only `text` and `json`, and returns a clear error for unsupported output formats before making RPC calls.

Testing performed:

- `go test ./pkg/cmd -count=1`
- `gofmt`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `net-info` command now validates the `--output` flag up front and returns an error for unsupported formats instead of falling back to text output. Supported formats are `text` and `json`.
* **Tests**
  * Added coverage to confirm `net-info --output yaml` is rejected with a descriptive error.
* **Documentation**
  * Updated the Unreleased changelog entry to note the `net-info --output` validation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->