### PR TITLE
test: make single sequencer timestamp assertions timezone-agnostic

### DIFF
--- a/pkg/sequencers/single/sequencer_test.go
+++ b/pkg/sequencers/single/sequencer_test.go
@@ -243,10 +243,8 @@ func TestSequencer_GetNextBatch_NoLastBatch(t *testing.T) {
 		t.Fatalf("Failed to get next batch: %v", err)
 	}
 
-	// Ensure the time is approximately the same
-	if res.Timestamp.Day() != time.Now().Day() {
-		t.Fatalf("Expected timestamp day to be %d, got %d", time.Now().Day(), res.Timestamp.Day())
-	}
+	// Ensure the time is approximately the same.
+	require.WithinDuration(t, time.Now().UTC(), res.Timestamp, time.Second)
 
 	// Should return an empty batch
 	if len(res.Batch.Transactions) != 0 {
@@ -281,10 +279,8 @@ func TestSequencer_GetNextBatch_Success(t *testing.T) {
 		t.Fatalf("Failed to get next batch: %v", err)
 	}
 
-	// Ensure the time is approximately the same
-	if res.Timestamp.Day() != time.Now().Day() {
-		t.Fatalf("Expected timestamp day to be %d, got %d", time.Now().Day(), res.Timestamp.Day())
-	}
+	// Ensure the time is approximately the same.
+	require.WithinDuration(t, time.Now().UTC(), res.Timestamp, time.Second)
 
 	// Ensure that the transactions are present
 	if len(res.Batch.Transactions) != 2 {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->

This updates the single sequencer timestamp assertions to avoid depending on the local timezone.

`GetNextBatch` returns timestamps using `time.Now().UTC()`, but the tests compared only `Timestamp.Day()` against `time.Now().Day()`. In non-UTC timezones, this can fail around day boundaries even when the returned timestamp is correct.

The tests now use `require.WithinDuration` against `time.Now().UTC()`, which checks the intended behavior directly and avoids local timezone drift.


## Testing

- `go test ./pkg/sequencers/single -run 'TestSequencer_GetNextBatch_(NoLastBatch|Success)' -count=1`
- `TZ=UTC go test ./pkg/sequencers/single -run 'TestSequencer_GetNextBatch_(NoLastBatch|Success)' -count=1`
- `go test ./...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Tightened two batching test assertions to verify timestamps are close to the current time, making the checks more precise and reliable.
  * Improved time validation by allowing a small tolerance instead of only comparing the calendar day.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->