### PR TITLE
fix: non aggregator readiness

### DIFF
--- a/pkg/rpc/server/http.go
+++ b/pkg/rpc/server/http.go
@@ -78,8 +78,9 @@ func RegisterCustomHTTPEndpoints(mux *http.ServeMux, s store.Store, pm p2p.P2PRP
 	// 2. Block production/sync status:
 	//    - Confirms node state is accessible
 	//    - Verifies at least one block has been produced/synced
-	// 3. Aggregator-specific checks (for aggregator nodes only):
-	//    - Validates blocks are being produced at expected rate (within 5x block_time)
+	// 3. Block execution liveness:
+	//    - Aggregator nodes: validates blocks are being produced at expected rate (within 5x block_time)
+	//    - Non-aggregator nodes: validates a block has been executed within readiness_window_seconds
 	// 4. Sync status (for all nodes):
 	//    - Compares local height with best known network height
 	//    - Ensures node is not falling behind by more than readiness_max_blocks_behind
@@ -132,6 +133,16 @@ func RegisterCustomHTTPEndpoints(mux *http.ServeMux, s store.Store, pm p2p.P2PRP
 			timeSinceLastBlock := time.Since(state.LastBlockTime)
 			if timeSinceLastBlock > maxAllowedDelay {
 				http.Error(w, "UNREADY: aggregator not producing blocks at expected rate", http.StatusServiceUnavailable)
+				return
+			}
+		} else {
+			readinessWindowSeconds := cfg.Node.ReadinessWindowSeconds
+			if readinessWindowSeconds == 0 {
+				readinessWindowSeconds = 15 // fallback to default 15s window
+			}
+			maxAllowedDelay := time.Duration(readinessWindowSeconds) * time.Second
+			if time.Since(state.LastBlockTime) > maxAllowedDelay {
+				http.Error(w, "UNREADY: node not executing blocks", http.StatusServiceUnavailable)
 				return
 			}
 		}

--- a/pkg/rpc/server/http_test.go
+++ b/pkg/rpc/server/http_test.go
@@ -232,3 +232,71 @@ func TestHealthReady_aggregatorBlockDelay(t *testing.T) {
 		})
 	}
 }
+
+func TestHealthReady_nonAggregatorBlockDelay(t *testing.T) {
+	logger := zerolog.Nop()
+
+	type spec struct {
+		readinessWindowSeconds uint64
+		delay                  time.Duration
+		expStatusCode          int
+		expBody                string
+	}
+
+	specs := map[string]spec{
+		"within readiness window": {
+			readinessWindowSeconds: 10,
+			delay:                  5 * time.Second,
+			expStatusCode:          http.StatusOK,
+			expBody:                "READY\n",
+		},
+		"exceeds readiness window": {
+			readinessWindowSeconds: 10,
+			delay:                  15 * time.Second,
+			expStatusCode:          http.StatusServiceUnavailable,
+			expBody:                "UNREADY: node not executing blocks\n",
+		},
+		"zero readiness window falls back to default 15s": {
+			readinessWindowSeconds: 0,
+			delay:                  10 * time.Second,
+			expStatusCode:          http.StatusOK,
+			expBody:                "READY\n",
+		},
+	}
+
+	for name, tc := range specs {
+		t.Run(name, func(t *testing.T) {
+			mux := http.NewServeMux()
+
+			cfg := config.DefaultConfig()
+			cfg.Node.Aggregator = false
+			cfg.Node.ReadinessWindowSeconds = tc.readinessWindowSeconds
+
+			mockStore := mocks.NewMockStore(t)
+			state := types.State{
+				LastBlockHeight: 10,
+				LastBlockTime:   time.Now().Add(-tc.delay),
+			}
+			mockStore.On("GetState", mock.Anything).Return(state, nil)
+
+			bestKnownHeightProvider := func() uint64 { return state.LastBlockHeight }
+
+			RegisterCustomHTTPEndpoints(mux, mockStore, nil, cfg, bestKnownHeightProvider, logger, nil)
+
+			ts := httptest.NewServer(mux)
+			t.Cleanup(ts.Close)
+
+			req, err := http.NewRequest(http.MethodGet, ts.URL+"/health/ready", nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req) //nolint:gosec // ok to use default client in tests
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = resp.Body.Close() })
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.expStatusCode, resp.StatusCode)
+			assert.Equal(t, tc.expBody, string(body))
+		})
+	}
+}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `/health/ready` checks for non-aggregator nodes so readiness now reflects how long it has been since the last block was produced.
  * Returns `503 UNREADY: node not executing blocks` when the delay exceeds the configured readiness window.
  * Uses a default fallback threshold when the readiness window is not set, helping avoid false-ready responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->