### PR TITLE
chore: fix based sequencer terminology in state comments

### DIFF
--- a/types/state.go
+++ b/types/state.go
@@ -136,9 +136,9 @@ func (s State) AssertValidSequence(header *SignedHeader) error {
 		return fmt.Errorf("%w - got: %v, last: %v", ErrInvalidBlockTime, headerTime, s.LastBlockTime)
 	}
 
-	// Trick to support the switch from a base sequencer to a normal syncing node.
-	// Based sequencers do not sign ehaders, meaning the last header hash will be different from the
-	// newly derived header hash when a base sequencer have switched to a syncing node
+	// Trick to support the switch from a based sequencer to a normal syncing node.
+	// Based sequencers do not sign headers, meaning the last header hash will be different from the
+	// newly derived header hash when a based sequencer has switched to a syncing node.
 	if !bytes.Equal(header.LastHeaderHash, s.LastHeaderHash) {
 		if lastHeaderHashErrCount == 1 {
 			return fmt.Errorf("%w - got: %x, want: %x", ErrInvalidLastHeaderHash, header.LastHeaderHash, s.LastHeaderHash)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.

NOTE: PR titles should follow semantic commits: https://www.conventionalcommits.org/en/v1.0.0/
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 

Ex: Closes #<issue number>
-->
Correct the comments around `State.AssertValidSequence` when handling a transition from a based sequencer to a normal syncing node.

The comments previously:

- referred to a "base sequencer" instead of the project's established "based sequencer" terminology;
- misspelled `headers` as `ehaders`;
- used the grammatically incorrect phrase "a base sequencer have switched."

This change only improves the comments and does not modify validation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified and corrected comments describing synchronization transitions and header-hash mismatch behavior.
  * No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->