### PR TITLE
chore: prep v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v1.2.0
+
+### Added
+
+- **BREAKING:** Proposer key rotation. State now tracks `NextProposerAddress`, and signed headers validate signer identity (the signer address must derive from the included public key), allowing the aggregator signing key to be rotated across blocks [#3282](https://github.com/evstack/ev-node/pull/3282)
+- Prepare for the Amsterdam fork: update ev-reth to reth 2.3 and add engine-API fork upgrade handling [#3352](https://github.com/evstack/ev-node/pull/3352)
+
 ### Removed
 
-- **BREAKING:** Remove the obsolete `evgrpc` app and `execution/grpc` transport module.
+- **BREAKING:** Remove the obsolete `evgrpc` app and `execution/grpc` transport module [#3380](https://github.com/evstack/ev-node/pull/3380).
 
 ### Fixed
 
-- Allow full followers without a DA endpoint to sync through P2P only, and reject aggregator startup without an explicit DA endpoint.
+- Allow full followers without a DA endpoint to sync through P2P only, and reject aggregator startup without an explicit DA endpoint [#3386](https://github.com/evstack/ev-node/pull/3386).
 - Reject unsupported `net-info --output` formats instead of falling back to text output [#3360](https://github.com/evstack/ev-node/pull/3360).
+- Report readiness correctly for non-aggregator nodes [#3376](https://github.com/evstack/ev-node/pull/3376).
+- Don't create a single sequencer for non-aggregator nodes [#3389](https://github.com/evstack/ev-node/pull/3389).
 
 ## v1.1.4
 


### PR DESCRIPTION
Stamps the `[Unreleased]` changelog section as **v1.2.0** — the CHANGELOG equivalent of the prior `chore: prep ...` release commits.

## Why a minor bump (1.1.x → 1.2.0)
- **Breaking `core` Executor change**: `ExecuteTxs` now returns an `ExecuteResult` struct (carrying `NextProposerAddress`) instead of `updatedStateRoot []byte` ([#3282]). `core` must be re-released (planned `core/v1.1.0`) before ev-node/apps can bump.
- **Proposer key rotation**: state tracks `NextProposerAddress` and signed headers now validate signer identity — a breaking state/consensus change ([#3282]).

## Changelog changes
The `[Unreleased]` section was missing the two largest features on main. Added:
- **Added:** proposer key rotation ([#3282]), Amsterdam fork prep / reth 2.3 ([#3352])
- **Fixed:** non-aggregator readiness ([#3376]), non-aggregator single sequencer ([#3389])
- Backfilled PR links on the existing ev-grpc removal and p2p-follower entries.

## Not in this PR (release execution, after merge)
Tags are **not** pushed here. The release sequence per `RELEASE.md`, once this merges:
1. `core/v1.1.0` → wait for proxy propagation
2. `v1.2.0` (ev-node root), `execution/evm/vX`
3. Comment-out replaces + bump apps → tag `apps/*/v1.2.0`
4. Bring back dev replaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[#3282]: https://github.com/evstack/ev-node/pull/3282
[#3352]: https://github.com/evstack/ev-node/pull/3352
[#3376]: https://github.com/evstack/ev-node/pull/3376
[#3389]: https://github.com/evstack/ev-node/pull/3389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added proposer key rotation support.
  * Added preparation for the Amsterdam fork through execution and engine API upgrades.

* **Bug Fixes**
  * Improved readiness reporting and P2P synchronization for non-aggregator nodes.
  * Prevented unsupported `net-info` output formats.
  * Avoided creating a single sequencer for non-aggregator nodes.

* **Removed**
  * Removed obsolete execution gRPC components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->