### PR TITLE
chore: prep execution/evm v1.1.0

### DIFF
--- a/apps/evm/go.mod
+++ b/apps/evm/go.mod
@@ -10,7 +10,7 @@ replace (
 
 require (
 	github.com/ethereum/go-ethereum v1.17.4
-	github.com/evstack/ev-node v1.1.3
+	github.com/evstack/ev-node v1.2.1
 	github.com/evstack/ev-node/core v1.1.0
 	github.com/evstack/ev-node/execution/evm v1.0.1
 	github.com/ipfs/go-datastore v0.9.1

--- a/execution/evm/go.mod
+++ b/execution/evm/go.mod
@@ -2,14 +2,9 @@ module github.com/evstack/ev-node/execution/evm
 
 go 1.25.8
 
-replace (
-	github.com/evstack/ev-node => ../../
-	github.com/evstack/ev-node/core => ../../core
-)
-
 require (
 	github.com/ethereum/go-ethereum v1.17.4
-	github.com/evstack/ev-node v1.1.2
+	github.com/evstack/ev-node v1.2.1
 	github.com/evstack/ev-node/core v1.1.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/ipfs/go-datastore v0.9.1

--- a/execution/evm/go.sum
+++ b/execution/evm/go.sum
@@ -121,6 +121,10 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.4 h1:uA4q+qiLp7QImBsjdRbINu8iX6OEVmj4DPc5/E5Fsxc=
 github.com/ethereum/go-ethereum v1.17.4/go.mod h1:qMdgwqqRAen+aT8P7KKQKi0Qt6RzG4cfejVAbCpJgqA=
+github.com/evstack/ev-node v1.2.1 h1:67u22AZFbFDkv/N6hyzx7eGtoS1RD7pOj4AsQqA4+pc=
+github.com/evstack/ev-node v1.2.1/go.mod h1:OG0eQEvqB6w0p70L9wIVboLDPiSRfr359dd5eKKJslg=
+github.com/evstack/ev-node/core v1.1.0 h1:Sa7uU5yuNF7YUyLBHPThD6Jt8/jacM1epRLATrdvKRE=
+github.com/evstack/ev-node/core v1.1.0/go.mod h1:n2w/LhYQTPsi48m6lMj16YiIqsaQw6gxwjyJvR+B3sY=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/ferranbt/fastssz v0.1.4 h1:OCDB+dYDEQDvAgtAGnTSidK1Pe2tW3nFV40XyMkTeDY=

--- a/execution/evm/test/go.mod
+++ b/execution/evm/test/go.mod
@@ -78,7 +78,7 @@ require (
 	github.com/dvsekhvalnov/jose2go v1.7.0 // indirect
 	github.com/emicklei/dot v1.6.2 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.6 // indirect
-	github.com/evstack/ev-node v1.1.2 // indirect
+	github.com/evstack/ev-node v1.2.1 // indirect
 	github.com/evstack/ev-node/core v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/ferranbt/fastssz v0.1.4 // indirect

--- a/test/e2e/go.mod
+++ b/test/e2e/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.53.6
 	github.com/cosmos/ibc-go/v8 v8.8.0
 	github.com/ethereum/go-ethereum v1.17.4
-	github.com/evstack/ev-node v1.1.2
+	github.com/evstack/ev-node v1.2.1
 	github.com/evstack/ev-node/execution/evm v0.0.0-20250602130019-2a732cf903a5
 	github.com/evstack/ev-node/execution/evm/test v0.0.0-00010101000000-000000000000
 	github.com/libp2p/go-libp2p v0.48.0


### PR DESCRIPTION
Release-ready go.mod for tagging **execution/evm/v1.1.0**.

## Changes
- Drop the local `replace` block (`ev-node => ../../`, `core => ../../core`) — local cross-module dev is handled by `go.work` (`go.work.example` covers all modules).
- Pin published upstreams: `ev-node v1.1.2 → v1.2.1`, `core v1.1.0` (already required).
- `go.sum` gains the v1.2.1 + core v1.1.0 checksums.

## Why v1.1.0 (new minor)
Last tag was `execution/evm/v1.0.1`. Since then reth 2.3 + Amsterdam fork prep (#3352) landed here — new features warrant a minor bump.

## Verification
- `go build ./...` passes resolving the **real published** ev-node v1.2.1 + core v1.1.0 (not local replace)
- `go mod tidy` is idempotent

Part of the v1.2.1 release chain (core/v1.1.0 → v1.2.1 → execution/evm/v1.1.0 → apps/*/v1.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the EV node integration to version 1.2.1 across application, execution, testing, and end-to-end environments.
  * Improved consistency by using the released dependency version instead of local overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->