### PR TITLE
chore: prep apps v1.2.1

### DIFF
--- a/apps/evm/go.mod
+++ b/apps/evm/go.mod
@@ -2,17 +2,11 @@ module github.com/evstack/ev-node/apps/evm
 
 go 1.25.8
 
-replace (
-	github.com/evstack/ev-node => ../../
-	github.com/evstack/ev-node/core => ../../core
-	github.com/evstack/ev-node/execution/evm => ../../execution/evm
-)
-
 require (
 	github.com/ethereum/go-ethereum v1.17.4
 	github.com/evstack/ev-node v1.2.1
 	github.com/evstack/ev-node/core v1.1.0
-	github.com/evstack/ev-node/execution/evm v1.0.1
+	github.com/evstack/ev-node/execution/evm v1.1.0
 	github.com/ipfs/go-datastore v0.9.1
 	github.com/rs/zerolog v1.35.1
 	github.com/spf13/cobra v1.10.2

--- a/apps/evm/go.sum
+++ b/apps/evm/go.sum
@@ -228,6 +228,12 @@ github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab h1:rvv6MJ
 github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab/go.mod h1:IuLm4IsPipXKF7CW5Lzf68PIbZ5yl7FFd74l/E0o9A8=
 github.com/ethereum/go-ethereum v1.17.4 h1:uA4q+qiLp7QImBsjdRbINu8iX6OEVmj4DPc5/E5Fsxc=
 github.com/ethereum/go-ethereum v1.17.4/go.mod h1:qMdgwqqRAen+aT8P7KKQKi0Qt6RzG4cfejVAbCpJgqA=
+github.com/evstack/ev-node v1.2.1 h1:67u22AZFbFDkv/N6hyzx7eGtoS1RD7pOj4AsQqA4+pc=
+github.com/evstack/ev-node v1.2.1/go.mod h1:OG0eQEvqB6w0p70L9wIVboLDPiSRfr359dd5eKKJslg=
+github.com/evstack/ev-node/core v1.1.0 h1:Sa7uU5yuNF7YUyLBHPThD6Jt8/jacM1epRLATrdvKRE=
+github.com/evstack/ev-node/core v1.1.0/go.mod h1:n2w/LhYQTPsi48m6lMj16YiIqsaQw6gxwjyJvR+B3sY=
+github.com/evstack/ev-node/execution/evm v1.1.0 h1:YKJktOwCI1mlyAZEJvOw8N6I9VUo/3W9yi7mtOb0ElE=
+github.com/evstack/ev-node/execution/evm v1.1.0/go.mod h1:3uG4HGdRjI1fqI4c9tvMOljfWFQ6w1rqNDRu+JEmgTo=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=

--- a/apps/testapp/go.mod
+++ b/apps/testapp/go.mod
@@ -2,13 +2,8 @@ module github.com/evstack/ev-node/apps/testapp
 
 go 1.25.8
 
-replace (
-	github.com/evstack/ev-node => ../../.
-	github.com/evstack/ev-node/core => ../../core
-)
-
 require (
-	github.com/evstack/ev-node v1.1.3
+	github.com/evstack/ev-node v1.2.1
 	github.com/evstack/ev-node/core v1.1.0
 	github.com/ipfs/go-datastore v0.9.1
 	github.com/rs/zerolog v1.35.1

--- a/apps/testapp/go.sum
+++ b/apps/testapp/go.sum
@@ -188,6 +188,10 @@ github.com/envoyproxy/go-control-plane/envoy v1.37.0/go.mod h1:DReE9MMrmecPy+YvQ
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v1.3.3 h1:MVQghNeW+LZcmXe7SY1V36Z+WFMDjpqGAGacLe2T0ds=
 github.com/envoyproxy/protoc-gen-validate v1.3.3/go.mod h1:TsndJ/ngyIdQRhMcVVGDDHINPLWB7C82oDArY51KfB0=
+github.com/evstack/ev-node v1.2.1 h1:67u22AZFbFDkv/N6hyzx7eGtoS1RD7pOj4AsQqA4+pc=
+github.com/evstack/ev-node v1.2.1/go.mod h1:OG0eQEvqB6w0p70L9wIVboLDPiSRfr359dd5eKKJslg=
+github.com/evstack/ev-node/core v1.1.0 h1:Sa7uU5yuNF7YUyLBHPThD6Jt8/jacM1epRLATrdvKRE=
+github.com/evstack/ev-node/core v1.1.0/go.mod h1:n2w/LhYQTPsi48m6lMj16YiIqsaQw6gxwjyJvR+B3sY=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.18.0 h1:S8gINlzdQ840/4pfAwic/ZE0djQEH3wM94VfqLTZcOM=


### PR DESCRIPTION
Release-ready go.mods for tagging **apps/evm/v1.2.1** and **apps/testapp/v1.2.1**.

## Changes
Drop the local `replace` blocks and pin published upstreams:
- **apps/evm:** `ev-node v1.2.1`, `core v1.1.0`, `execution/evm v1.0.1 → v1.1.0`
- **apps/testapp:** `ev-node v1.1.3 → v1.2.1`, `core v1.1.0`

Local cross-module dev relies on `go.work` (`go.work.example` covers all modules).

## Verification
- Both apps `go build ./...` pass resolving **published** modules (no replace)
- `go mod tidy` idempotent on both
- Untouched modules (`apps/loadgen`, `execution/evm/test`, `test/e2e`) still build

Final code step of the v1.2.1 chain: core/v1.1.0 → v1.2.1 → execution/evm/v1.1.0 → **apps/*/v1.2.1**. (`apps/grpc` removed in #3380 — not released this cycle.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core platform components to newer released versions.
  * Removed local development overrides so applications use the published component packages.
  * Updated the test application to align with the latest platform release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->