### PR TITLE
chore: changelog v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## v1.2.0
+## v1.2.1
+
+> Supersedes v1.2.0, which was tagged before `core/v1.1.0` was published and
+> therefore required an unavailable `core` version — unusable by consumers.
+> The contents below shipped in v1.2.1.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v1.2.1
 
-> Supersedes v1.2.0, which was tagged before `core/v1.1.0` was published and
-> therefore required an unavailable `core` version — unusable by consumers.
-> The contents below shipped in v1.2.1.
 
 ### Added
 


### PR DESCRIPTION
Renames the `## v1.2.0` changelog section to `## v1.2.1` and notes that v1.2.0 was superseded (it was tagged before `core/v1.1.0` was published, so it required an unavailable `core` version and is unusable by consumers).

## Why this matters
The GitHub Release workflow (`release-github.yml`) reads `CHANGELOG.md` from the checked-out ref (main — no `ref:` override), searching for a section matching the release version. Releasing tag `v1.2.1` needs a `## v1.2.1` section or the notes come out empty.

**Merge this before running the "Github Release" workflow for v1.2.1.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to identify the current release as v1.2.1.
  * Clarified that v1.2.1 supersedes v1.2.0 and includes the listed changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->