### PR TITLE
fix: support maximum block size in P2P sync

### DIFF
--- a/pkg/sync/p2p_message_size.go
+++ b/pkg/sync/p2p_message_size.go
@@ -1,0 +1,13 @@
+package sync
+
+import (
+	"github.com/celestiaorg/go-libp2p-messenger/serde"
+
+	"github.com/evstack/ev-node/pkg/blobsize"
+)
+
+func init() {
+	// go-header wraps block data in another protobuf message, so leave room for
+	// framing overhead beyond the maximum block payload.
+	serde.MaxMessageSize = 2 * blobsize.DefaultMaxBlobSize
+}

--- a/pkg/sync/p2p_message_size_test.go
+++ b/pkg/sync/p2p_message_size_test.go
@@ -1,0 +1,34 @@
+package sync
+
+import (
+	"encoding/binary"
+	"testing"
+
+	p2ppb "github.com/celestiaorg/go-header/p2p/pb"
+	"github.com/celestiaorg/go-libp2p-messenger/serde"
+	"github.com/stretchr/testify/require"
+
+	"github.com/evstack/ev-node/pkg/blobsize"
+	"github.com/evstack/ev-node/types"
+)
+
+func TestP2PMessageSizeSupportsMaxBlob(t *testing.T) {
+	data := &types.P2PData{
+		Data: &types.Data{
+			Metadata: &types.Metadata{
+				ChainID: "test-chain",
+				Height:  1,
+				Time:    1,
+			},
+			Txs: types.Txs{make([]byte, int(blobsize.DefaultMaxBlobSize))},
+		},
+	}
+
+	body, err := data.MarshalBinary()
+	require.NoError(t, err)
+
+	response := &p2ppb.HeaderResponse{Body: body}
+	buf := make([]byte, response.Size()+binary.MaxVarintLen64)
+	_, err = serde.Marshal(response, buf)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Overview

ev-node allows block payloads up to `DefaultMaxBlobSize` (5 MiB by default), while the go-header exchange inherits go-libp2p-messenger's 1 MiB message limit. As a result, P2P historical sync resets the stream when it encounters an otherwise valid block larger than 1 MiB.

This change configures the go-header framing limit to twice `DefaultMaxBlobSize`, leaving room for the protobuf response envelope while keeping the limit derived from ev-node's existing block-size configuration.

It also adds a regression test that serializes a maximum-size `P2PData` payload through the same `HeaderResponse` framing path used by go-header.

## Impact

Nodes can exchange and catch up through P2P when blocks exceed 1 MiB, up to ev-node's configured maximum block size.

## Validation

- `go test ./... -count=1`
- `go vet ./pkg/sync ./pkg/p2p`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large peer-to-peer messages, allowing messages at the maximum supported blob size to be transmitted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->